### PR TITLE
Put in higher rate limit jupiter swap url

### DIFF
--- a/packages/tokens-to-rent-service/src/env.ts
+++ b/packages/tokens-to-rent-service/src/env.ts
@@ -5,6 +5,6 @@ process.env.ANCHOR_WALLET =
 
 export const SOLANA_URL = process.env.SOLANA_URL || 'http://127.0.0.1:8899';
 export const JUPITER_URL =
-  process.env.JUPITER_URL || 'https://quote-api.jup.ag/v6';
+  process.env.JUPITER_URL || 'https://public.jupiterapi.com';
 export const JUPITER_FEE_BPS = process.env.JUPITER_FEE_BPS || '0';
 export const JUPITER_FEE_ACCOUNT = process.env.JUPITER_FEE_ACCOUNT || undefined;


### PR DESCRIPTION
This PR adjusts the API provided for the jupiter package. The default API was updated for swap/quote to leverage [jupiterapi.com](https://www.jupiterapi.com/). The API offers higher rate limits (up to 10 rps) along with a faster updated market cache. The [jupiterapi.com](https://www.jupiterapi.com/) market cache surfaces newly launched tokens faster since it doesn't require a certain volume/liquidity threshold to be met, along with an improved cadence of it being updated. _With that said, the API does take a small platform fee (0.2%) on swaps given the stability/rate limits/new markets it provides._ 

More details can be found on the site.