### PR TITLE
Optimize integrityCheck for cpu

### DIFF
--- a/packages/account-postgres-sink-service/src/server.ts
+++ b/packages/account-postgres-sink-service/src/server.ts
@@ -88,43 +88,88 @@ if (PG_POOL_SIZE < 5) {
   await server.register(fastifyCron, { jobs: [...customJobs] });
   await server.register(metrics);
   const eventHandler = new EventEmitter();
-  let refreshing: Promise<void> | undefined = undefined;
-  eventHandler.on("refresh-accounts", (programId, accountType) => {
-    if (!refreshing) {
-      refreshing = (async () => {
-        try {
-          if (configs) {
-            for (const config of configs) {
-              if (programId && programId == config.programId) {
-                const refreshTarget = accountType
-                  ? `account type '${accountType}' for program: ${config.programId}`
-                  : `all accounts for program: ${config.programId}`;
-                console.log(`Refreshing ${refreshTarget}`);
+  let processingJob = false;
+  const jobQueue: {
+    type: "integrity-check" | "refresh-accounts";
+    programId: string;
+    accountType?: string;
+    resolve: () => void;
+    reject: (err: any) => void;
+  }[] = [];
 
-                try {
-                  await upsertProgramAccounts({
-                    programId: new PublicKey(config.programId),
-                    accounts: accountType
-                      ? config.accounts.filter(
-                          (acc) => acc.type === accountType
-                        )
-                      : config.accounts,
-                  });
-
-                  console.log(`Accounts refreshed for ${refreshTarget}`);
-                } catch (err) {
-                  throw err;
-                }
-              }
-            }
-          }
-        } catch (err) {
-          console.error(err);
-        } finally {
-          refreshing = undefined;
-        }
-      })();
+  const processJobQueue = async () => {
+    if (processingJob || jobQueue.length === 0) {
+      return;
     }
+
+    processingJob = true;
+    const job = jobQueue.shift();
+
+    if (!job) {
+      processingJob = false;
+      return;
+    }
+
+    const jobDesc =
+      job.type === "refresh-accounts" && job.accountType
+        ? `${job.type} (${job.accountType}) for: ${job.programId}`
+        : `${job.type} for: ${job.programId}`;
+
+    console.log(`Starting ${jobDesc} (${jobQueue.length} remaining in queue)`);
+
+    try {
+      const config = configs.find((c) => c.programId === job.programId);
+
+      if (!config) {
+        throw new Error(`No config for program: ${job.programId}`);
+      }
+
+      if (job.type === "integrity-check") {
+        await integrityCheckProgramAccounts({
+          fastify: server,
+          programId: new PublicKey(config.programId),
+          accounts: config.accounts,
+        });
+      } else if (job.type === "refresh-accounts") {
+        await upsertProgramAccounts({
+          programId: new PublicKey(config.programId),
+          accounts: job.accountType
+            ? config.accounts.filter((acc) => acc.type === job.accountType)
+            : config.accounts,
+        });
+      }
+
+      console.log(`Completed ${jobDesc}`);
+      job.resolve();
+    } catch (err) {
+      console.error(`Job failed for ${jobDesc}:`, err);
+      job.reject(err);
+    } finally {
+      processingJob = false;
+      setImmediate(() => processJobQueue());
+    }
+  };
+
+  const queueJob = (
+    type: "integrity-check" | "refresh-accounts",
+    programId: string,
+    accountType?: string
+  ): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      jobQueue.push({ type, programId, accountType, resolve, reject });
+      console.log(
+        `Queued ${type} for: ${programId}${
+          accountType ? ` (${accountType})` : ""
+        } (queue size: ${jobQueue.length})`
+      );
+      processJobQueue();
+    });
+  };
+
+  eventHandler.on("refresh-accounts", (programId, accountType) => {
+    queueJob("refresh-accounts", programId, accountType).catch((err) => {
+      console.error("Error in queued refresh job:", err);
+    });
   });
 
   try {
@@ -173,20 +218,11 @@ if (PG_POOL_SIZE < 5) {
         }
       }
 
-      let prevRefreshing = refreshing;
+      // Queue the refresh job
       eventHandler.emit("refresh-accounts", programId, accountType);
-      if (prevRefreshing) {
-        res
-          .code(StatusCodes.TOO_MANY_REQUESTS)
-          .send(ReasonPhrases.TOO_MANY_REQUESTS);
-      } else {
-        res.code(StatusCodes.OK).send(ReasonPhrases.OK);
-      }
-    });
-
-    server.get("/refreshing", async (req, res) => {
       res.code(StatusCodes.OK).send({
-        refreshing: !!refreshing,
+        message: "Refresh job queued",
+        queueSize: jobQueue.length,
       });
     });
 
@@ -208,29 +244,22 @@ if (PG_POOL_SIZE < 5) {
               )
               .map(({ programId }) => programId);
 
-        for (const progId of programsToCheck) {
-          const config = configs.find((c) => c.programId === progId);
+        // Queue all integrity checks instead of running them directly
+        const queuePromises = programsToCheck.map((progId) =>
+          queueJob("integrity-check", progId)
+        );
 
-          if (!config) {
-            console.error(`No config for program: ${progId} found`);
-            continue;
-          }
+        // Return immediately after queueing (don't wait for completion)
+        res.code(StatusCodes.OK).send({
+          message: "Integrity checks queued",
+          queued: programsToCheck.length,
+          queueSize: jobQueue.length,
+        });
 
-          try {
-            await integrityCheckProgramAccounts({
-              fastify: server,
-              programId: new PublicKey(config.programId),
-              accounts: config.accounts,
-            });
-          } catch (err) {
-            console.error(
-              `Integrity check failed for program: ${progId}:`,
-              err
-            );
-          }
-        }
-
-        res.code(StatusCodes.OK).send(ReasonPhrases.OK);
+        // Let them run in background
+        Promise.all(queuePromises).catch((err) => {
+          console.error("Error in queued integrity checks:", err);
+        });
       } catch (err) {
         res.code(StatusCodes.INTERNAL_SERVER_ERROR).send(err);
         console.error(err);
@@ -352,7 +381,10 @@ if (PG_POOL_SIZE < 5) {
           });
           return;
         }
-        if (refreshing) {
+        const hasRefreshJob =
+          (processingJob && jobQueue[0]?.type === "refresh-accounts") ||
+          jobQueue.some((job) => job.type === "refresh-accounts");
+        if (hasRefreshJob) {
           res.code(StatusCodes.SERVICE_UNAVAILABLE).send({
             message: "Refresh is happening, cannot create transactions",
           });
@@ -389,7 +421,10 @@ if (PG_POOL_SIZE < 5) {
           });
           return;
         }
-        if (refreshing) {
+        const hasRefreshJob =
+          (processingJob && jobQueue[0]?.type === "refresh-accounts") ||
+          jobQueue.some((job) => job.type === "refresh-accounts");
+        if (hasRefreshJob) {
           res.code(StatusCodes.SERVICE_UNAVAILABLE).send({
             message: "Refresh is happening, cannot create transactions",
           });
@@ -445,22 +480,12 @@ if (PG_POOL_SIZE < 5) {
     console.log(`Running on 0.0.0.0:${port}`);
 
     if (REFRESH_ON_BOOT) {
-      console.log("Refreshing all program accounts on boot...");
+      console.log("Queueing all program accounts for refresh on boot...");
       for (const config of configs) {
-        console.log(`Refreshing accounts for program: ${config.programId}`);
-        // Wait for each refresh to complete before starting the next one
-        await new Promise<void>((resolve) => {
-          const originalRefreshing = refreshing;
-          eventHandler.emit("refresh-accounts", config.programId);
-
-          // If refresh started, wait for it to complete
-          if (refreshing && refreshing !== originalRefreshing) {
-            refreshing.then(() => resolve()).catch(() => resolve());
-          } else {
-            resolve();
-          }
-        });
+        console.log(`Queueing refresh for program: ${config.programId}`);
+        await queueJob("refresh-accounts", config.programId);
       }
+      console.log("All boot refresh jobs completed");
     }
 
     if (customJobs.length > 0) {

--- a/packages/account-postgres-sink-service/src/utils/handleAccountWebhook.ts
+++ b/packages/account-postgres-sink-service/src/utils/handleAccountWebhook.ts
@@ -79,7 +79,6 @@ export const handleAccountWebhook = async ({
 
         await Promise.all(deletePromises);
         await t.commit();
-        // @ts-ignore
         fastify.customMetrics.accountWebhookCounter.inc();
         return;
       }
@@ -189,7 +188,6 @@ export const handleAccountWebhook = async ({
       }
 
       await t.commit();
-      // @ts-ignore
       fastify.customMetrics.accountWebhookCounter.inc();
     } catch (err) {
       await t.rollback();

--- a/packages/account-postgres-sink-service/src/utils/handleTransactionWebhook.ts
+++ b/packages/account-postgres-sink-service/src/utils/handleTransactionWebhook.ts
@@ -132,7 +132,6 @@ export const handleTransactionWebhook = async ({
           }
 
           await t.commit();
-          // @ts-ignore
           fastify.customMetrics.transactionWebhookCounter.inc();
         } catch (err) {
           await t.rollback();


### PR DESCRIPTION
- Added a jobQueue to handle both refresh-accounts and integrity-checkers ensuring only 1 running at a time.
- Optimized integrity check to filter accounts prior to processing.