### PR TITLE
Remove superfluous line from buffer deploy

### DIFF
--- a/.github/actions/buffer-deploy/action.yaml
+++ b/.github/actions/buffer-deploy/action.yaml
@@ -114,4 +114,3 @@ runs:
         NETWORK: ${{ inputs.network }}
     - run: rm ./deploy-keypair.json
       shell: bash
-      if: always()


### PR DESCRIPTION
You don't need this since always is implied, right?