### PR TITLE
Add pagination to metadata-service

### DIFF
--- a/packages/metadata-service/src/index.ts
+++ b/packages/metadata-service/src/index.ts
@@ -177,6 +177,9 @@ server.get<{ Querystring: { subnetwork: string, page: string } }>(
             required: true,
           },
         ],
+        order: [
+          [IotHotspotInfo, "created_at", "ASC"],
+        ],
       });
 
       let result = {
@@ -201,6 +204,9 @@ server.get<{ Querystring: { subnetwork: string, page: string } }>(
             model: MobileHotspotInfo,
             required: true,
           },
+        ],
+        order: [
+          [MobileHotspotInfo, "created_at", "ASC"],
         ],
       });
 

--- a/packages/metadata-service/src/index.ts
+++ b/packages/metadata-service/src/index.ts
@@ -31,7 +31,7 @@ import {
 } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 
-const PAGE_SIZE = 1000;
+const pageSize = Number(process.env.PAGE_SIZE) || 1000;
 
 const server: FastifyInstance = Fastify({
   logger: true,
@@ -115,10 +115,6 @@ server.get<{ Querystring: { subnetwork: string } }>(
   "/v2/hotspots/pagination-metadata",
   async (request, reply) => {
     const { subnetwork } = request.query;
-    const pageInt = 0;
-
-    const offset = (pageInt - 1) * PAGE_SIZE;
-    const limit = PAGE_SIZE;
 
     if (subnetwork === "iot") {
       const count = await KeyToAsset.count({
@@ -131,8 +127,9 @@ server.get<{ Querystring: { subnetwork: string } }>(
       });
 
       let result = {
+        pageSize,
         totalItems: count,
-        totalPages: Math.ceil(count / PAGE_SIZE),
+        totalPages: Math.ceil(count / pageSize),
       };
 
       return result;
@@ -148,7 +145,7 @@ server.get<{ Querystring: { subnetwork: string } }>(
 
       let result = {
         totalItems: count,
-        totalPages: Math.ceil(count / PAGE_SIZE),
+        totalPages: Math.ceil(count / pageSize),
       };
 
       return result;
@@ -164,8 +161,8 @@ server.get<{ Querystring: { subnetwork: string, page: string } }>(
     const { subnetwork, page: pageStr } = request.query;
     const pageInt = pageStr ? parseInt(pageStr) : 1;
 
-    const offset = (pageInt - 1) * PAGE_SIZE;
-    const limit = PAGE_SIZE;
+    const offset = (pageInt - 1) * pageSize;
+    const limit = pageSize;
 
     if (subnetwork === "iot") {
       const { count, rows: ktas } = await KeyToAsset.findAndCountAll({

--- a/packages/metadata-service/src/index.ts
+++ b/packages/metadata-service/src/index.ts
@@ -177,6 +177,7 @@ server.get<{ Querystring: { subnetwork: string, page: string } }>(
         ],
         order: [
           [IotHotspotInfo, "created_at", "ASC"],
+          [IotHotspotInfo, "address", "ASC"], // Need to sort additionally by address otherwise there are dupes across pages because of tight created_at coupling
         ],
       });
 
@@ -205,6 +206,7 @@ server.get<{ Querystring: { subnetwork: string, page: string } }>(
         ],
         order: [
           [MobileHotspotInfo, "created_at", "ASC"],
+          [MobileHotspotInfo, "address", "ASC"], // Need to sort additionally by address otherwise there are dupes across pages because of tight created_at coupling
         ],
       });
 

--- a/packages/metadata-service/src/index.ts
+++ b/packages/metadata-service/src/index.ts
@@ -144,6 +144,7 @@ server.get<{ Querystring: { subnetwork: string } }>(
       });
 
       let result = {
+        pageSize,
         totalItems: count,
         totalPages: Math.ceil(count / pageSize),
       };
@@ -159,7 +160,7 @@ server.get<{ Querystring: { subnetwork: string, page: string } }>(
   "/v2/hotspots",
   async (request, reply) => {
     const { subnetwork, page: pageStr } = request.query;
-    const pageInt = pageStr ? parseInt(pageStr) : 1;
+    const pageInt = pageStr ? Number(pageStr) : 1;
 
     const offset = (pageInt - 1) * pageSize;
     const limit = pageSize;


### PR DESCRIPTION
This PR:
- Updates `GET /v2/hotspots?subnetwork=<subnetwork>` to paginate.
    - Add `&page=<page_number>` to get results at page (e.g., `/v2/hotspots?subnetwork=iot&page=100`)
    - Results are sorted by `created_at` in `<subnetwork>_hotspot_infos` table
- Adds `GET /v2/hotspots/pagination-metadata?subnetwork=<subnetwork>` to yield metadata about pagination (e.g., `totalItems` and `totalPages`). Done so that we can cache `GET /v2/hotspots?subnetwork=<subnetwork>` by not returning such data there