### PR TITLE
Upgrade helium-crypto

### DIFF
--- a/utils/bulk-claim-rewards/Cargo.lock
+++ b/utils/bulk-claim-rewards/Cargo.lock
@@ -1902,17 +1902,20 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bf107355a22f734a9f0b75d85db7cb5c5fa90bd06de4a46179225ea659b67b"
+checksum = "c3b0aaa2935b0ce50bb033a89ca6a332b0c8a47a84d732707cb77180e0da216a"
 dependencies = [
  "base64 0.21.0",
  "bs58 0.5.0",
+ "byteorder",
  "ed25519-compact",
+ "getrandom 0.2.9",
  "k256",
  "lazy_static",
  "p256",
  "rand_core 0.6.4",
+ "rsa",
  "serde",
  "sha2 0.10.6",
  "signature",
@@ -2376,6 +2379,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "libc"
@@ -2392,6 +2398,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libsecp256k1"
@@ -2829,6 +2841,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9bc3e36fd683e004fd59c64a425e0e991616f5a8b617c3b9a933a93c168facc"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,6 +2918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3626,6 +3656,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0aeddcca1082112a6eeb43bf25fd7820b066aaf6eaef776e19d0a1febe38fe"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "lazy_static",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "simple_asn1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4051,6 +4100,18 @@ checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 dependencies = [
  "digest 0.9.0",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
+dependencies = [
+ "chrono",
+ "num-bigint 0.4.3",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]

--- a/utils/bulk-claim-rewards/Cargo.lock
+++ b/utils/bulk-claim-rewards/Cargo.lock
@@ -674,8 +674,15 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "sha2 0.9.9",
+ "sha2 0.10.6",
+ "tinyvec",
 ]
 
 [[package]]
@@ -1032,6 +1039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
+name = "const-oid"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,7 +1282,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid",
+ "const-oid 0.7.1",
 ]
 
 [[package]]
@@ -1320,6 +1333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.4",
  "crypto-common",
  "subtle",
 ]
@@ -1888,12 +1902,12 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.6.8"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289576899272c1b9f6cb1a2d393c5f3c142b62b4343454bd1ada5d0eefd47ce7"
+checksum = "24bf107355a22f734a9f0b75d85db7cb5c5fa90bd06de4a46179225ea659b67b"
 dependencies = [
  "base64 0.21.0",
- "bs58 0.4.0",
+ "bs58 0.5.0",
  "ed25519-compact",
  "k256",
  "lazy_static",

--- a/utils/bulk-claim-rewards/Cargo.toml
+++ b/utils/bulk-claim-rewards/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = "1.3.2"
 hmac = "0"
 sha2 = "0"
 clap = { version = "4", features = ["derive"]}
-helium-crypto = { version = "0.6.3", features = ["solana"] }
+helium-crypto = { version = "0.7.1", features = ["solana"] }
 reqwest = "0"
 helium-entity-manager = { path = "../../programs/helium-entity-manager", features = [ "no-entrypoint" ] }
 circuit-breaker = { path = "../../programs/circuit-breaker", features = [ "no-entrypoint" ] }

--- a/utils/bulk-claim-rewards/Cargo.toml
+++ b/utils/bulk-claim-rewards/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = "1.3.2"
 hmac = "0"
 sha2 = "0"
 clap = { version = "4", features = ["derive"]}
-helium-crypto = { version = "0.7.1", features = ["solana"] }
+helium-crypto = { version = "0.7.3", features = ["solana"] }
 reqwest = "0"
 helium-entity-manager = { path = "../../programs/helium-entity-manager", features = [ "no-entrypoint" ] }
 circuit-breaker = { path = "../../programs/circuit-breaker", features = [ "no-entrypoint" ] }

--- a/utils/ecc-sig-verifier/Cargo.lock
+++ b/utils/ecc-sig-verifier/Cargo.lock
@@ -1219,17 +1219,20 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bf107355a22f734a9f0b75d85db7cb5c5fa90bd06de4a46179225ea659b67b"
+checksum = "c3b0aaa2935b0ce50bb033a89ca6a332b0c8a47a84d732707cb77180e0da216a"
 dependencies = [
  "base64 0.21.0",
  "bs58 0.5.0",
+ "byteorder",
  "ed25519-compact",
+ "getrandom 0.2.8",
  "k256",
  "lazy_static",
  "p256",
  "rand_core 0.6.4",
+ "rsa",
  "serde",
  "sha2 0.10.6",
  "signature",
@@ -1530,12 +1533,21 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libsecp256k1"
@@ -1699,7 +1711,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.6",
  "tokio",
  "tokio-util",
  "version_check",
@@ -1734,6 +1746,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9bc3e36fd683e004fd59c64a425e0e991616f5a8b617c3b9a933a93c168facc"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,12 +1795,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2290,6 +2342,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0aeddcca1082112a6eeb43bf25fd7820b066aaf6eaef776e19d0a1febe38fe"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "lazy_static",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "simple_asn1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2578,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2793,12 @@ dependencies = [
  "rustversion",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"

--- a/utils/ecc-sig-verifier/Cargo.lock
+++ b/utils/ecc-sig-verifier/Cargo.lock
@@ -456,8 +456,15 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "sha2 0.9.9",
+ "sha2 0.10.6",
+ "tinyvec",
 ]
 
 [[package]]
@@ -568,6 +575,12 @@ name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
+name = "const-oid"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "constant_time_eq"
@@ -745,7 +758,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid",
+ "const-oid 0.7.1",
 ]
 
 [[package]]
@@ -803,6 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.4",
  "crypto-common",
  "subtle",
 ]
@@ -1205,12 +1219,12 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.6.8"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289576899272c1b9f6cb1a2d393c5f3c142b62b4343454bd1ada5d0eefd47ce7"
+checksum = "24bf107355a22f734a9f0b75d85db7cb5c5fa90bd06de4a46179225ea659b67b"
 dependencies = [
  "base64 0.21.0",
- "bs58 0.4.0",
+ "bs58 0.5.0",
  "ed25519-compact",
  "k256",
  "lazy_static",

--- a/utils/ecc-sig-verifier/Cargo.toml
+++ b/utils/ecc-sig-verifier/Cargo.toml
@@ -11,7 +11,7 @@ overflow-checks = true
 [dependencies]
 solana-sdk = "1.14.11"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
-helium-crypto = "0.7.1"
+helium-crypto = "0.7.3"
 hex = "0.4.3"
 serde = "1.0.157"
 bincode = "1.3.3"

--- a/utils/ecc-sig-verifier/Cargo.toml
+++ b/utils/ecc-sig-verifier/Cargo.toml
@@ -11,7 +11,7 @@ overflow-checks = true
 [dependencies]
 solana-sdk = "1.14.11"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
-helium-crypto = "0.6.8"
+helium-crypto = "0.7.1"
 hex = "0.4.3"
 serde = "1.0.157"
 bincode = "1.3.3"


### PR DESCRIPTION
Upgrade helium-crypto to 0.7.1 which adds RSA key support

Note:

* utils/vehnt does not build for other errors so was not upgraded
* utils/generate-test-gateway-txn was not upgraded because of other errors