### PR TITLE
Update getting_started.md to throw exception when intended

### DIFF
--- a/packages/docsite/src/pages/docs/learn/getting_started.md
+++ b/packages/docsite/src/pages/docs/learn/getting_started.md
@@ -181,7 +181,7 @@ export const claimHotspotReward = async ({
 
   const recipientK = recipientKey(lazyDistributor, asset)
 
-  const recipientAcc = await lazyDistributorProgram.account.recipientV0.fetch(
+  const recipientAcc = await lazyDistributorProgram.account.recipientV0.fetchNullable(
     recipientK[0]
   )
 


### PR DESCRIPTION
Not even sure this check needs to be here since `formTransaction` handles when there's no recipient account [here](https://github.com/helium/helium-program-library/blob/ad08dacbd40b4b8ca1baa8be5dd3c36f812913e9/packages/distributor-oracle/src/client.ts#L597).