### PR TITLE
poor mans comparison

### DIFF
--- a/packages/account-fetch-cache-hooks/src/hooks/useAccounts.ts
+++ b/packages/account-fetch-cache-hooks/src/hooks/useAccounts.ts
@@ -158,9 +158,16 @@ export function useAccounts<T>(
   // Start watchers
   useEffect(() => {
     if (result) {
-      setAccounts(result);
+      if (JSON.stringify(accounts) !== JSON.stringify(result)) {
+        setAccounts(result);
+      }
+
       const disposers = result.map((account) => {
-        return cache.watch(account.publicKey, account.parser, !!account.account);
+        return cache.watch(
+          account.publicKey,
+          account.parser,
+          !!account.account
+        );
       });
 
       return () => {
@@ -194,7 +201,10 @@ export function useAccounts<T>(
             },
             ...accounts.slice(index + 1),
           ];
-          setAccounts(newAccounts);
+
+          if (JSON.stringify(accounts) !== JSON.stringify(newAccounts)) {
+            setAccounts(newAccounts);
+          }
         }
       }
     });


### PR DESCRIPTION
Was getting 

> ERROR  Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.

[wdyr](https://github.com/welldone-software/why-did-you-render) and found 

>  LOG      {"StoreAtaBalance": [Function StoreAtaBalance]} Re-rendered because of hook changes:
 GROUP        [hook useState result]
 LOG        different objects that are equal by value. (more info at http://bit.ly/wdyr3)
 LOG        {"prev ": [{"account": [Object], "info": [Object], "parser": [Function anonymous], "publicKey": [PublicKey]}]} !== {"next ": [{"account": [Object], "info": [Object], "parser": [Function anonymous], "publicKey": [PublicKey]}]}
 LOG        {"For detailed diff, right click the following fn, save as global, and run: ": [Function diffFn]}