### PR TITLE
Fix VSR relinquish flow for expired vote markers

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -1,5 +1,10 @@
 name: "Setup Solana"
 description: "Setup Solana"
+inputs:
+  solana_cli_version:
+    description: "Solana CLI version to install when SOLANA_CLI_VERSION is unset"
+    required: false
+    default: "2.1.6"
 runs:
   using: "composite"
   steps:
@@ -10,9 +15,11 @@ runs:
           path: |
             ~/.cache/solana/
             ~/.local/share/solana/
-          key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_CLI_VERSION }}
-      - run: sh -c "$(curl -sSfL https://release.anza.xyz/v${{ env.SOLANA_CLI_VERSION }}/install)"
+          key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_CLI_VERSION || inputs.solana_cli_version }}
+      - run: sh -c "$(curl -sSfL https://release.anza.xyz/v${SOLANA_CLI_VERSION}/install)"
         shell: bash
+        env:
+          SOLANA_CLI_VERSION: ${{ env.SOLANA_CLI_VERSION || inputs.solana_cli_version }}
         if: steps.cache-solana.outputs.cache-hit != 'true'
       - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
         shell: bash

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -140,6 +140,9 @@ address = "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn" # Wormhole guardian set
 address = "HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni" # Wormhole guardian set index 5
 
 [[test.validator.clone]]
+address = "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf" # Wormhole guardian set index 6
+
+[[test.validator.clone]]
 address = "DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b"
 
 # Squads multisig program

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/voting/relinquish-position-votes.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/voting/relinquish-position-votes.ts
@@ -76,28 +76,30 @@ export const relinquishPositionVotes =
       const proposalAccounts =
         await proposalProgram.account.proposalV0.fetchMultiple(proposalKeys);
 
-      const proposals = proposalKeys.flatMap((pubkey, idx) => {
-        const account = proposalAccounts[idx];
-        return account ? [{ account, pubkey }] : [];
+      const proposals = proposalKeys.flatMap((pubkey, index) => {
+        const account = proposalAccounts[index];
+        return account
+          ? [
+              {
+                account,
+                pubkey,
+                markerPubkey: voteMarkerKey(positionMintPubkey, pubkey)[0],
+              },
+            ]
+          : [];
       });
 
-      const markerKeys = proposals.map(
-        (p) => voteMarkerKey(positionMintPubkey, p.pubkey)[0],
-      );
+      const markerAccounts =
+        await vsrProgram.account.voteMarkerV0.fetchMultiple(
+          proposals.map(({ markerPubkey }) => markerPubkey),
+        );
 
-      const markers = (
-        await vsrProgram.account.voteMarkerV0.fetchMultiple(markerKeys)
-      ).map((marker, index) => ({
-        marker,
-        markerPubkey: markerKeys[index],
-        proposal: proposals[index],
-      }));
-
-      const markersWithChoices = markers.flatMap((entry) =>
-        entry.marker && entry.marker.choices.length > 0
-          ? [{ ...entry, marker: entry.marker }]
-          : [],
-      );
+      const markersWithChoices = proposals.flatMap((proposal, index) => {
+        const marker = markerAccounts[index];
+        return marker && marker.choices.length > 0
+          ? [{ ...proposal, marker }]
+          : [];
+      });
 
       if (markersWithChoices.length === 0) {
         throw errors.BAD_REQUEST({
@@ -107,10 +109,15 @@ export const relinquishPositionVotes =
 
       const groups: InstructionGroup[] = [];
 
-      for (const { marker, markerPubkey, proposal } of markersWithChoices) {
+      for (const {
+        marker,
+        markerPubkey,
+        pubkey,
+        account,
+      } of markersWithChoices) {
         const instructions: TransactionInstruction[] = [];
 
-        if (typeof proposal.account.state.voting !== "undefined") {
+        if (typeof account.state.voting !== "undefined") {
           for (const choice of marker.choices) {
             instructions.push(
               await vsrProgram.methods
@@ -132,7 +139,7 @@ export const relinquishPositionVotes =
                 rentRefund: marker.rentRefund,
                 marker: markerPubkey,
                 position: positionPubkey,
-                proposal: proposal.pubkey,
+                proposal: pubkey,
                 systemProgram: SystemProgram.programId,
               })
               .instruction(),

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/voting/relinquish-position-votes.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/voting/relinquish-position-votes.ts
@@ -9,14 +9,17 @@ import {
 } from "@/lib/utils/transaction-tags";
 import { init as initOrg, proposalKey } from "@helium/organization-sdk";
 import { init as initProposal } from "@helium/proposal-sdk";
-import { truthy } from "@helium/spl-utils";
 import {
   init as initVsr,
   positionKey,
   voteMarkerKey,
 } from "@helium/voter-stake-registry-sdk";
 import { NATIVE_MINT } from "@solana/spl-token";
-import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import {
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+} from "@solana/web3.js";
 import BN from "bn.js";
 import { requirePositionOwnership, buildBatchedTransactions } from "../helpers";
 import type { InstructionGroup } from "../helpers";
@@ -73,51 +76,75 @@ export const relinquishPositionVotes =
       const proposalAccounts =
         await proposalProgram.account.proposalV0.fetchMultiple(proposalKeys);
 
-      const activeProposals = proposalKeys
-        .map((pubkey, idx) => ({ account: proposalAccounts[idx], pubkey }))
-        .filter(
-          (p) =>
-            p.account &&
-            typeof p.account.state.voting !== "undefined" &&
-            typeof p.account.state.resolved === "undefined",
-        );
+      const proposals = proposalKeys.flatMap((pubkey, idx) => {
+        const account = proposalAccounts[idx];
+        return account ? [{ account, pubkey }] : [];
+      });
 
-      const markerKeys = activeProposals.map(
+      const markerKeys = proposals.map(
         (p) => voteMarkerKey(positionMintPubkey, p.pubkey)[0],
       );
 
       const markers = (
         await vsrProgram.account.voteMarkerV0.fetchMultiple(markerKeys)
-      ).filter(truthy);
+      ).map((marker, index) => ({
+        marker,
+        markerPubkey: markerKeys[index],
+        proposal: proposals[index],
+      }));
 
-      if (markers.length === 0) {
+      const markersWithChoices = markers.flatMap((entry) =>
+        entry.marker && entry.marker.choices.length > 0
+          ? [{ ...entry, marker: entry.marker }]
+          : [],
+      );
+
+      if (markersWithChoices.length === 0) {
         throw errors.BAD_REQUEST({
-          message: "No active vote markers found for this position",
+          message: "No vote markers found for this position",
         });
       }
 
       const groups: InstructionGroup[] = [];
 
-      for (const marker of markers) {
+      for (const { marker, markerPubkey, proposal } of markersWithChoices) {
         const instructions: TransactionInstruction[] = [];
-        for (const choice of marker.choices) {
+
+        if (typeof proposal.account.state.voting !== "undefined") {
+          for (const choice of marker.choices) {
+            instructions.push(
+              await vsrProgram.methods
+                .relinquishVoteV1({ choice })
+                .accountsPartial({
+                  marker: markerPubkey,
+                  proposal: marker.proposal,
+                  voter: walletPubkey,
+                  position: positionPubkey,
+                })
+                .instruction(),
+            );
+          }
+        } else {
           instructions.push(
             await vsrProgram.methods
-              .relinquishVoteV1({ choice })
-              .accountsPartial({
-                proposal: marker.proposal,
-                voter: walletPubkey,
+              .relinquishExpiredVoteV0()
+              .accountsStrict({
+                rentRefund: marker.rentRefund,
+                marker: markerPubkey,
                 position: positionPubkey,
+                proposal: proposal.pubkey,
+                systemProgram: SystemProgram.programId,
               })
               .instruction(),
           );
         }
+
         groups.push({
           instructions,
           metadata: {
             type: "voting_relinquish_all",
             description: "Relinquish all votes from position",
-            votesRelinquished: instructions.length,
+            votesRelinquished: marker.choices.length,
           },
         });
       }
@@ -158,7 +185,11 @@ export const relinquishPositionVotes =
           transactions,
           parallel: false,
           tag,
-          actionMetadata: { type: "voting_relinquish_position", positionMint, organization },
+          actionMetadata: {
+            type: "voting_relinquish_position",
+            positionMint,
+            organization,
+          },
         },
         hasMore,
         estimatedSolFee: toTokenAmountOutput(

--- a/packages/blockchain-api/tests/e2e/governance.test.ts
+++ b/packages/blockchain-api/tests/e2e/governance.test.ts
@@ -15,6 +15,8 @@ import { NATIVE_MINT } from "@solana/spl-token";
 import { expect } from "chai";
 import { after, before, describe, it } from "mocha";
 import { isDefinedError } from "@orpc/client";
+import BN from "bn.js";
+import { getCurrentSeasonEnd } from "../../src/server/api/routers/governance/procedures/helpers/get-current-season";
 import { stopNextServer } from "./helpers/next";
 import { stopSurfpool } from "./helpers/surfpool";
 import { setupTestCtx, TestCtx } from "./helpers/context";
@@ -52,6 +54,38 @@ async function getPrograms(ctx: TestCtx) {
   const proxyProgram = await initProxy(provider);
 
   return { vsrProgram, hsdProgram, proxyProgram, provider };
+}
+
+const PROXY_ASSIGNMENT_DURATION_SECONDS = 86400 * 90;
+const PROXY_EXPIRATION_BUFFER_SECONDS = 60;
+
+async function getSeasonBoundedProxyExpirationTime(
+  ctx: TestCtx,
+  positionMint: string
+): Promise<number> {
+  const { vsrProgram, proxyProgram } = await getPrograms(ctx);
+  const now = Math.floor(Date.now() / 1000);
+  const [positionPubkey] = positionKey(new PublicKey(positionMint));
+  const positionAcc = await vsrProgram.account.positionV0.fetch(positionPubkey);
+  const registrar = await vsrProgram.account.registrar.fetch(
+    positionAcc.registrar
+  );
+  const proxyConfig = await proxyProgram.account.proxyConfigV0.fetch(
+    registrar.proxyConfig
+  );
+  const seasonEnd = getCurrentSeasonEnd(proxyConfig.seasons, new BN(now));
+
+  if (!seasonEnd) {
+    throw new Error("No current proxy season found");
+  }
+
+  const maxExpiration =
+    seasonEnd.toNumber() - PROXY_EXPIRATION_BUFFER_SECONDS;
+  if (maxExpiration <= now) {
+    throw new Error("Current proxy season has already ended");
+  }
+
+  return Math.min(now + PROXY_ASSIGNMENT_DURATION_SECONDS, maxExpiration);
 }
 
 describe("governance", () => {
@@ -782,7 +816,10 @@ describe("governance", () => {
     it("assigns proxy to position", async () => {
       // #given position with no proxy
       // #when assigning proxy
-      const expirationTime = Math.floor(Date.now() / 1000) + 86400 * 90; // 90 days
+      const expirationTime = await getSeasonBoundedProxyExpirationTime(
+        ctx,
+        positionMint
+      );
 
       const { data, error } = await ctx.safeClient.governance.assignProxies({
         walletAddress,
@@ -837,7 +874,10 @@ describe("governance", () => {
       });
       const unassignMint = unassignResult.positionMint;
 
-      const expirationTime = Math.floor(Date.now() / 1000) + 86400 * 90;
+      const expirationTime = await getSeasonBoundedProxyExpirationTime(
+        ctx,
+        unassignMint
+      );
       const { data: assignData, error: assignError } =
         await ctx.safeClient.governance.assignProxies({
           walletAddress,
@@ -917,7 +957,10 @@ describe("governance", () => {
 
     it("re-assigns proxy from one recipient to another", async () => {
       // #given position with proxy assigned to TEST_PROXY_ADDRESS
-      const expirationTime = Math.floor(Date.now() / 1000) + 86400 * 90;
+      const expirationTime = await getSeasonBoundedProxyExpirationTime(
+        ctx,
+        positionMint
+      );
 
       const { data: assignData, error: assignError } =
         await ctx.safeClient.governance.assignProxies({

--- a/programs/helium-sub-daos/src/state.rs
+++ b/programs/helium-sub-daos/src/state.rs
@@ -148,7 +148,9 @@ impl DaoV0 {
       self.recent_proposals[self.recent_proposals.len() - 1] = new_proposal;
     }
     // Re-sort the array to ensure it's in descending order by timestamp
-    self.recent_proposals.sort_by(|a, b| b.ts.cmp(&a.ts));
+    self
+      .recent_proposals
+      .sort_by_key(|proposal| std::cmp::Reverse(proposal.ts));
   }
 }
 

--- a/tests/circuit-breaker.ts
+++ b/tests/circuit-breaker.ts
@@ -19,6 +19,30 @@ import {
   ThresholdType,
 } from "../packages/circuit-breaker-sdk";
 
+const CIRCUIT_BREAKER_TRIGGERED_MESSAGE = "The circuit breaker was triggered";
+const CIRCUIT_BREAKER_TRIGGERED_CODE = 6000;
+
+function expectCircuitBreakerTriggered(error: any) {
+  const errorText = [
+    error?.toString?.(),
+    error?.message,
+    error?.msg,
+    error?.error?.errorMessage,
+    ...(error?.logs || []),
+    ...(error?.errorLogs || []),
+    ...(error?.transactionLogs || []),
+    ...(error?.simulationResponse?.value?.logs || []),
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const errorCode = Number(error?.code ?? error?.error?.errorCode?.number);
+  expect(
+    errorCode === CIRCUIT_BREAKER_TRIGGERED_CODE ||
+      errorText.includes(CIRCUIT_BREAKER_TRIGGERED_MESSAGE)
+  ).to.eq(true, errorText);
+}
+
 describe("circuit-breaker", () => {
   anchor.setProvider(anchor.AnchorProvider.local("http://127.0.0.1:8899"));
 
@@ -179,7 +203,7 @@ describe("circuit-breaker", () => {
           .rpc({ skipPreflight: true });
         throw new Error("should not get here");
       } catch (e: any) {
-        expect(e.toString()).to.include("The circuit breaker was triggered");
+        expectCircuitBreakerTriggered(e);
       }
 
       // Wait til the window passes
@@ -313,8 +337,7 @@ describe("circuit-breaker", () => {
           .rpc({ skipPreflight: true });
         throw new Error("should not get here");
       } catch (e: any) {
-        console.error(e);
-        expect(e.toString()).to.include("The circuit breaker was triggered");
+        expectCircuitBreakerTriggered(e);
       }
 
       // Wait til the window passes


### PR DESCRIPTION
fixes a stuck-position case where a VSR position can have numActiveVotes > 0 even though the UI cannot find any active vote markers to relinquish. That happens when a proposal is already resolved but its vote marker was not closed by tuktuk.

position-level relinquish endpoint now scans all proposals, finds remaining vote markers with choices, and builds the correct instruction based on proposal state:

* relinquishVoteV1 for proposals still in voting
* relinquishExpiredVoteV0 for resolved or otherwise non-voting proposals

also some ci and test fixes.

* default the shared Solana setup action to the repo-pinned CLI version when a caller does not set `SOLANA_CLI_VERSION`. This prevents E2E jobs from trying to install from an empty `release.anza.xyz/v/install` URL
* updates a Rust sort in `helium-sub-daos` to satisfy the current clippy lint set without introducing `is_multiple_of`, which is not available on the Rust toolchain used by the Anchor build
clone Wormhole guardian set index 6 into the Anchor local validator fixture so fresh Pyth VAAs can be verified in local contract tests.
* bind governance proxy E2E expirations to the current cloned proxy season instead of assuming a fixed 90-day expiration is always valid.
* make circuit-breaker negative tests assert the structured program error code or log message instead of relying only on Anchor's stringified error wrapper.