### PR TITLE
Add oracle as the payer for rent of recipient so migrated users don't get insufficient balance errors

### DIFF
--- a/packages/distributor-oracle/src/client.ts
+++ b/packages/distributor-oracle/src/client.ts
@@ -164,6 +164,8 @@ export async function formTransaction({
           lazyDistributor,
           assetEndpoint,
           owner: wallet,
+          // Make the oracle pay for the recipient to avoid newly migrated users not having enough sol to claim rewards
+          payer: lazyDistributorAcc.oracles[0].oracle,
           getAssetFn: () => Promise.resolve(asset), // cache result so we don't hit again
           getAssetProofFn,
         })

--- a/packages/lazy-distributor-sdk/src/functions/initializeCompressionRecipient.ts
+++ b/packages/lazy-distributor-sdk/src/functions/initializeCompressionRecipient.ts
@@ -13,6 +13,8 @@ export async function initializeCompressionRecipient({
   assetEndpoint,
   // @ts-ignore
   owner = program.provider.wallet.publicKey,
+  // @ts-ignore
+  payer = program.provider.wallet.publicKey,
   getAssetFn = getAsset,
   getAssetProofFn = getAssetProof,
 }: {
@@ -20,6 +22,7 @@ export async function initializeCompressionRecipient({
   assetId: PublicKey;
   lazyDistributor: PublicKey;
   owner?: PublicKey;
+  payer?: PublicKey;
   assetEndpoint?: string;
   getAssetFn?: (url: string, assetId: PublicKey) => Promise<Asset | undefined>;
   getAssetProofFn?: (
@@ -43,14 +46,14 @@ export async function initializeCompressionRecipient({
     compression: { leafId },
   } = asset;
   const { root, proof, leaf, treeId } = assetProof;
-  const canopy = await(
+  const canopy = await (
     await ConcurrentMerkleTreeAccount.fromAccountAddress(
       program.provider.connection,
       treeId
     )
   ).getCanopyDepth();
 
-  const recipient = recipientKey(lazyDistributor, assetId)[0]
+  const recipient = recipientKey(lazyDistributor, assetId)[0];
 
   return program.methods
     .initializeCompressionRecipientV0({
@@ -65,6 +68,7 @@ export async function initializeCompressionRecipient({
       owner: owner,
       delegate: owner,
       recipient,
+      payer,
     })
     .remainingAccounts(
       proof.slice(0, proof.length - canopy).map((p) => {

--- a/packages/monitor-service/package.json
+++ b/packages/monitor-service/package.json
@@ -35,6 +35,7 @@
     "@coral-xyz/anchor": "0.26.0",
     "@helium/circuit-breaker-sdk": "^0.0.49",
     "@helium/helium-sub-daos-sdk": "^0.0.49",
+    "@helium/lazy-transactions-sdk": "^0.0.49",
     "@helium/data-credits-sdk": "^0.0.49",
     "@helium/idls": "^0.0.49",
     "@helium/spl-utils": "^0.0.49",

--- a/tests/distributor-oracle.ts
+++ b/tests/distributor-oracle.ts
@@ -9,12 +9,14 @@ import {
   createMint,
   getAsset,
   sendAndConfirmWithRetry,
+  sendInstructions,
 } from "@helium/spl-utils";
 import {
   Keypair,
   PublicKey,
   SystemProgram,
   Transaction,
+  LAMPORTS_PER_SOL,
 } from "@solana/web3.js";
 import chai, { assert } from "chai";
 import chaiHttp from "chai-http";
@@ -59,7 +61,7 @@ export class DatabaseMock implements Database {
   }
 
   async getActiveDevices(): Promise<number> {
-    return 0
+    return 0;
   }
 
   getBulkRewards(entityKeys: string[]): Promise<Record<string, string>> {
@@ -167,7 +169,13 @@ describe("distributor-oracle", () => {
     "https://mobile-metadata.helium.io/13CGbZcFcAXkDqvACAKdWRdt5gdMEz8mbZC8nc4HGqZozyFYxSP";
   const getAssetFn = async () =>
     ({
-      compression: { compressed: true, tree: merkle.publicKey, leafId: 0, dataHash, creatorHash },
+      compression: {
+        compressed: true,
+        tree: merkle.publicKey,
+        leafId: 0,
+        dataHash,
+        creatorHash,
+      },
       ownership: { owner: me },
       content: { json_uri: uri },
     } as Asset);
@@ -235,6 +243,13 @@ describe("distributor-oracle", () => {
       lazyDistributor
     );
     await oracleServer.start();
+    await sendInstructions(provider, [
+      SystemProgram.transfer({
+        fromPubkey: me,
+        toPubkey: oracle.publicKey,
+        lamports: LAMPORTS_PER_SOL,
+      }),
+    ]);
   });
 
   after(async function () {


### PR DESCRIPTION
The way things are currently architected, 100tx worth of sol is not enough to pay to create the recipient PDA for a hotspot. So users may not be able to claim rewards without buying sol. Spoke with @abhay and we're okay with fronting that rent on an as-needed basis to avoid this issue. 