### PR TITLE
Treats 'Hotspot' as proper noun.

### DIFF
--- a/packages/hotspot-utils/package.json
+++ b/packages/hotspot-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@helium/hotspot-utils",
   "version": "0.0.46",
-  "description": "Utils for hotspot interaction",
+  "description": "Utils for Hotspot interaction",
   "homepage": "https://github.com/helium/helium-program-library#readme",
   "publishConfig": {
     "access": "public",

--- a/packages/metadata-service/src/index.ts
+++ b/packages/metadata-service/src/index.ts
@@ -22,7 +22,7 @@ server.get<{ Params: { eccCompact: string } }>("/:eccCompact", async (request, r
 
   return {
     name: digest,
-    description: "A hotspot NFT on Helium",
+    description: "A Hotspot NFT on Helium",
     image:
       "https://shdw-drive.genesysgo.net/CsDkETHRRR1EcueeN346MJoqzymkkr7RFjMqGpZMzAib/hotspot.png",
     attributes: [


### PR DESCRIPTION
Updates the two instances I found. 