### PR TITLE
support rsa key types for addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@coral-xyz/anchor": "^0.26.0",
     "@coral-xyz/anchor-cli": "^0.26.0",
     "@coral-xyz/borsh": "^0.2.6",
-    "@helium/crypto": "^4.6.2",
+    "@helium/crypto": "^4.10.2",
     "@helium/transactions": "^3.38.0",
     "@metaplex-foundation/mpl-bubblegum": "^0.6.2",
     "@pythnetwork/client": "^2.8.0",

--- a/packages/distributor-oracle/package.json
+++ b/packages/distributor-oracle/package.json
@@ -37,7 +37,7 @@
     "@coral-xyz/anchor": "^0.26.0",
     "@fastify/cors": "^8.1.1",
     "@helium/account-fetch-cache": "^0.2.5",
-    "@helium/address": "^4.6.2",
+    "@helium/address": "^4.10.2",
     "@helium/helium-entity-manager-sdk": "^0.2.10",
     "@helium/helium-sub-daos-sdk": "^0.2.5",
     "@helium/idls": "^0.2.5",

--- a/packages/fanout-metadata-service/package.json
+++ b/packages/fanout-metadata-service/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.26.0",
     "@fastify/cors": "^8.1.1",
-    "@helium/address": "^4.6.2",
+    "@helium/address": "^4.10.2",
     "@helium/fanout-sdk": "^0.2.5",
     "@metaplex-foundation/mpl-token-metadata": "^2.2.3",
     "@solana/spl-account-compression": "^0.1.7",

--- a/packages/helium-admin-cli/package.json
+++ b/packages/helium-admin-cli/package.json
@@ -43,7 +43,7 @@
     "@coral-xyz/anchor": "^0.26.0",
     "@helium/address": "^4.10.2",
     "@helium/circuit-breaker-sdk": "^0.2.5",
-    "@helium/crypto": "^4.6.2",
+    "@helium/crypto": "^4.10.2",
     "@helium/data-credits-sdk": "^0.2.5",
     "@helium/distributor-oracle": "^0.2.10",
     "@helium/fanout-sdk": "^0.2.5",

--- a/packages/helium-admin-cli/package.json
+++ b/packages/helium-admin-cli/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@clockwork-xyz/sdk": "^0.2.4",
     "@coral-xyz/anchor": "^0.26.0",
-    "@helium/address": "^4.6.2",
+    "@helium/address": "^4.10.2",
     "@helium/circuit-breaker-sdk": "^0.2.5",
     "@helium/crypto": "^4.6.2",
     "@helium/data-credits-sdk": "^0.2.5",

--- a/packages/helium-entity-manager-sdk/package.json
+++ b/packages/helium-entity-manager-sdk/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.26.0",
-    "@helium/address": "^4.6.2",
+    "@helium/address": "^4.10.2",
     "@helium/anchor-resolvers": "^0.2.5",
     "@helium/helium-sub-daos-sdk": "^0.2.5",
     "@helium/idls": "^0.2.5",

--- a/packages/hnt-to-rent-service/package.json
+++ b/packages/hnt-to-rent-service/package.json
@@ -35,7 +35,7 @@
     "@coral-xyz/anchor": "^0.26.0",
     "@fastify/cors": "^8.1.1",
     "@helium/account-fetch-cache": "^0.2.5",
-    "@helium/address": "^4.6.2",
+    "@helium/address": "^4.10.2",
     "@orca-so/whirlpools-sdk": "^0.8.2",
     "@solana/web3.js": "^1.66.2",
     "axios": "^1.1.3",

--- a/packages/hotspot-data-sink/package.json
+++ b/packages/hotspot-data-sink/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.26",
     "@fastify/cors": "^8.1.1",
-    "@helium/address": "^4.6.2",
+    "@helium/address": "^4.10.2",
     "@helium/helium-entity-manager-sdk": "^0.2.10",
     "@helium/helium-sub-daos-sdk": "^0.2.5",
     "@helium/idls": "^0.2.5",

--- a/packages/metadata-service/package.json
+++ b/packages/metadata-service/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.26.0",
     "@fastify/cors": "^8.1.1",
-    "@helium/address": "^4.6.2",
+    "@helium/address": "^4.10.2",
     "@helium/helium-entity-manager-sdk": "^0.2.10",
     "@helium/helium-sub-daos-sdk": "^0.2.5",
     "@metaplex-foundation/mpl-token-metadata": "^2.2.3",

--- a/packages/migration-service/package.json
+++ b/packages/migration-service/package.json
@@ -38,7 +38,7 @@
     "@helium/account-fetch-cache": "^0.2.5",
     "@helium/address": "^4.10.2",
     "@helium/circuit-breaker-sdk": "^0.2.5",
-    "@helium/crypto": "^4.6.2",
+    "@helium/crypto": "^4.10.2",
     "@helium/data-credits-sdk": "^0.2.5",
     "@helium/distributor-oracle": "^0.2.10",
     "@helium/helium-entity-manager-sdk": "^0.2.10",

--- a/packages/migration-service/package.json
+++ b/packages/migration-service/package.json
@@ -36,7 +36,7 @@
     "@coral-xyz/anchor": "^0.26.0",
     "@fastify/cors": "^8.1.1",
     "@helium/account-fetch-cache": "^0.2.5",
-    "@helium/address": "^4.6.2",
+    "@helium/address": "^4.10.2",
     "@helium/circuit-breaker-sdk": "^0.2.5",
     "@helium/crypto": "^4.6.2",
     "@helium/data-credits-sdk": "^0.2.5",

--- a/packages/spl-utils/package.json
+++ b/packages/spl-utils/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.26.0",
     "@helium/account-fetch-cache": "^0.2.5",
-    "@helium/address": "^4.8.1",
+    "@helium/address": "^4.10.2",
     "@helium/anchor-resolvers": "^0.2.5",
     "@metaplex-foundation/mpl-token-metadata": "^2.5.2",
     "@solana/spl-account-compression": "^0.1.7",

--- a/packages/vsr-metadata-service/package.json
+++ b/packages/vsr-metadata-service/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.26.0",
     "@fastify/cors": "^8.1.1",
-    "@helium/address": "^4.6.2",
+    "@helium/address": "^4.10.2",
     "@helium/voter-stake-registry-sdk": "^0.2.5",
     "@metaplex-foundation/mpl-token-metadata": "^2.2.3",
     "@solana/spl-account-compression": "^0.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,15 +283,6 @@
     js-sha256 "^0.9.0"
     multiformats "^9.6.4"
 
-"@helium/address@^4.8.1":
-  version "4.8.1"
-  resolved "https://registry.npmjs.org/@helium/address/-/address-4.8.1.tgz"
-  integrity sha512-OEqX9j8m4sIc6bmvGUWV3/AHeuJCBWIl9EvRpS9xOPy+mC17OkDiPwZI35DSbMlAM7cK7+UjKYZvIVQL/aCgSQ==
-  dependencies:
-    bs58 "^5.0.0"
-    js-sha256 "^0.9.0"
-    multiformats "^9.6.4"
-
 "@helium/crypto@^3.60.0":
   version "3.60.0"
   resolved "https://registry.yarnpkg.com/@helium/crypto/-/crypto-3.60.0.tgz#58be74745d0c7cc3198481dc69f5530393fc7287"
@@ -301,12 +292,12 @@
     create-hash "^1.2.0"
     libsodium-wrappers "^0.7.6"
 
-"@helium/crypto@^4.6.2":
-  version "4.8.1"
-  resolved "https://registry.npmjs.org/@helium/crypto/-/crypto-4.8.1.tgz"
-  integrity sha512-yoiyenUShDRwVnUi7zrIiDJNjgeKNxcpRr0HNWF8ncOBaFikMQGuTwOaivDG04s1wIdHqK5k3MD7boEGjXlJFA==
+"@helium/crypto@^4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@helium/crypto/-/crypto-4.10.2.tgz#4707756a4623035e5a6f30b6e4ae51158f1e269a"
+  integrity sha512-ltDWuQwEMNNvIq82QhqF1EPsHm1LrOceiGZgPvi0c9FPp5B6ft2TPjpDueGM27uKy0XbcHAjvBM7HhSCRhs+iQ==
   dependencies:
-    "@helium/address" "^4.8.1"
+    "@helium/address" "^4.10.2"
     create-hash "^1.2.0"
     libsodium-wrappers "^0.7.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -274,7 +274,16 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@helium/address@^4.6.2", "@helium/address@^4.8.1":
+"@helium/address@^4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@helium/address/-/address-4.10.2.tgz#56960b118fceb6b6ddabe3e4ecec467d9ae50e26"
+  integrity sha512-qCswC7Z3GXuJyHv36RcOSnffeghjqJQx0fdu2Lxpf9fgOnIi1JZO2tjjk1mBaqOwCyp+0YzrTPUoEukL/WCtsA==
+  dependencies:
+    bs58 "^5.0.0"
+    js-sha256 "^0.9.0"
+    multiformats "^9.6.4"
+
+"@helium/address@^4.8.1":
   version "4.8.1"
   resolved "https://registry.npmjs.org/@helium/address/-/address-4.8.1.tgz"
   integrity sha512-OEqX9j8m4sIc6bmvGUWV3/AHeuJCBWIl9EvRpS9xOPy+mC17OkDiPwZI35DSbMlAM7cK7+UjKYZvIVQL/aCgSQ==


### PR DESCRIPTION
upgrades `@helium/crypto` to 4.10.2 and `@helium/address` to 4.10.2 to support RSA keytypes