### PR TITLE
Feat/proxy assign queue relinquish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# helium-program-library — Claude rules
+
+## Housekeeping
+
+- **Never commit plans or specs to this repo.** Brainstorming output, implementation plans, design specs, and similar working documents go in `~/.claude/plans/`, not in `docs/` or anywhere else in the project tree. This includes anything written by the `superpowers:brainstorming`, `superpowers:writing-plans`, or related skills — those skills' default paths (`docs/superpowers/...`) are overridden by this rule.
+- If a plan or spec is already staged or committed, move it to `~/.claude/plans/` and drop it from the commit before pushing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,0 @@
-# helium-program-library — Claude rules
-
-## Housekeeping
-
-- **Never commit plans or specs to this repo.** Brainstorming output, implementation plans, design specs, and similar working documents go in `~/.claude/plans/`, not in `docs/` or anywhere else in the project tree. This includes anything written by the `superpowers:brainstorming`, `superpowers:writing-plans`, or related skills — those skills' default paths (`docs/superpowers/...`) are overridden by this rule.
-- If a plan or spec is already staged or committed, move it to `~/.claude/plans/` and drop it from the commit before pushing.

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
@@ -339,6 +339,25 @@ export const assign = publicProcedure.governance.assignProxies.handler(
                 })
                 .instruction()
             );
+
+            if (nextAvailable.length === 0) {
+              throw errors.BAD_REQUEST({ message: "No available task IDs" });
+            }
+            const freeTaskId = nextAvailable.pop()!;
+            instructions.push(
+              await hplCronsProgram.methods
+                .queueRelinquishExpiredVoteMarkerV0({
+                  freeTaskId,
+                  triggerTs: vote.endTs,
+                })
+                .accountsPartial({
+                  marker: voteMarkerKeys[i],
+                  position: positionPubkey,
+                  task: taskKey(TASK_QUEUE, freeTaskId)[0],
+                  taskQueue: TASK_QUEUE,
+                })
+                .instruction()
+            );
           }
         }
       }

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
@@ -19,18 +19,17 @@ import {
 } from "@helium/organization-sdk";
 import { init as initHplCrons } from "@helium/hpl-crons-sdk";
 import { init as initProposal } from "@helium/proposal-sdk";
-import { truthy } from "@helium/spl-utils";
-import { init as initStateController } from "@helium/state-controller-sdk";
 import {
+  customSignerKey,
   nextAvailableTaskIds,
   taskKey,
+  taskQueueAuthorityKey,
   init as initTuktuk,
 } from "@helium/tuktuk-sdk";
 import {
   init as initVsr,
   positionKey,
   proxyVoteMarkerKey,
-  voteMarkerKey,
 } from "@helium/voter-stake-registry-sdk";
 import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
 import { getJitoTipAmountLamports } from "@/lib/utils/jito";
@@ -56,7 +55,6 @@ export const assign = publicProcedure.governance.assignProxies.handler(
     const proxyProgram = await initProxy(provider);
     const orgProgram = await initOrg(provider);
     const proposalProgram = await initProposal(provider);
-    const stateControllerProgram = await initStateController(provider);
     const hplCronsProgram = await initHplCrons(provider);
     const tuktukProgram = await initTuktuk(provider);
 
@@ -68,15 +66,6 @@ export const assign = publicProcedure.governance.assignProxies.handler(
     type ProposalVoteData = {
       proposalPubkey: PublicKey;
       proxyMarkerPubkey: PublicKey;
-      proxyMarkerAcc: NonNullable<
-        Awaited<
-          ReturnType<typeof vsrProgram.account.proxyMarkerV0.fetchNullable>
-        >
-      >;
-      proposalConfig: PublicKey;
-      stateController: PublicKey;
-      onVoteHook: PublicKey;
-      endTs: BN;
     };
 
     let activeProxyVotes: ProposalVoteData[] = [];
@@ -105,73 +94,13 @@ export const assign = publicProcedure.governance.assignProxies.handler(
         const proxyVoteAccounts =
           await vsrProgram.account.proxyMarkerV0.fetchMultiple(proxyVoteKeys);
 
-        const proposalConfigKeys = [
-          ...new Set(
-            proposals
-              .map((p) => p.account.proposalConfig.toBase58())
-              .filter(truthy)
-          ),
-        ];
-        type ProposalConfigV0 = NonNullable<
-          Awaited<
-            ReturnType<
-              typeof proposalProgram.account.proposalConfigV0.fetchNullable
-            >
-          >
-        >;
-        const proposalConfigs: Record<string, ProposalConfigV0> = (
-          await proposalProgram.account.proposalConfigV0.fetchMultiple(
-            proposalConfigKeys
-          )
-        ).reduce((acc, pc, index) => {
-          if (pc) acc[proposalConfigKeys[index]] = pc;
-          return acc;
-        }, {} as Record<string, ProposalConfigV0>);
-
-        const stateControllerKeys = [
-          ...new Set(
-            Object.values(proposalConfigs)
-              .map((pc) => pc.stateController.toBase58())
-              .filter(truthy)
-          ),
-        ];
-        const resolutionSettings = (
-          await stateControllerProgram.account.resolutionSettingsV0.fetchMultiple(
-            stateControllerKeys
-          )
-        ).reduce((acc, rs, index) => {
-          if (rs) acc[stateControllerKeys[index]] = rs;
-          return acc;
-        }, {} as Record<string, NonNullable<Awaited<ReturnType<typeof stateControllerProgram.account.resolutionSettingsV0.fetchNullable>>>>);
-
         for (let i = 0; i < proposals.length; i++) {
           const proxyMarkerAcc = proxyVoteAccounts[i];
           if (!proxyMarkerAcc || proxyMarkerAcc.choices.length === 0) continue;
 
-          const proposal = proposals[i];
-          const config =
-            proposalConfigs[proposal.account.proposalConfig.toBase58()];
-          if (!config) continue;
-
-          const rs = resolutionSettings[config.stateController.toBase58()];
-          if (!rs) continue;
-
-          const startTs = new BN(proposal.account.state.voting!.startTs);
-          const offsetNode = rs.settings.nodes.find(
-            (node: { offsetFromStartTs?: { offset: BN } }) =>
-              typeof node.offsetFromStartTs !== "undefined"
-          );
-          const offset = offsetNode?.offsetFromStartTs?.offset ?? new BN(0);
-          const endTs = startTs.add(offset);
-
           activeProxyVotes.push({
-            proposalPubkey: proposal.pubkey,
+            proposalPubkey: proposals[i].pubkey,
             proxyMarkerPubkey: proxyVoteKeys[i],
-            proxyMarkerAcc,
-            proposalConfig: proposal.account.proposalConfig,
-            stateController: config.stateController,
-            onVoteHook: config.onVoteHook,
-            endTs,
           });
         }
       }
@@ -183,15 +112,10 @@ export const assign = publicProcedure.governance.assignProxies.handler(
       Awaited<ReturnType<typeof vsrProgram.account.registrar.fetch>>
     >();
 
-    const taskQueueAcc =
-      activeProxyVotes.length > 0
-        ? await tuktukProgram.account.taskQueueV0.fetch(TASK_QUEUE)
-        : null;
-    const maxTaskIds = positionMints.length * activeProxyVotes.length;
-    const nextAvailable =
-      taskQueueAcc && maxTaskIds > 0
-        ? nextAvailableTaskIds(taskQueueAcc.taskBitmap, maxTaskIds)
-        : [];
+    // Whether any position being assigned is delegated. The proxy's votes can
+    // only be propagated to delegated positions, so we only kick the proxy-vote
+    // cron when at least one delegated position is in this assignment.
+    let hasDelegatedAssignment = false;
 
     for (const positionMint of positionMints) {
       const positionMintPubkey = new PublicKey(positionMint);
@@ -282,10 +206,7 @@ export const assign = publicProcedure.governance.assignProxies.handler(
         }
       }
 
-      const {
-        instruction: assignInstruction,
-        pubkeys: { nextProxyAssignment },
-      } = await proxyProgram.methods
+      const { instruction: assignInstruction } = await proxyProgram.methods
         .assignProxyV0({ expirationTime: expirationTimeBN })
         .accountsPartial({
           asset: positionMintPubkey,
@@ -302,67 +223,70 @@ export const assign = publicProcedure.governance.assignProxies.handler(
 
       instructions.push(assignInstruction);
 
-      if (activeProxyVotes.length > 0 && nextProxyAssignment) {
+      if (activeProxyVotes.length > 0) {
         const [delegatedPosKey] = delegatedPositionKey(positionPubkey);
         const isDelegated = !!(await connection.getAccountInfo(
           delegatedPosKey
         ));
-
         if (isDelegated) {
-          const voteMarkerKeys = activeProxyVotes.map(
-            (v) => voteMarkerKey(positionMintPubkey, v.proposalPubkey)[0]
-          );
-          const existingMarkers =
-            await vsrProgram.account.voteMarkerV0.fetchMultiple(voteMarkerKeys);
-
-          for (let i = 0; i < activeProxyVotes.length; i++) {
-            if (existingMarkers[i]) continue;
-            const vote = activeProxyVotes[i];
-
-            instructions.push(
-              await vsrProgram.methods
-                .countProxyVoteV0()
-                .accountsPartial({
-                  payer: walletPubkey,
-                  proxyMarker: vote.proxyMarkerPubkey,
-                  marker: voteMarkerKeys[i],
-                  voter: vote.proxyMarkerAcc.voter,
-                  proxyAssignment: nextProxyAssignment,
-                  registrar: positionAcc.registrar,
-                  position: positionPubkey,
-                  proposal: vote.proposalPubkey,
-                  proposalConfig: vote.proposalConfig,
-                  stateController: vote.stateController,
-                  onVoteHook: vote.onVoteHook,
-                  proposalProgram: proposalProgram.programId,
-                  systemProgram: SystemProgram.programId,
-                })
-                .instruction()
-            );
-
-            if (nextAvailable.length === 0) {
-              throw errors.BAD_REQUEST({ message: "No available task IDs" });
-            }
-            const freeTaskId = nextAvailable.pop()!;
-            instructions.push(
-              await hplCronsProgram.methods
-                .queueRelinquishExpiredVoteMarkerV0({
-                  freeTaskId,
-                  triggerTs: vote.endTs,
-                })
-                .accountsPartial({
-                  marker: voteMarkerKeys[i],
-                  position: positionPubkey,
-                  task: taskKey(TASK_QUEUE, freeTaskId)[0],
-                  taskQueue: TASK_QUEUE,
-                })
-                .instruction()
-            );
-          }
+          hasDelegatedAssignment = true;
         }
       }
 
       allInstructions.push(instructions);
+    }
+
+    // If the proxy has already voted on an active proposal, that vote was cast
+    // before these positions were delegated to it, so the newly delegated
+    // positions aren't covered. Queueing a proxy-vote task lets the
+    // vote-service cron count the votes for them and schedule each marker's
+    // relinquish via the task-queue PDA (the only signer authorized to do so).
+    if (hasDelegatedAssignment && activeProxyVotes.length > 0) {
+      const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
+        TASK_QUEUE
+      );
+      const nextAvailable = nextAvailableTaskIds(
+        taskQueueAcc.taskBitmap,
+        activeProxyVotes.length
+      );
+      const queueAuthority = PublicKey.findProgramAddressSync(
+        [Buffer.from("queue_authority")],
+        hplCronsProgram.programId
+      )[0];
+
+      const proxyVoteTaskInstructions: TransactionInstruction[] = [];
+      for (const vote of activeProxyVotes) {
+        if (nextAvailable.length === 0) {
+          throw errors.BAD_REQUEST({ message: "No available task IDs" });
+        }
+        const freeTaskId = nextAvailable.pop()!;
+        proxyVoteTaskInstructions.push(
+          await hplCronsProgram.methods
+            // @ts-ignore queueProxyVoteV0 is missing from the published IDL types
+            .queueProxyVoteV0({ freeTaskId })
+            .accountsPartial({
+              marker: vote.proxyMarkerPubkey,
+              task: taskKey(TASK_QUEUE, freeTaskId)[0],
+              taskQueue: TASK_QUEUE,
+              payer: walletPubkey,
+              systemProgram: SystemProgram.programId,
+              queueAuthority,
+              tuktukProgram: tuktukProgram.programId,
+              voter: proxyKeyPubkey,
+              pdaWallet: customSignerKey(TASK_QUEUE, [
+                Buffer.from("vote_payer"),
+                proxyKeyPubkey.toBuffer(),
+              ])[0],
+              taskQueueAuthority: taskQueueAuthorityKey(
+                TASK_QUEUE,
+                queueAuthority
+              )[0],
+            })
+            .instruction()
+        );
+      }
+
+      allInstructions.push(proxyVoteTaskInstructions);
     }
 
     const groups: InstructionGroup[] = allInstructions

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
@@ -7,6 +7,7 @@ import {
 import {
   requirePositionOwnershipWithMessage,
   buildBatchedTransactions,
+  TASK_QUEUE,
 } from "../helpers";
 import type { InstructionGroup } from "../helpers";
 import { delegatedPositionKey } from "@helium/helium-sub-daos-sdk";
@@ -16,8 +17,15 @@ import {
   organizationKey,
   proposalKey,
 } from "@helium/organization-sdk";
+import { init as initHplCrons } from "@helium/hpl-crons-sdk";
 import { init as initProposal } from "@helium/proposal-sdk";
 import { truthy } from "@helium/spl-utils";
+import { init as initStateController } from "@helium/state-controller-sdk";
+import {
+  nextAvailableTaskIds,
+  taskKey,
+  init as initTuktuk,
+} from "@helium/tuktuk-sdk";
 import {
   init as initVsr,
   positionKey,
@@ -48,10 +56,14 @@ export const assign = publicProcedure.governance.assignProxies.handler(
     const proxyProgram = await initProxy(provider);
     const orgProgram = await initOrg(provider);
     const proposalProgram = await initProposal(provider);
+    const stateControllerProgram = await initStateController(provider);
+    const hplCronsProgram = await initHplCrons(provider);
+    const tuktukProgram = await initTuktuk(provider);
 
     const hntOrg = organizationKey("Helium")[0];
-    const organization =
-      await orgProgram.account.organizationV0.fetchNullable(hntOrg);
+    const organization = await orgProgram.account.organizationV0.fetchNullable(
+      hntOrg
+    );
 
     type ProposalVoteData = {
       proposalPubkey: PublicKey;
@@ -73,7 +85,7 @@ export const assign = publicProcedure.governance.assignProxies.handler(
         .fill(0)
         .map(
           (_, index) =>
-            proposalKey(hntOrg, organization.numProposals - index - 1)[0],
+            proposalKey(hntOrg, organization.numProposals - index - 1)[0]
         );
 
       const proposals = (
@@ -82,12 +94,12 @@ export const assign = publicProcedure.governance.assignProxies.handler(
         .map((account, index) => ({ account, pubkey: proposalKeys[index] }))
         .filter(
           (p): p is typeof p & { account: NonNullable<typeof p.account> } =>
-            !!p.account?.state.voting,
+            !!p.account?.state.voting
         );
 
       if (proposals.length > 0) {
         const proxyVoteKeys = proposals.map(
-          (p) => proxyVoteMarkerKey(proxyKeyPubkey, p.pubkey)[0],
+          (p) => proxyVoteMarkerKey(proxyKeyPubkey, p.pubkey)[0]
         );
         const proxyVoteAccounts =
           await vsrProgram.account.proxyMarkerV0.fetchMultiple(proxyVoteKeys);
@@ -96,29 +108,17 @@ export const assign = publicProcedure.governance.assignProxies.handler(
           ...new Set(
             proposals
               .map((p) => p.account.proposalConfig.toBase58())
-              .filter(truthy),
+              .filter(truthy)
           ),
         ];
         const proposalConfigs = (
           await proposalProgram.account.proposalConfigV0.fetchMultiple(
-            proposalConfigKeys,
+            proposalConfigKeys
           )
-        ).reduce(
-          (acc, pc, index) => {
-            if (pc) acc[proposalConfigKeys[index]] = pc;
-            return acc;
-          },
-          {} as Record<
-            string,
-            NonNullable<
-              Awaited<
-                ReturnType<
-                  typeof proposalProgram.account.proposalConfigV0.fetchNullable
-                >
-              >
-            >
-          >,
-        );
+        ).reduce((acc, pc, index) => {
+          if (pc) acc[proposalConfigKeys[index]] = pc;
+          return acc;
+        }, {} as Record<string, NonNullable<Awaited<ReturnType<typeof proposalProgram.account.proposalConfigV0.fetchNullable>>>>);
 
         for (let i = 0; i < proposals.length; i++) {
           const proxyMarkerAcc = proxyVoteAccounts[i];
@@ -151,8 +151,9 @@ export const assign = publicProcedure.governance.assignProxies.handler(
       const positionMintPubkey = new PublicKey(positionMint);
       const [positionPubkey] = positionKey(positionMintPubkey);
 
-      const positionAcc =
-        await vsrProgram.account.positionV0.fetchNullable(positionPubkey);
+      const positionAcc = await vsrProgram.account.positionV0.fetchNullable(
+        positionPubkey
+      );
 
       if (!positionAcc) {
         throw errors.NOT_FOUND({
@@ -165,14 +166,14 @@ export const assign = publicProcedure.governance.assignProxies.handler(
         positionMintPubkey,
         walletPubkey,
         positionMint,
-        errors,
+        errors
       );
 
       const registrarKey = positionAcc.registrar.toBase58();
       let registrar = registrarCache.get(registrarKey);
       if (!registrar) {
         registrar = await vsrProgram.account.registrar.fetch(
-          positionAcc.registrar,
+          positionAcc.registrar
         );
         registrarCache.set(registrarKey, registrar);
       }
@@ -181,12 +182,12 @@ export const assign = publicProcedure.governance.assignProxies.handler(
       const ownedAssetProxyAssignmentAddress = proxyAssignmentKey(
         proxyConfig,
         positionMintPubkey,
-        PublicKey.default,
+        PublicKey.default
       )[0];
 
       const existingProxyAssignment =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(
-          ownedAssetProxyAssignmentAddress,
+          ownedAssetProxyAssignmentAddress
         );
 
       const instructions: TransactionInstruction[] = [];
@@ -202,7 +203,7 @@ export const assign = publicProcedure.governance.assignProxies.handler(
           const addr = proxyAssignmentKey(
             proxyConfig,
             positionMintPubkey,
-            currentVoter,
+            currentVoter
           )[0];
           chain.push({ address: addr, voter: currentVoter });
           const acc =
@@ -227,10 +228,10 @@ export const assign = publicProcedure.governance.assignProxies.handler(
                 approver: walletPubkey,
                 tokenAccount: getAssociatedTokenAddressSync(
                   positionMintPubkey,
-                  walletPubkey,
+                  walletPubkey
                 ),
               })
-              .instruction(),
+              .instruction()
           );
         }
       }
@@ -248,7 +249,7 @@ export const assign = publicProcedure.governance.assignProxies.handler(
           approver: walletPubkey,
           tokenAccount: getAssociatedTokenAddressSync(
             positionMintPubkey,
-            walletPubkey,
+            walletPubkey
           ),
         })
         .prepare();
@@ -257,12 +258,13 @@ export const assign = publicProcedure.governance.assignProxies.handler(
 
       if (activeProxyVotes.length > 0 && nextProxyAssignment) {
         const [delegatedPosKey] = delegatedPositionKey(positionPubkey);
-        const isDelegated =
-          !!(await connection.getAccountInfo(delegatedPosKey));
+        const isDelegated = !!(await connection.getAccountInfo(
+          delegatedPosKey
+        ));
 
         if (isDelegated) {
           const voteMarkerKeys = activeProxyVotes.map(
-            (v) => voteMarkerKey(positionMintPubkey, v.proposalPubkey)[0],
+            (v) => voteMarkerKey(positionMintPubkey, v.proposalPubkey)[0]
           );
           const existingMarkers =
             await vsrProgram.account.voteMarkerV0.fetchMultiple(voteMarkerKeys);
@@ -289,7 +291,7 @@ export const assign = publicProcedure.governance.assignProxies.handler(
                   proposalProgram: proposalProgram.programId,
                   systemProgram: SystemProgram.programId,
                 })
-                .instruction(),
+                .instruction()
             );
           }
         }
@@ -350,13 +352,17 @@ export const assign = publicProcedure.governance.assignProxies.handler(
         transactions,
         parallel: true,
         tag,
-        actionMetadata: { type: "proxy_assign", proxyKey, positionCount: positionMints.length },
+        actionMetadata: {
+          type: "proxy_assign",
+          proxyKey,
+          positionCount: positionMints.length,
+        },
       },
       hasMore,
       estimatedSolFee: await toTokenAmountOutput(
         new BN(totalFee),
-        NATIVE_MINT.toBase58(),
+        NATIVE_MINT.toBase58()
       ),
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
@@ -183,6 +183,16 @@ export const assign = publicProcedure.governance.assignProxies.handler(
       Awaited<ReturnType<typeof vsrProgram.account.registrar.fetch>>
     >();
 
+    const taskQueueAcc =
+      activeProxyVotes.length > 0
+        ? await tuktukProgram.account.taskQueueV0.fetch(TASK_QUEUE)
+        : null;
+    const maxTaskIds = positionMints.length * activeProxyVotes.length;
+    const nextAvailable =
+      taskQueueAcc && maxTaskIds > 0
+        ? nextAvailableTaskIds(taskQueueAcc.taskBitmap, maxTaskIds)
+        : [];
+
     for (const positionMint of positionMints) {
       const positionMintPubkey = new PublicKey(positionMint);
       const [positionPubkey] = positionKey(positionMintPubkey);

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
@@ -76,6 +76,7 @@ export const assign = publicProcedure.governance.assignProxies.handler(
       proposalConfig: PublicKey;
       stateController: PublicKey;
       onVoteHook: PublicKey;
+      endTs: BN;
     };
 
     let activeProxyVotes: ProposalVoteData[] = [];
@@ -111,14 +112,37 @@ export const assign = publicProcedure.governance.assignProxies.handler(
               .filter(truthy)
           ),
         ];
-        const proposalConfigs = (
+        type ProposalConfigV0 = NonNullable<
+          Awaited<
+            ReturnType<
+              typeof proposalProgram.account.proposalConfigV0.fetchNullable
+            >
+          >
+        >;
+        const proposalConfigs: Record<string, ProposalConfigV0> = (
           await proposalProgram.account.proposalConfigV0.fetchMultiple(
             proposalConfigKeys
           )
         ).reduce((acc, pc, index) => {
           if (pc) acc[proposalConfigKeys[index]] = pc;
           return acc;
-        }, {} as Record<string, NonNullable<Awaited<ReturnType<typeof proposalProgram.account.proposalConfigV0.fetchNullable>>>>);
+        }, {} as Record<string, ProposalConfigV0>);
+
+        const stateControllerKeys = [
+          ...new Set(
+            Object.values(proposalConfigs)
+              .map((pc) => pc.stateController.toBase58())
+              .filter(truthy)
+          ),
+        ];
+        const resolutionSettings = (
+          await stateControllerProgram.account.resolutionSettingsV0.fetchMultiple(
+            stateControllerKeys
+          )
+        ).reduce((acc, rs, index) => {
+          if (rs) acc[stateControllerKeys[index]] = rs;
+          return acc;
+        }, {} as Record<string, NonNullable<Awaited<ReturnType<typeof stateControllerProgram.account.resolutionSettingsV0.fetchNullable>>>>);
 
         for (let i = 0; i < proposals.length; i++) {
           const proxyMarkerAcc = proxyVoteAccounts[i];
@@ -129,6 +153,17 @@ export const assign = publicProcedure.governance.assignProxies.handler(
             proposalConfigs[proposal.account.proposalConfig.toBase58()];
           if (!config) continue;
 
+          const rs = resolutionSettings[config.stateController.toBase58()];
+          if (!rs) continue;
+
+          const startTs = new BN(proposal.account.state.voting!.startTs);
+          const offsetNode = rs.settings.nodes.find(
+            (node: { offsetFromStartTs?: { offset: BN } }) =>
+              typeof node.offsetFromStartTs !== "undefined"
+          );
+          const offset = offsetNode?.offsetFromStartTs?.offset ?? new BN(0);
+          const endTs = startTs.add(offset);
+
           activeProxyVotes.push({
             proposalPubkey: proposal.pubkey,
             proxyMarkerPubkey: proxyVoteKeys[i],
@@ -136,6 +171,7 @@ export const assign = publicProcedure.governance.assignProxies.handler(
             proposalConfig: proposal.account.proposalConfig,
             stateController: config.stateController,
             onVoteHook: config.onVoteHook,
+            endTs,
           });
         }
       }

--- a/packages/blockchain-api/tests/e2e/governance.test.ts
+++ b/packages/blockchain-api/tests/e2e/governance.test.ts
@@ -56,7 +56,7 @@ async function getPrograms(ctx: TestCtx) {
   const provider = new AnchorProvider(
     ctx.connection,
     wallet,
-    AnchorProvider.defaultOptions(),
+    AnchorProvider.defaultOptions()
   );
 
   const vsrProgram = await initVsr(provider);
@@ -71,17 +71,17 @@ const PROXY_EXPIRATION_BUFFER_SECONDS = 60;
 
 async function getSeasonBoundedProxyExpirationTime(
   ctx: TestCtx,
-  positionMint: string,
+  positionMint: string
 ): Promise<number> {
   const { vsrProgram, proxyProgram } = await getPrograms(ctx);
   const now = Math.floor(Date.now() / 1000);
   const [positionPubkey] = positionKey(new PublicKey(positionMint));
   const positionAcc = await vsrProgram.account.positionV0.fetch(positionPubkey);
   const registrar = await vsrProgram.account.registrar.fetch(
-    positionAcc.registrar,
+    positionAcc.registrar
   );
   const proxyConfig = await proxyProgram.account.proxyConfigV0.fetch(
-    registrar.proxyConfig,
+    registrar.proxyConfig
   );
   const seasonEnd = getCurrentSeasonEnd(proxyConfig.seasons, new BN(now));
 
@@ -162,7 +162,7 @@ describe("governance", () => {
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
@@ -188,8 +188,9 @@ describe("governance", () => {
       const [positionPubkey] = positionKey(new PublicKey(result.positionMint));
 
       // Read clock before operation for exact endTs computation
-      const clockInfo =
-        await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+      const clockInfo = await ctx.connection.getAccountInfo(
+        SYSVAR_CLOCK_PUBKEY
+      );
       const clockTimestamp = Number(clockInfo!.data.readBigInt64LE(32));
 
       // #when extending the lockup to 60 days
@@ -205,19 +206,20 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_extend",
+        "position_extend"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify lockup endTs matches expected: clockTimestamp + 60 days
-      const positionAfter =
-        await vsrProgram.account.positionV0.fetch(positionPubkey);
+      const positionAfter = await vsrProgram.account.positionV0.fetch(
+        positionPubkey
+      );
       const expectedEndTs = clockTimestamp + 60 * 86400;
       const actualEndTs = positionAfter.lockup.endTs.toNumber();
       expect(actualEndTs).to.be.within(expectedEndTs, expectedEndTs + 3);
@@ -243,21 +245,22 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_flip_lockup",
+        "position_flip_lockup"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify lockup kind changed to constant on-chain
       const { vsrProgram } = await getPrograms(ctx);
       const [positionPubkey] = positionKey(new PublicKey(result.positionMint));
-      const positionAfter =
-        await vsrProgram.account.positionV0.fetch(positionPubkey);
+      const positionAfter = await vsrProgram.account.positionV0.fetch(
+        positionPubkey
+      );
       expect(Object.keys(positionAfter.lockup.kind)[0]).to.equal("constant");
     });
 
@@ -270,8 +273,9 @@ describe("governance", () => {
       });
 
       // Read clock before operation for exact endTs computation
-      const clockInfo =
-        await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+      const clockInfo = await ctx.connection.getAccountInfo(
+        SYSVAR_CLOCK_PUBKEY
+      );
       const clockTimestamp = Number(clockInfo!.data.readBigInt64LE(32));
 
       // #when resetting lockup to cliff with new period
@@ -288,21 +292,22 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_reset_lockup",
+        "position_reset_lockup"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify lockup kind is cliff and endTs matches expected
       const { vsrProgram } = await getPrograms(ctx);
       const [positionPubkey] = positionKey(new PublicKey(result.positionMint));
-      const positionAfter =
-        await vsrProgram.account.positionV0.fetch(positionPubkey);
+      const positionAfter = await vsrProgram.account.positionV0.fetch(
+        positionPubkey
+      );
       expect(Object.keys(positionAfter.lockup.kind)[0]).to.equal("cliff");
       const expectedEndTs = clockTimestamp + 90 * 86400;
       expect(positionAfter.lockup.endTs.toNumber()).to.be.oneOf([
@@ -341,7 +346,7 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_close",
+        "position_close"
       );
     });
   });
@@ -376,13 +381,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_split",
+        "position_split"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
@@ -417,7 +422,7 @@ describe("governance", () => {
       await signAndSubmitTransactionData(
         ctx.connection,
         splitData!.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       const targetPositionMint = splitData!.transactionData.transactions[0]
         .metadata?.newPositionMint as string;
@@ -425,10 +430,12 @@ describe("governance", () => {
       const { vsrProgram } = await getPrograms(ctx);
       const [sourcePubkey] = positionKey(new PublicKey(source.positionMint));
       const [targetPubkey] = positionKey(new PublicKey(targetPositionMint));
-      const sourceBefore =
-        await vsrProgram.account.positionV0.fetch(sourcePubkey);
-      const targetBefore =
-        await vsrProgram.account.positionV0.fetch(targetPubkey);
+      const sourceBefore = await vsrProgram.account.positionV0.fetch(
+        sourcePubkey
+      );
+      const targetBefore = await vsrProgram.account.positionV0.fetch(
+        targetPubkey
+      );
       const sourceAmountBefore = sourceBefore.amountDepositedNative.toNumber();
       const targetAmountBefore = targetBefore.amountDepositedNative.toNumber();
 
@@ -447,26 +454,28 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_transfer",
+        "position_transfer"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify amounts changed on-chain
-      const sourceAfter =
-        await vsrProgram.account.positionV0.fetch(sourcePubkey);
-      const targetAfter =
-        await vsrProgram.account.positionV0.fetch(targetPubkey);
+      const sourceAfter = await vsrProgram.account.positionV0.fetch(
+        sourcePubkey
+      );
+      const targetAfter = await vsrProgram.account.positionV0.fetch(
+        targetPubkey
+      );
       expect(sourceAfter.amountDepositedNative.toNumber()).to.equal(
-        sourceAmountBefore - transferAmount,
+        sourceAmountBefore - transferAmount
       );
       expect(targetAfter.amountDepositedNative.toNumber()).to.equal(
-        targetAmountBefore + transferAmount,
+        targetAmountBefore + transferAmount
       );
     });
   });
@@ -502,7 +511,7 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_transfer_ownership",
+        "position_transfer_ownership"
       );
       expect(data?.transactionData?.actionMetadata).to.deep.include({
         type: "position_transfer_ownership",
@@ -517,8 +526,8 @@ describe("governance", () => {
       const tx = VersionedTransaction.deserialize(
         Buffer.from(
           data.transactionData.transactions[0].serializedTransaction,
-          "base64",
-        ),
+          "base64"
+        )
       );
       tx.message.recentBlockhash = blockhash;
       tx.sign([ctx.payer]);
@@ -527,30 +536,32 @@ describe("governance", () => {
       });
       await ctx.connection.confirmTransaction(
         { signature: sig, blockhash, lastValidBlockHeight },
-        "confirmed",
+        "confirmed"
       );
 
       // Verify ownership transferred on-chain: recipient now holds the position NFT
       const recipientAta = getAssociatedTokenAddressSync(
         new PublicKey(result.positionMint),
         recipient.publicKey,
-        true,
+        true
       );
-      const recipientTokenAccount =
-        await ctx.connection.getAccountInfo(recipientAta);
+      const recipientTokenAccount = await ctx.connection.getAccountInfo(
+        recipientAta
+      );
       expect(recipientTokenAccount).to.not.be.null;
 
       // Original owner no longer holds it
       const originalAta = getAssociatedTokenAddressSync(
         new PublicKey(result.positionMint),
         ctx.payer.publicKey,
-        true,
+        true
       );
       const originalTokenAccount = await ctx.connection
         .getTokenAccountBalance(originalAta)
         .catch(() => null);
-      const recipientBalance =
-        await ctx.connection.getTokenAccountBalance(recipientAta);
+      const recipientBalance = await ctx.connection.getTokenAccountBalance(
+        recipientAta
+      );
       expect(recipientBalance.value.uiAmount).to.equal(1);
     });
   });
@@ -577,7 +588,7 @@ describe("governance", () => {
           positionMints: [result.positionMint],
           subDaoMint: MOBILE_MINT.toBase58(),
           automationEnabled: false,
-        },
+        }
       );
 
       // #then transaction builds and delegation is created
@@ -586,21 +597,22 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "delegation_delegate",
+        "delegation_delegate"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify delegated position exists on-chain
       const [positionPubkey] = positionKey(new PublicKey(result.positionMint));
       const [delegatedPosPubkey] = delegatedPositionKey(positionPubkey);
-      const delegatedInfo =
-        await ctx.connection.getAccountInfo(delegatedPosPubkey);
+      const delegatedInfo = await ctx.connection.getAccountInfo(
+        delegatedPosPubkey
+      );
       expect(delegatedInfo).to.not.be.null;
     });
 
@@ -617,14 +629,15 @@ describe("governance", () => {
       const [positionPubkey] = positionKey(new PublicKey(result.positionMint));
       const [delegatedPosPubkey] = delegatedPositionKey(positionPubkey);
 
-      const clockInfo =
-        await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+      const clockInfo = await ctx.connection.getAccountInfo(
+        SYSVAR_CLOCK_PUBKEY
+      );
       const clockTimestamp = Number(clockInfo!.data.readBigInt64LE(32));
       const shortExpiration = clockTimestamp + 3600;
       await setDelegatedPositionExpiration(
         ctx,
         delegatedPosPubkey,
-        shortExpiration,
+        shortExpiration
       );
 
       const delegatedBefore =
@@ -643,21 +656,22 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "delegation_extend",
+        "delegation_extend"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify delegated position expiration increased
-      const delegatedAfter =
-        await hsdProgram.account.delegatedPositionV0.fetch(delegatedPosPubkey);
+      const delegatedAfter = await hsdProgram.account.delegatedPositionV0.fetch(
+        delegatedPosPubkey
+      );
       expect(delegatedAfter.expirationTs.toNumber()).to.be.greaterThan(
-        delegatedBefore.expirationTs.toNumber(),
+        delegatedBefore.expirationTs.toNumber()
       );
     });
 
@@ -683,21 +697,22 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "delegation_undelegate",
+        "delegation_undelegate"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify delegated position account is closed on-chain
       const [positionPubkey] = positionKey(new PublicKey(result.positionMint));
       const [delegatedPosPubkey] = delegatedPositionKey(positionPubkey);
-      const delegatedInfo =
-        await ctx.connection.getAccountInfo(delegatedPosPubkey);
+      const delegatedInfo = await ctx.connection.getAccountInfo(
+        delegatedPosPubkey
+      );
       expect(delegatedInfo).to.be.null;
     });
   });
@@ -728,7 +743,7 @@ describe("governance", () => {
           positionMints: [positionMint],
           subDaoMint: MOBILE_MINT.toBase58(),
           automationEnabled: false,
-        },
+        }
       );
 
       // #then transaction builds and delegation changes
@@ -740,15 +755,16 @@ describe("governance", () => {
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify delegation changed to MOBILE sub-DAO
       const [positionPubkey] = positionKey(new PublicKey(positionMint));
       const [delegatedPosPubkey] = delegatedPositionKey(positionPubkey);
-      const delegatedInfo =
-        await ctx.connection.getAccountInfo(delegatedPosPubkey);
+      const delegatedInfo = await ctx.connection.getAccountInfo(
+        delegatedPosPubkey
+      );
       expect(delegatedInfo).to.not.be.null;
     });
   });
@@ -775,7 +791,7 @@ describe("governance", () => {
           positionMints: [result.positionMint],
           subDaoMint: MOBILE_MINT.toBase58(),
           automationEnabled: false,
-        },
+        }
       );
 
       // #then only delegation transaction is returned (no claims needed)
@@ -784,13 +800,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data.transactionData.transactions[0].metadata?.type).to.equal(
-        "delegation_delegate",
+        "delegation_delegate"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
     });
@@ -864,7 +880,7 @@ describe("governance", () => {
           positionMints: [mint1, mint2],
           subDaoMint: MOBILE_MINT.toBase58(),
           automationEnabled: false,
-        },
+        }
       );
 
       // #then response contains transactions for both positions
@@ -876,7 +892,7 @@ describe("governance", () => {
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs.length).to.equal(data.transactionData.transactions.length);
 
@@ -914,7 +930,7 @@ describe("governance", () => {
       // #when assigning proxy
       const expirationTime = await getSeasonBoundedProxyExpirationTime(
         ctx,
-        positionMint,
+        positionMint
       );
 
       const { data, error } = await ctx.safeClient.governance.assignProxies({
@@ -930,13 +946,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "proxy_assign",
+        "proxy_assign"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
@@ -944,19 +960,20 @@ describe("governance", () => {
       const { vsrProgram, proxyProgram } = await getPrograms(ctx);
       const positionMintPubkey = new PublicKey(positionMint);
       const [positionPubkey] = positionKey(positionMintPubkey);
-      const positionAcc =
-        await vsrProgram.account.positionV0.fetch(positionPubkey);
+      const positionAcc = await vsrProgram.account.positionV0.fetch(
+        positionPubkey
+      );
       const registrar = await vsrProgram.account.registrar.fetch(
-        positionAcc.registrar,
+        positionAcc.registrar
       );
       const [proxyAssignment] = proxyAssignmentKey(
         registrar.proxyConfig,
         positionMintPubkey,
-        new PublicKey(TEST_PROXY_ADDRESS),
+        new PublicKey(TEST_PROXY_ADDRESS)
       );
       const proxyAssignmentAcc =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(
-          proxyAssignment,
+          proxyAssignment
         );
       expect(proxyAssignmentAcc).to.not.be.null;
     });
@@ -972,7 +989,7 @@ describe("governance", () => {
 
       const expirationTime = await getSeasonBoundedProxyExpirationTime(
         ctx,
-        unassignMint,
+        unassignMint
       );
       const { data: assignData, error: assignError } =
         await ctx.safeClient.governance.assignProxies({
@@ -983,13 +1000,13 @@ describe("governance", () => {
         });
       if (assignError) {
         throw new Error(
-          `Failed to assign proxy: ${JSON.stringify(assignError)}`,
+          `Failed to assign proxy: ${JSON.stringify(assignError)}`
         );
       }
       await signAndSubmitTransactionData(
         ctx.connection,
         assignData!.transactionData,
-        ctx.payer,
+        ctx.payer
       );
 
       // #when unassigning proxy
@@ -1005,13 +1022,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "proxy_unassign",
+        "proxy_unassign"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
@@ -1019,19 +1036,20 @@ describe("governance", () => {
       const { vsrProgram, proxyProgram } = await getPrograms(ctx);
       const positionMintPubkey = new PublicKey(unassignMint);
       const [positionPubkey] = positionKey(positionMintPubkey);
-      const positionAcc =
-        await vsrProgram.account.positionV0.fetch(positionPubkey);
+      const positionAcc = await vsrProgram.account.positionV0.fetch(
+        positionPubkey
+      );
       const registrar = await vsrProgram.account.registrar.fetch(
-        positionAcc.registrar,
+        positionAcc.registrar
       );
       const [proxyAssignment] = proxyAssignmentKey(
         registrar.proxyConfig,
         positionMintPubkey,
-        new PublicKey(TEST_PROXY_ADDRESS),
+        new PublicKey(TEST_PROXY_ADDRESS)
       );
       const proxyAssignmentAcc =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(
-          proxyAssignment,
+          proxyAssignment
         );
       expect(proxyAssignmentAcc).to.be.null;
     });
@@ -1057,7 +1075,7 @@ describe("governance", () => {
       // #given position with proxy assigned to TEST_PROXY_ADDRESS
       const expirationTime = await getSeasonBoundedProxyExpirationTime(
         ctx,
-        positionMint,
+        positionMint
       );
 
       const { data: assignData, error: assignError } =
@@ -1069,13 +1087,13 @@ describe("governance", () => {
         });
       if (assignError) {
         throw new Error(
-          `Failed to assign proxy: ${JSON.stringify(assignError)}`,
+          `Failed to assign proxy: ${JSON.stringify(assignError)}`
         );
       }
       await signAndSubmitTransactionData(
         ctx.connection,
         assignData!.transactionData,
-        ctx.payer,
+        ctx.payer
       );
 
       // #when re-assigning proxy to a new address
@@ -1093,13 +1111,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "proxy_assign",
+        "proxy_assign"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
@@ -1107,16 +1125,17 @@ describe("governance", () => {
       const { vsrProgram, proxyProgram } = await getPrograms(ctx);
       const positionMintPubkey = new PublicKey(positionMint);
       const [positionPubkey] = positionKey(positionMintPubkey);
-      const positionAcc =
-        await vsrProgram.account.positionV0.fetch(positionPubkey);
+      const positionAcc = await vsrProgram.account.positionV0.fetch(
+        positionPubkey
+      );
       const registrar = await vsrProgram.account.registrar.fetch(
-        positionAcc.registrar,
+        positionAcc.registrar
       );
 
       const [oldProxy] = proxyAssignmentKey(
         registrar.proxyConfig,
         positionMintPubkey,
-        new PublicKey(TEST_PROXY_ADDRESS),
+        new PublicKey(TEST_PROXY_ADDRESS)
       );
       const oldProxyAcc =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(oldProxy);
@@ -1126,7 +1145,7 @@ describe("governance", () => {
       const [newProxy] = proxyAssignmentKey(
         registrar.proxyConfig,
         positionMintPubkey,
-        new PublicKey(newRecipient),
+        new PublicKey(newRecipient)
       );
       const newProxyAcc =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(newProxy);
@@ -1151,7 +1170,7 @@ describe("governance", () => {
       const names: string[] = [];
       for (const t of txData.transactions) {
         const tx = VersionedTransaction.deserialize(
-          Buffer.from(t.serializedTransaction, "base64"),
+          Buffer.from(t.serializedTransaction, "base64")
         );
         const keys = tx.message.staticAccountKeys;
         for (const ix of tx.message.compiledInstructions) {
@@ -1182,7 +1201,7 @@ describe("governance", () => {
       const { vsrProgram } = await getPrograms(ctx);
       const [proxyVoteMarker] = proxyVoteMarkerKey(
         proxyKp.publicKey,
-        proposalSetup.proposal,
+        proposalSetup.proposal
       );
       const proxiedVoteIx = await vsrProgram.methods
         .proxiedVoteV1({ choice: 0 })
@@ -1200,17 +1219,18 @@ describe("governance", () => {
       proxiedVoteTx.add(proxiedVoteIx);
       proxiedVoteTx.sign(ctx.payer, proxyKp);
       const proxiedVoteSig = await ctx.connection.sendRawTransaction(
-        proxiedVoteTx.serialize(),
+        proxiedVoteTx.serialize()
       );
       await ctx.connection.confirmTransaction(
         { signature: proxiedVoteSig, blockhash, lastValidBlockHeight },
-        "confirmed",
+        "confirmed"
       );
 
-      // Sanity: the proxy marker now records a choice.
-      const proxyMarkerAcc =
-        await vsrProgram.account.proxyMarkerV0.fetch(proxyVoteMarker);
-      expect(proxyMarkerAcc.choices).to.include(0);
+      // Sanity: the proxy marker now records the cast choice.
+      const proxyMarkerAcc = await vsrProgram.account.proxyMarkerV0.fetch(
+        proxyVoteMarker
+      );
+      expect(proxyMarkerAcc.choices).to.deep.equal([0]);
 
       // #given a delegated position owned by the wallet, not yet proxied
       const { positionMint } = await createAndFundPosition(ctx, {
@@ -1227,19 +1247,19 @@ describe("governance", () => {
         });
       if (delegateError) {
         throw new Error(
-          `Failed to delegate position: ${JSON.stringify(delegateError)}`,
+          `Failed to delegate position: ${JSON.stringify(delegateError)}`
         );
       }
       await signAndSubmitTransactionData(
         ctx.connection,
         delegateData!.transactionData,
-        ctx.payer,
+        ctx.payer
       );
 
       // #when assigning the delegated position to the proxy that already voted
       const expirationTime = await getSeasonBoundedProxyExpirationTime(
         ctx,
-        positionMint,
+        positionMint
       );
       const { data, error } = await ctx.safeClient.governance.assignProxies({
         walletAddress,
@@ -1248,8 +1268,7 @@ describe("governance", () => {
         expirationTime,
       });
 
-      // #then it builds successfully (the old inline relinquish required the
-      // proxy to sign, which is impossible from a wallet-signed assign tx)
+      // #then the call succeeds
       if (error) {
         expect.fail(`Unexpected error: ${JSON.stringify(error)}`);
       }
@@ -1265,7 +1284,7 @@ describe("governance", () => {
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data!.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs.length).to.be.greaterThan(0);
 
@@ -1273,19 +1292,20 @@ describe("governance", () => {
       const { proxyProgram } = await getPrograms(ctx);
       const positionMintPubkey = new PublicKey(positionMint);
       const [positionPubkey] = positionKey(positionMintPubkey);
-      const positionAcc =
-        await vsrProgram.account.positionV0.fetch(positionPubkey);
+      const positionAcc = await vsrProgram.account.positionV0.fetch(
+        positionPubkey
+      );
       const registrar = await vsrProgram.account.registrar.fetch(
-        positionAcc.registrar,
+        positionAcc.registrar
       );
       const [proxyAssignment] = proxyAssignmentKey(
         registrar.proxyConfig,
         positionMintPubkey,
-        proxyKp.publicKey,
+        proxyKp.publicKey
       );
       const proxyAssignmentAcc =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(
-          proxyAssignment,
+          proxyAssignment
         );
       expect(proxyAssignmentAcc).to.not.be.null;
     });
@@ -1320,20 +1340,20 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "voting_vote",
+        "voting_vote"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify vote marker exists
       const [voteMarker] = voteMarkerKey(
         new PublicKey(result.positionMint),
-        proposalSetup.proposal,
+        proposalSetup.proposal
       );
       const markerInfo = await ctx.connection.getAccountInfo(voteMarker);
       expect(markerInfo).to.not.be.null;
@@ -1360,7 +1380,7 @@ describe("governance", () => {
       await signAndSubmitTransactionData(
         ctx.connection,
         voteData!.transactionData,
-        ctx.payer,
+        ctx.payer
       );
 
       // #when relinquishing vote
@@ -1377,13 +1397,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "voting_relinquish",
+        "voting_relinquish"
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
@@ -1391,10 +1411,11 @@ describe("governance", () => {
       const { vsrProgram } = await getPrograms(ctx);
       const [voteMarker] = voteMarkerKey(
         new PublicKey(result.positionMint),
-        proposalSetup.proposal,
+        proposalSetup.proposal
       );
-      const markerAfter =
-        await vsrProgram.account.voteMarkerV0.fetchNullable(voteMarker);
+      const markerAfter = await vsrProgram.account.voteMarkerV0.fetchNullable(
+        voteMarker
+      );
       if (markerAfter) {
         expect(markerAfter.choices).to.not.include(0);
       }
@@ -1421,7 +1442,7 @@ describe("governance", () => {
       await signAndSubmitTransactionData(
         ctx.connection,
         voteData!.transactionData,
-        ctx.payer,
+        ctx.payer
       );
 
       // #when second vote on same choice
@@ -1435,7 +1456,7 @@ describe("governance", () => {
       // #then should fail - already voted for this choice
       if (!isDefinedError(error)) {
         expect.fail(
-          `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+          `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
         );
       }
       expect(error.code).to.equal("BAD_REQUEST");
@@ -1471,7 +1492,7 @@ describe("governance", () => {
       await signAndSubmitTransactionData(
         ctx.connection,
         data!.transactionData,
-        ctx.payer,
+        ctx.payer
       );
     });
 
@@ -1491,26 +1512,27 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "voting_relinquish_all",
+        "voting_relinquish_all"
       );
       expect(
-        data?.transactionData?.transactions[0].metadata?.votesRelinquished,
+        data?.transactionData?.transactions[0].metadata?.votesRelinquished
       ).to.equal(1);
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer,
+        ctx.payer
       );
       expect(sigs).to.have.length(1);
 
       // Verify vote marker is cleared on-chain
       const [voteMarker] = voteMarkerKey(
         new PublicKey(positionMint),
-        orgProposalSetup.proposal,
+        orgProposalSetup.proposal
       );
       const { vsrProgram } = await getPrograms(ctx);
-      const markerAfter =
-        await vsrProgram.account.voteMarkerV0.fetchNullable(voteMarker);
+      const markerAfter = await vsrProgram.account.voteMarkerV0.fetchNullable(
+        voteMarker
+      );
       if (markerAfter) {
         expect(markerAfter.choices).to.have.length(0);
       }
@@ -1541,7 +1563,7 @@ describe("governance", () => {
         await signAndSubmitTransactionData(
           ctx.connection,
           voteData!.transactionData,
-          ctx.payer,
+          ctx.payer
         );
 
         // #when trying to close position with active votes
@@ -1553,7 +1575,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1578,7 +1600,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST about lockup not expired
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1606,7 +1628,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1637,7 +1659,7 @@ describe("governance", () => {
         await signAndSubmitTransactionData(
           ctx.connection,
           splitData!.transactionData,
-          ctx.payer,
+          ctx.payer
         );
         const targetMint = splitData!.transactionData.transactions[0].metadata
           ?.newPositionMint as string;
@@ -1656,7 +1678,7 @@ describe("governance", () => {
         await signAndSubmitTransactionData(
           ctx.connection,
           voteData!.transactionData,
-          ctx.payer,
+          ctx.payer
         );
 
         // #when trying to transfer from position with active votes
@@ -1670,7 +1692,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1697,7 +1719,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1722,7 +1744,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1739,16 +1761,17 @@ describe("governance", () => {
         });
 
         const [positionPubkey] = positionKey(
-          new PublicKey(result.positionMint),
+          new PublicKey(result.positionMint)
         );
 
-        const clockInfo =
-          await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+        const clockInfo = await ctx.connection.getAccountInfo(
+          SYSVAR_CLOCK_PUBKEY
+        );
         const clockTimestamp = Number(clockInfo!.data.readBigInt64LE(32));
         await setPositionLockupEndTs(
           ctx,
           positionPubkey,
-          clockTimestamp - 3600,
+          clockTimestamp - 3600
         );
 
         // #when attempting to delegate
@@ -1762,12 +1785,12 @@ describe("governance", () => {
         // #then returns BAD_REQUEST with decay message
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
         expect(error.message).to.equal(
-          "Position lockup has fully decayed and cannot be delegated",
+          "Position lockup has fully decayed and cannot be delegated"
         );
       });
 
@@ -1782,16 +1805,17 @@ describe("governance", () => {
         });
 
         const [positionPubkey] = positionKey(
-          new PublicKey(result.positionMint),
+          new PublicKey(result.positionMint)
         );
 
-        const clockInfo =
-          await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+        const clockInfo = await ctx.connection.getAccountInfo(
+          SYSVAR_CLOCK_PUBKEY
+        );
         const clockTimestamp = Number(clockInfo!.data.readBigInt64LE(32));
         await setPositionLockupEndTs(
           ctx,
           positionPubkey,
-          clockTimestamp - 3600,
+          clockTimestamp - 3600
         );
 
         // #when attempting to extend delegation
@@ -1803,12 +1827,12 @@ describe("governance", () => {
         // #then returns BAD_REQUEST with decay message
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
         expect(error.message).to.equal(
-          "Position lockup has fully decayed and cannot be extended",
+          "Position lockup has fully decayed and cannot be extended"
         );
       });
     });
@@ -1833,7 +1857,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");

--- a/packages/blockchain-api/tests/e2e/governance.test.ts
+++ b/packages/blockchain-api/tests/e2e/governance.test.ts
@@ -8,9 +8,18 @@ import { HNT_MINT, IOT_MINT, MOBILE_MINT } from "@helium/spl-utils";
 import {
   init as initVsr,
   positionKey,
+  proxyVoteMarkerKey,
   voteMarkerKey,
 } from "@helium/voter-stake-registry-sdk";
-import { Keypair, LAMPORTS_PER_SOL, PublicKey, SYSVAR_CLOCK_PUBKEY, VersionedTransaction } from "@solana/web3.js";
+import { init as initHplCrons } from "@helium/hpl-crons-sdk";
+import {
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  SYSVAR_CLOCK_PUBKEY,
+  Transaction,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import { getAssociatedTokenAddressSync, NATIVE_MINT } from "@solana/spl-token";
 import { expect } from "chai";
 import { after, before, describe, it } from "mocha";
@@ -35,6 +44,7 @@ import {
 import {
   createTestProposal,
   createTestOrganizationProposal,
+  createHeliumOrgVotingProposal,
   ProposalSetup,
 } from "./helpers/proposal";
 
@@ -46,7 +56,7 @@ async function getPrograms(ctx: TestCtx) {
   const provider = new AnchorProvider(
     ctx.connection,
     wallet,
-    AnchorProvider.defaultOptions()
+    AnchorProvider.defaultOptions(),
   );
 
   const vsrProgram = await initVsr(provider);
@@ -61,17 +71,17 @@ const PROXY_EXPIRATION_BUFFER_SECONDS = 60;
 
 async function getSeasonBoundedProxyExpirationTime(
   ctx: TestCtx,
-  positionMint: string
+  positionMint: string,
 ): Promise<number> {
   const { vsrProgram, proxyProgram } = await getPrograms(ctx);
   const now = Math.floor(Date.now() / 1000);
   const [positionPubkey] = positionKey(new PublicKey(positionMint));
   const positionAcc = await vsrProgram.account.positionV0.fetch(positionPubkey);
   const registrar = await vsrProgram.account.registrar.fetch(
-    positionAcc.registrar
+    positionAcc.registrar,
   );
   const proxyConfig = await proxyProgram.account.proxyConfigV0.fetch(
-    registrar.proxyConfig
+    registrar.proxyConfig,
   );
   const seasonEnd = getCurrentSeasonEnd(proxyConfig.seasons, new BN(now));
 
@@ -79,8 +89,7 @@ async function getSeasonBoundedProxyExpirationTime(
     throw new Error("No current proxy season found");
   }
 
-  const maxExpiration =
-    seasonEnd.toNumber() - PROXY_EXPIRATION_BUFFER_SECONDS;
+  const maxExpiration = seasonEnd.toNumber() - PROXY_EXPIRATION_BUFFER_SECONDS;
   if (maxExpiration <= now) {
     throw new Error("Current proxy season has already ended");
   }
@@ -126,13 +135,12 @@ describe("governance", () => {
     it("creates a position with cliff lockup", async () => {
       // #given funded wallet with HNT
       // #when creating a position
-      const { data, error } =
-        await ctx.safeClient.governance.createPosition({
-          walletAddress,
-          tokenAmount: { amount: "100000000", mint: HNT_MINT.toBase58() }, // 1 HNT in bones
-          lockupKind: "cliff",
-          lockupPeriodsInDays: 30,
-        });
+      const { data, error } = await ctx.safeClient.governance.createPosition({
+        walletAddress,
+        tokenAmount: { amount: "100000000", mint: HNT_MINT.toBase58() }, // 1 HNT in bones
+        lockupKind: "cliff",
+        lockupPeriodsInDays: 30,
+      });
 
       // #then transaction builds successfully
       if (error) {
@@ -154,12 +162,13 @@ describe("governance", () => {
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
       // Verify position exists on-chain
-      const positionMint = data.transactionData.transactions[0].metadata?.positionMint as string;
+      const positionMint = data.transactionData.transactions[0].metadata
+        ?.positionMint as string;
       expect(positionMint).to.not.be.undefined;
 
       const [positionPubkey] = positionKey(new PublicKey(positionMint));
@@ -179,16 +188,16 @@ describe("governance", () => {
       const [positionPubkey] = positionKey(new PublicKey(result.positionMint));
 
       // Read clock before operation for exact endTs computation
-      const clockInfo = await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+      const clockInfo =
+        await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
       const clockTimestamp = Number(clockInfo!.data.readBigInt64LE(32));
 
       // #when extending the lockup to 60 days
-      const { data, error } =
-        await ctx.safeClient.governance.extendPosition({
-          walletAddress,
-          positionMint: result.positionMint,
-          lockupPeriodsInDays: 60,
-        });
+      const { data, error } = await ctx.safeClient.governance.extendPosition({
+        walletAddress,
+        positionMint: result.positionMint,
+        lockupPeriodsInDays: 60,
+      });
 
       // #then transaction builds and submits successfully
       if (error) {
@@ -196,13 +205,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_extend"
+        "position_extend",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -223,11 +232,10 @@ describe("governance", () => {
       });
 
       // #when flipping lockup kind
-      const { data, error } =
-        await ctx.safeClient.governance.flipLockupKind({
-          walletAddress,
-          positionMint: result.positionMint,
-        });
+      const { data, error } = await ctx.safeClient.governance.flipLockupKind({
+        walletAddress,
+        positionMint: result.positionMint,
+      });
 
       // #then transaction builds and submits successfully
       if (error) {
@@ -235,13 +243,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_flip_lockup"
+        "position_flip_lockup",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -262,17 +270,17 @@ describe("governance", () => {
       });
 
       // Read clock before operation for exact endTs computation
-      const clockInfo = await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+      const clockInfo =
+        await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
       const clockTimestamp = Number(clockInfo!.data.readBigInt64LE(32));
 
       // #when resetting lockup to cliff with new period
-      const { data, error } =
-        await ctx.safeClient.governance.resetLockup({
-          walletAddress,
-          positionMint: result.positionMint,
-          lockupKind: "cliff",
-          lockupPeriodsInDays: 90,
-        });
+      const { data, error } = await ctx.safeClient.governance.resetLockup({
+        walletAddress,
+        positionMint: result.positionMint,
+        lockupKind: "cliff",
+        lockupPeriodsInDays: 90,
+      });
 
       // #then transaction builds and submits successfully
       if (error) {
@@ -280,13 +288,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_reset_lockup"
+        "position_reset_lockup",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -302,7 +310,6 @@ describe("governance", () => {
         expectedEndTs + 1,
       ]);
     });
-
   });
 
   describe("position close", () => {
@@ -334,7 +341,7 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_close"
+        "position_close",
       );
     });
   });
@@ -369,19 +376,19 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_split"
+        "position_split",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
       // Verify new position exists on-chain
-      const targetPositionMint =
-        data.transactionData.transactions[0].metadata?.newPositionMint as string;
+      const targetPositionMint = data.transactionData.transactions[0].metadata
+        ?.newPositionMint as string;
       expect(targetPositionMint).to.not.be.undefined;
       const [targetPubkey] = positionKey(new PublicKey(targetPositionMint));
       const targetInfo = await ctx.connection.getAccountInfo(targetPubkey);
@@ -410,7 +417,7 @@ describe("governance", () => {
       await signAndSubmitTransactionData(
         ctx.connection,
         splitData!.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       const targetPositionMint = splitData!.transactionData.transactions[0]
         .metadata?.newPositionMint as string;
@@ -427,13 +434,12 @@ describe("governance", () => {
 
       // #when transferring 0.5 HNT from source to target
       const transferAmount = 50000000; // 0.5 HNT
-      const { data, error } =
-        await ctx.safeClient.governance.transferPosition({
-          walletAddress,
-          positionMint: source.positionMint,
-          targetPositionMint,
-          amount: transferAmount.toString(),
-        });
+      const { data, error } = await ctx.safeClient.governance.transferPosition({
+        walletAddress,
+        positionMint: source.positionMint,
+        targetPositionMint,
+        amount: transferAmount.toString(),
+      });
 
       // #then transaction builds and submits successfully
       if (error) {
@@ -441,13 +447,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_transfer"
+        "position_transfer",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -457,10 +463,10 @@ describe("governance", () => {
       const targetAfter =
         await vsrProgram.account.positionV0.fetch(targetPubkey);
       expect(sourceAfter.amountDepositedNative.toNumber()).to.equal(
-        sourceAmountBefore - transferAmount
+        sourceAmountBefore - transferAmount,
       );
       expect(targetAfter.amountDepositedNative.toNumber()).to.equal(
-        targetAmountBefore + transferAmount
+        targetAmountBefore + transferAmount,
       );
     });
   });
@@ -496,7 +502,7 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "position_transfer_ownership"
+        "position_transfer_ownership",
       );
       expect(data?.transactionData?.actionMetadata).to.deep.include({
         type: "position_transfer_ownership",
@@ -511,8 +517,8 @@ describe("governance", () => {
       const tx = VersionedTransaction.deserialize(
         Buffer.from(
           data.transactionData.transactions[0].serializedTransaction,
-          "base64"
-        )
+          "base64",
+        ),
       );
       tx.message.recentBlockhash = blockhash;
       tx.sign([ctx.payer]);
@@ -521,14 +527,14 @@ describe("governance", () => {
       });
       await ctx.connection.confirmTransaction(
         { signature: sig, blockhash, lastValidBlockHeight },
-        "confirmed"
+        "confirmed",
       );
 
       // Verify ownership transferred on-chain: recipient now holds the position NFT
       const recipientAta = getAssociatedTokenAddressSync(
         new PublicKey(result.positionMint),
         recipient.publicKey,
-        true
+        true,
       );
       const recipientTokenAccount =
         await ctx.connection.getAccountInfo(recipientAta);
@@ -538,10 +544,11 @@ describe("governance", () => {
       const originalAta = getAssociatedTokenAddressSync(
         new PublicKey(result.positionMint),
         ctx.payer.publicKey,
-        true
+        true,
       );
-      const originalTokenAccount =
-        await ctx.connection.getTokenAccountBalance(originalAta).catch(() => null);
+      const originalTokenAccount = await ctx.connection
+        .getTokenAccountBalance(originalAta)
+        .catch(() => null);
       const recipientBalance =
         await ctx.connection.getTokenAccountBalance(recipientAta);
       expect(recipientBalance.value.uiAmount).to.equal(1);
@@ -564,13 +571,14 @@ describe("governance", () => {
       });
 
       // #when delegating to MOBILE sub-DAO
-      const { data, error } =
-        await ctx.safeClient.governance.delegatePositions({
+      const { data, error } = await ctx.safeClient.governance.delegatePositions(
+        {
           walletAddress,
           positionMints: [result.positionMint],
           subDaoMint: MOBILE_MINT.toBase58(),
           automationEnabled: false,
-        });
+        },
+      );
 
       // #then transaction builds and delegation is created
       if (error) {
@@ -578,13 +586,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "delegation_delegate"
+        "delegation_delegate",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -609,21 +617,25 @@ describe("governance", () => {
       const [positionPubkey] = positionKey(new PublicKey(result.positionMint));
       const [delegatedPosPubkey] = delegatedPositionKey(positionPubkey);
 
-      const clockInfo = await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+      const clockInfo =
+        await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
       const clockTimestamp = Number(clockInfo!.data.readBigInt64LE(32));
       const shortExpiration = clockTimestamp + 3600;
-      await setDelegatedPositionExpiration(ctx, delegatedPosPubkey, shortExpiration);
+      await setDelegatedPositionExpiration(
+        ctx,
+        delegatedPosPubkey,
+        shortExpiration,
+      );
 
       const delegatedBefore =
         await hsdProgram.account.delegatedPositionV0.fetch(delegatedPosPubkey);
       expect(delegatedBefore.expirationTs.toNumber()).to.equal(shortExpiration);
 
       // #when extending delegation expiration
-      const { data, error } =
-        await ctx.safeClient.governance.extendDelegation({
-          walletAddress,
-          positionMint: result.positionMint,
-        });
+      const { data, error } = await ctx.safeClient.governance.extendDelegation({
+        walletAddress,
+        positionMint: result.positionMint,
+      });
 
       // #then transaction builds and submits successfully
       if (error) {
@@ -631,13 +643,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "delegation_extend"
+        "delegation_extend",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -645,7 +657,7 @@ describe("governance", () => {
       const delegatedAfter =
         await hsdProgram.account.delegatedPositionV0.fetch(delegatedPosPubkey);
       expect(delegatedAfter.expirationTs.toNumber()).to.be.greaterThan(
-        delegatedBefore.expirationTs.toNumber()
+        delegatedBefore.expirationTs.toNumber(),
       );
     });
 
@@ -671,13 +683,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "delegation_undelegate"
+        "delegation_undelegate",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -688,7 +700,6 @@ describe("governance", () => {
         await ctx.connection.getAccountInfo(delegatedPosPubkey);
       expect(delegatedInfo).to.be.null;
     });
-
   });
 
   describe("delegation with sub-DAO change", () => {
@@ -711,13 +722,14 @@ describe("governance", () => {
     it("changes delegation from IOT to MOBILE sub-DAO", async () => {
       // #given position delegated to IOT
       // #when changing delegation to MOBILE
-      const { data, error } =
-        await ctx.safeClient.governance.delegatePositions({
+      const { data, error } = await ctx.safeClient.governance.delegatePositions(
+        {
           walletAddress,
           positionMints: [positionMint],
           subDaoMint: MOBILE_MINT.toBase58(),
           automationEnabled: false,
-        });
+        },
+      );
 
       // #then transaction builds and delegation changes
       if (error) {
@@ -728,7 +740,7 @@ describe("governance", () => {
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -757,13 +769,14 @@ describe("governance", () => {
       });
 
       // #when delegating for first time
-      const { data, error } =
-        await ctx.safeClient.governance.delegatePositions({
+      const { data, error } = await ctx.safeClient.governance.delegatePositions(
+        {
           walletAddress,
           positionMints: [result.positionMint],
           subDaoMint: MOBILE_MINT.toBase58(),
           automationEnabled: false,
-        });
+        },
+      );
 
       // #then only delegation transaction is returned (no claims needed)
       if (error) {
@@ -771,13 +784,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data.transactionData.transactions[0].metadata?.type).to.equal(
-        "delegation_delegate"
+        "delegation_delegate",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
     });
@@ -816,7 +829,6 @@ describe("governance", () => {
       expect(data?.transactionData?.transactions).to.have.length(0);
       expect(data?.hasMore).to.equal(false);
     });
-
   });
 
   describe("multi-position delegation batching", () => {
@@ -846,13 +858,14 @@ describe("governance", () => {
     it("delegates multiple positions in a single call", async () => {
       // #given 2 undelegated positions
       // #when delegating both to MOBILE
-      const { data, error } =
-        await ctx.safeClient.governance.delegatePositions({
+      const { data, error } = await ctx.safeClient.governance.delegatePositions(
+        {
           walletAddress,
           positionMints: [mint1, mint2],
           subDaoMint: MOBILE_MINT.toBase58(),
           automationEnabled: false,
-        });
+        },
+      );
 
       // #then response contains transactions for both positions
       if (error) {
@@ -863,7 +876,7 @@ describe("governance", () => {
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs.length).to.equal(data.transactionData.transactions.length);
 
@@ -901,7 +914,7 @@ describe("governance", () => {
       // #when assigning proxy
       const expirationTime = await getSeasonBoundedProxyExpirationTime(
         ctx,
-        positionMint
+        positionMint,
       );
 
       const { data, error } = await ctx.safeClient.governance.assignProxies({
@@ -917,13 +930,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "proxy_assign"
+        "proxy_assign",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -934,16 +947,16 @@ describe("governance", () => {
       const positionAcc =
         await vsrProgram.account.positionV0.fetch(positionPubkey);
       const registrar = await vsrProgram.account.registrar.fetch(
-        positionAcc.registrar
+        positionAcc.registrar,
       );
       const [proxyAssignment] = proxyAssignmentKey(
         registrar.proxyConfig,
         positionMintPubkey,
-        new PublicKey(TEST_PROXY_ADDRESS)
+        new PublicKey(TEST_PROXY_ADDRESS),
       );
       const proxyAssignmentAcc =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(
-          proxyAssignment
+          proxyAssignment,
         );
       expect(proxyAssignmentAcc).to.not.be.null;
     });
@@ -959,7 +972,7 @@ describe("governance", () => {
 
       const expirationTime = await getSeasonBoundedProxyExpirationTime(
         ctx,
-        unassignMint
+        unassignMint,
       );
       const { data: assignData, error: assignError } =
         await ctx.safeClient.governance.assignProxies({
@@ -969,12 +982,14 @@ describe("governance", () => {
           expirationTime,
         });
       if (assignError) {
-        throw new Error(`Failed to assign proxy: ${JSON.stringify(assignError)}`);
+        throw new Error(
+          `Failed to assign proxy: ${JSON.stringify(assignError)}`,
+        );
       }
       await signAndSubmitTransactionData(
         ctx.connection,
         assignData!.transactionData,
-        ctx.payer
+        ctx.payer,
       );
 
       // #when unassigning proxy
@@ -990,13 +1005,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "proxy_unassign"
+        "proxy_unassign",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -1007,16 +1022,16 @@ describe("governance", () => {
       const positionAcc =
         await vsrProgram.account.positionV0.fetch(positionPubkey);
       const registrar = await vsrProgram.account.registrar.fetch(
-        positionAcc.registrar
+        positionAcc.registrar,
       );
       const [proxyAssignment] = proxyAssignmentKey(
         registrar.proxyConfig,
         positionMintPubkey,
-        new PublicKey(TEST_PROXY_ADDRESS)
+        new PublicKey(TEST_PROXY_ADDRESS),
       );
       const proxyAssignmentAcc =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(
-          proxyAssignment
+          proxyAssignment,
         );
       expect(proxyAssignmentAcc).to.be.null;
     });
@@ -1042,7 +1057,7 @@ describe("governance", () => {
       // #given position with proxy assigned to TEST_PROXY_ADDRESS
       const expirationTime = await getSeasonBoundedProxyExpirationTime(
         ctx,
-        positionMint
+        positionMint,
       );
 
       const { data: assignData, error: assignError } =
@@ -1053,12 +1068,14 @@ describe("governance", () => {
           expirationTime,
         });
       if (assignError) {
-        throw new Error(`Failed to assign proxy: ${JSON.stringify(assignError)}`);
+        throw new Error(
+          `Failed to assign proxy: ${JSON.stringify(assignError)}`,
+        );
       }
       await signAndSubmitTransactionData(
         ctx.connection,
         assignData!.transactionData,
-        ctx.payer
+        ctx.payer,
       );
 
       // #when re-assigning proxy to a new address
@@ -1076,13 +1093,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "proxy_assign"
+        "proxy_assign",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -1093,13 +1110,13 @@ describe("governance", () => {
       const positionAcc =
         await vsrProgram.account.positionV0.fetch(positionPubkey);
       const registrar = await vsrProgram.account.registrar.fetch(
-        positionAcc.registrar
+        positionAcc.registrar,
       );
 
       const [oldProxy] = proxyAssignmentKey(
         registrar.proxyConfig,
         positionMintPubkey,
-        new PublicKey(TEST_PROXY_ADDRESS)
+        new PublicKey(TEST_PROXY_ADDRESS),
       );
       const oldProxyAcc =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(oldProxy);
@@ -1109,11 +1126,168 @@ describe("governance", () => {
       const [newProxy] = proxyAssignmentKey(
         registrar.proxyConfig,
         positionMintPubkey,
-        new PublicKey(newRecipient)
+        new PublicKey(newRecipient),
       );
       const newProxyAcc =
         await proxyProgram.account.proxyAssignmentV0.fetchNullable(newProxy);
       expect(newProxyAcc).to.not.be.null;
+    });
+  });
+
+  describe("proxy assignment when proxy already voted", () => {
+    let walletAddress: string;
+
+    before(async () => {
+      walletAddress = ctx.payer.publicKey.toBase58();
+    });
+
+    // Decode the instruction name of every instruction in the returned
+    // transactions that belongs to the vsr or hpl-crons program.
+    async function instructionNames(txData: {
+      transactions: Array<{ serializedTransaction: string }>;
+    }): Promise<string[]> {
+      const { vsrProgram, provider } = await getPrograms(ctx);
+      const hplCronsProgram = await initHplCrons(provider);
+      const names: string[] = [];
+      for (const t of txData.transactions) {
+        const tx = VersionedTransaction.deserialize(
+          Buffer.from(t.serializedTransaction, "base64"),
+        );
+        const keys = tx.message.staticAccountKeys;
+        for (const ix of tx.message.compiledInstructions) {
+          const programId = keys[ix.programIdIndex];
+          const data = Buffer.from(ix.data);
+          if (programId.equals(vsrProgram.programId)) {
+            const decoded = vsrProgram.coder.instruction.decode(data);
+            if (decoded) names.push(decoded.name);
+          } else if (programId.equals(hplCronsProgram.programId)) {
+            const decoded = hplCronsProgram.coder.instruction.decode(data);
+            if (decoded) names.push(decoded.name);
+          }
+        }
+      }
+      return names;
+    }
+
+    it("queues a proxy-vote task instead of counting the vote inline", async () => {
+      // #given an active Helium-org proposal that the proxy has already voted on
+      const proxyKp = Keypair.generate();
+      const proposalSetup = await createHeliumOrgVotingProposal(ctx, {
+        name: `pv-${Math.random().toString(36).substring(2, 8)}`,
+        votingDurationSecs: 3600,
+        // Backdate so endTs is already in the past while still in Voting state.
+        startedSecsAgo: 7200,
+      });
+
+      const { vsrProgram } = await getPrograms(ctx);
+      const [proxyVoteMarker] = proxyVoteMarkerKey(
+        proxyKp.publicKey,
+        proposalSetup.proposal,
+      );
+      const proxiedVoteIx = await vsrProgram.methods
+        .proxiedVoteV1({ choice: 0 })
+        .accountsPartial({
+          proposal: proposalSetup.proposal,
+          voter: proxyKp.publicKey,
+          marker: proxyVoteMarker,
+        })
+        .instruction();
+      const { blockhash, lastValidBlockHeight } =
+        await ctx.connection.getLatestBlockhash("confirmed");
+      const proxiedVoteTx = new Transaction();
+      proxiedVoteTx.recentBlockhash = blockhash;
+      proxiedVoteTx.feePayer = ctx.payer.publicKey;
+      proxiedVoteTx.add(proxiedVoteIx);
+      proxiedVoteTx.sign(ctx.payer, proxyKp);
+      const proxiedVoteSig = await ctx.connection.sendRawTransaction(
+        proxiedVoteTx.serialize(),
+      );
+      await ctx.connection.confirmTransaction(
+        { signature: proxiedVoteSig, blockhash, lastValidBlockHeight },
+        "confirmed",
+      );
+
+      // Sanity: the proxy marker now records a choice.
+      const proxyMarkerAcc =
+        await vsrProgram.account.proxyMarkerV0.fetch(proxyVoteMarker);
+      expect(proxyMarkerAcc.choices).to.include(0);
+
+      // #given a delegated position owned by the wallet, not yet proxied
+      const { positionMint } = await createAndFundPosition(ctx, {
+        amount: "100000000",
+        lockupKind: "cliff",
+        lockupPeriodsInDays: 365,
+      });
+      const { data: delegateData, error: delegateError } =
+        await ctx.safeClient.governance.delegatePositions({
+          walletAddress,
+          positionMints: [positionMint],
+          subDaoMint: MOBILE_MINT.toBase58(),
+          automationEnabled: false,
+        });
+      if (delegateError) {
+        throw new Error(
+          `Failed to delegate position: ${JSON.stringify(delegateError)}`,
+        );
+      }
+      await signAndSubmitTransactionData(
+        ctx.connection,
+        delegateData!.transactionData,
+        ctx.payer,
+      );
+
+      // #when assigning the delegated position to the proxy that already voted
+      const expirationTime = await getSeasonBoundedProxyExpirationTime(
+        ctx,
+        positionMint,
+      );
+      const { data, error } = await ctx.safeClient.governance.assignProxies({
+        walletAddress,
+        positionMints: [positionMint],
+        proxyKey: proxyKp.publicKey.toBase58(),
+        expirationTime,
+      });
+
+      // #then it builds successfully (the old inline relinquish required the
+      // proxy to sign, which is impossible from a wallet-signed assign tx)
+      if (error) {
+        expect.fail(`Unexpected error: ${JSON.stringify(error)}`);
+      }
+
+      // #then it queues a proxy-vote cron task and does NOT count the vote or
+      // queue the wallet-unsignable relinquish inline
+      const names = await instructionNames(data!.transactionData);
+      expect(names).to.include("queueProxyVoteV0");
+      expect(names).to.not.include("countProxyVoteV0");
+      expect(names).to.not.include("queueRelinquishExpiredVoteMarkerV0");
+
+      // #then the assign transactions submit successfully
+      const sigs = await signAndSubmitTransactionData(
+        ctx.connection,
+        data!.transactionData,
+        ctx.payer,
+      );
+      expect(sigs.length).to.be.greaterThan(0);
+
+      // #then the proxy assignment exists on-chain
+      const { proxyProgram } = await getPrograms(ctx);
+      const positionMintPubkey = new PublicKey(positionMint);
+      const [positionPubkey] = positionKey(positionMintPubkey);
+      const positionAcc =
+        await vsrProgram.account.positionV0.fetch(positionPubkey);
+      const registrar = await vsrProgram.account.registrar.fetch(
+        positionAcc.registrar,
+      );
+      const [proxyAssignment] = proxyAssignmentKey(
+        registrar.proxyConfig,
+        positionMintPubkey,
+        proxyKp.publicKey,
+      );
+      const proxyAssignmentAcc =
+        await proxyProgram.account.proxyAssignmentV0.fetchNullable(
+          proxyAssignment,
+        );
+      expect(proxyAssignmentAcc).to.not.be.null;
     });
   });
 
@@ -1146,20 +1320,20 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "voting_vote"
+        "voting_vote",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
       // Verify vote marker exists
       const [voteMarker] = voteMarkerKey(
         new PublicKey(result.positionMint),
-        proposalSetup.proposal
+        proposalSetup.proposal,
       );
       const markerInfo = await ctx.connection.getAccountInfo(voteMarker);
       expect(markerInfo).to.not.be.null;
@@ -1186,17 +1360,16 @@ describe("governance", () => {
       await signAndSubmitTransactionData(
         ctx.connection,
         voteData!.transactionData,
-        ctx.payer
+        ctx.payer,
       );
 
       // #when relinquishing vote
-      const { data, error } =
-        await ctx.safeClient.governance.relinquishVote({
-          walletAddress,
-          proposalKey: proposalSetup.proposal.toBase58(),
-          positionMints: [result.positionMint],
-          choice: 0,
-        });
+      const { data, error } = await ctx.safeClient.governance.relinquishVote({
+        walletAddress,
+        proposalKey: proposalSetup.proposal.toBase58(),
+        positionMints: [result.positionMint],
+        choice: 0,
+      });
 
       // #then transaction builds and submits
       if (error) {
@@ -1204,13 +1377,13 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "voting_relinquish"
+        "voting_relinquish",
       );
 
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
@@ -1218,7 +1391,7 @@ describe("governance", () => {
       const { vsrProgram } = await getPrograms(ctx);
       const [voteMarker] = voteMarkerKey(
         new PublicKey(result.positionMint),
-        proposalSetup.proposal
+        proposalSetup.proposal,
       );
       const markerAfter =
         await vsrProgram.account.voteMarkerV0.fetchNullable(voteMarker);
@@ -1248,7 +1421,7 @@ describe("governance", () => {
       await signAndSubmitTransactionData(
         ctx.connection,
         voteData!.transactionData,
-        ctx.payer
+        ctx.payer,
       );
 
       // #when second vote on same choice
@@ -1262,7 +1435,7 @@ describe("governance", () => {
       // #then should fail - already voted for this choice
       if (!isDefinedError(error)) {
         expect.fail(
-          `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+          `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
         );
       }
       expect(error.code).to.equal("BAD_REQUEST");
@@ -1298,7 +1471,7 @@ describe("governance", () => {
       await signAndSubmitTransactionData(
         ctx.connection,
         data!.transactionData,
-        ctx.payer
+        ctx.payer,
       );
     });
 
@@ -1318,22 +1491,22 @@ describe("governance", () => {
       }
       expect(data?.transactionData?.transactions).to.have.length(1);
       expect(data?.transactionData?.transactions[0].metadata?.type).to.equal(
-        "voting_relinquish_all"
+        "voting_relinquish_all",
       );
       expect(
-        data?.transactionData?.transactions[0].metadata?.votesRelinquished
+        data?.transactionData?.transactions[0].metadata?.votesRelinquished,
       ).to.equal(1);
       const sigs = await signAndSubmitTransactionData(
         ctx.connection,
         data.transactionData,
-        ctx.payer
+        ctx.payer,
       );
       expect(sigs).to.have.length(1);
 
       // Verify vote marker is cleared on-chain
       const [voteMarker] = voteMarkerKey(
         new PublicKey(positionMint),
-        orgProposalSetup.proposal
+        orgProposalSetup.proposal,
       );
       const { vsrProgram } = await getPrograms(ctx);
       const markerAfter =
@@ -1368,7 +1541,7 @@ describe("governance", () => {
         await signAndSubmitTransactionData(
           ctx.connection,
           voteData!.transactionData,
-          ctx.payer
+          ctx.payer,
         );
 
         // #when trying to close position with active votes
@@ -1380,7 +1553,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1405,7 +1578,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST about lockup not expired
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1433,7 +1606,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1464,7 +1637,7 @@ describe("governance", () => {
         await signAndSubmitTransactionData(
           ctx.connection,
           splitData!.transactionData,
-          ctx.payer
+          ctx.payer,
         );
         const targetMint = splitData!.transactionData.transactions[0].metadata
           ?.newPositionMint as string;
@@ -1483,22 +1656,21 @@ describe("governance", () => {
         await signAndSubmitTransactionData(
           ctx.connection,
           voteData!.transactionData,
-          ctx.payer
+          ctx.payer,
         );
 
         // #when trying to transfer from position with active votes
-        const { error } =
-          await ctx.safeClient.governance.transferPosition({
-            walletAddress,
-            positionMint: source.positionMint,
-            targetPositionMint: targetMint,
-            amount: "50000000",
-          });
+        const { error } = await ctx.safeClient.governance.transferPosition({
+          walletAddress,
+          positionMint: source.positionMint,
+          targetPositionMint: targetMint,
+          amount: "50000000",
+        });
 
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1517,16 +1689,15 @@ describe("governance", () => {
         });
 
         // #when requesting undelegate
-        const { error } =
-          await ctx.safeClient.governance.undelegatePosition({
-            walletAddress,
-            positionMint: result.positionMint,
-          });
+        const { error } = await ctx.safeClient.governance.undelegatePosition({
+          walletAddress,
+          positionMint: result.positionMint,
+        });
 
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1551,7 +1722,7 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
@@ -1568,7 +1739,7 @@ describe("governance", () => {
         });
 
         const [positionPubkey] = positionKey(
-          new PublicKey(result.positionMint)
+          new PublicKey(result.positionMint),
         );
 
         const clockInfo =
@@ -1577,27 +1748,26 @@ describe("governance", () => {
         await setPositionLockupEndTs(
           ctx,
           positionPubkey,
-          clockTimestamp - 3600
+          clockTimestamp - 3600,
         );
 
         // #when attempting to delegate
-        const { error } =
-          await ctx.safeClient.governance.delegatePositions({
-            walletAddress,
-            positionMints: [result.positionMint],
-            subDaoMint: MOBILE_MINT.toBase58(),
-            automationEnabled: false,
-          });
+        const { error } = await ctx.safeClient.governance.delegatePositions({
+          walletAddress,
+          positionMints: [result.positionMint],
+          subDaoMint: MOBILE_MINT.toBase58(),
+          automationEnabled: false,
+        });
 
         // #then returns BAD_REQUEST with decay message
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
         expect(error.message).to.equal(
-          "Position lockup has fully decayed and cannot be delegated"
+          "Position lockup has fully decayed and cannot be delegated",
         );
       });
 
@@ -1612,7 +1782,7 @@ describe("governance", () => {
         });
 
         const [positionPubkey] = positionKey(
-          new PublicKey(result.positionMint)
+          new PublicKey(result.positionMint),
         );
 
         const clockInfo =
@@ -1621,25 +1791,24 @@ describe("governance", () => {
         await setPositionLockupEndTs(
           ctx,
           positionPubkey,
-          clockTimestamp - 3600
+          clockTimestamp - 3600,
         );
 
         // #when attempting to extend delegation
-        const { error } =
-          await ctx.safeClient.governance.extendDelegation({
-            walletAddress,
-            positionMint: result.positionMint,
-          });
+        const { error } = await ctx.safeClient.governance.extendDelegation({
+          walletAddress,
+          positionMint: result.positionMint,
+        });
 
         // #then returns BAD_REQUEST with decay message
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
         expect(error.message).to.equal(
-          "Position lockup has fully decayed and cannot be extended"
+          "Position lockup has fully decayed and cannot be extended",
         );
       });
     });
@@ -1664,13 +1833,12 @@ describe("governance", () => {
         // #then returns BAD_REQUEST
         if (!isDefinedError(error)) {
           expect.fail(
-            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`
+            `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
           );
         }
         expect(error.code).to.equal("BAD_REQUEST");
         expect(error.message).to.include("No proxy assignments");
       });
     });
-
   });
 });

--- a/packages/blockchain-api/tests/e2e/helpers/proposal.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/proposal.ts
@@ -19,6 +19,7 @@ import { init as initHsd, daoKey } from "@helium/helium-sub-daos-sdk";
 import { HNT_MINT } from "@helium/spl-utils";
 import { TestCtx } from "./context";
 import { sendAndConfirmInstructions } from "./tx";
+import { getSurfpoolRpcUrl } from "./surfpool";
 import BN from "bn.js";
 
 interface CreateProposalOptions {
@@ -43,11 +44,11 @@ export interface ProposalSetup {
  */
 function proposalConfigKey(
   name: string,
-  programId: PublicKey = PROPOSAL_PROGRAM_ID
+  programId: PublicKey = PROPOSAL_PROGRAM_ID,
 ): [PublicKey, number] {
   return PublicKey.findProgramAddressSync(
     [Buffer.from("proposal_config"), Buffer.from(name, "utf-8")],
-    programId
+    programId,
   );
 }
 
@@ -63,14 +64,14 @@ function proposalConfigKey(
  */
 export async function createTestProposal(
   ctx: TestCtx,
-  options: CreateProposalOptions
+  options: CreateProposalOptions,
 ): Promise<ProposalSetup> {
   // Create a signing provider using the test context's connection and payer
   const wallet = new Wallet(ctx.payer);
   const provider = new AnchorProvider(
     ctx.connection,
     wallet,
-    AnchorProvider.defaultOptions()
+    AnchorProvider.defaultOptions(),
   );
 
   const hsdProgram = await initHsd(provider);
@@ -91,7 +92,9 @@ export async function createTestProposal(
   const votingDuration = new BN(options.votingDurationSecs ?? 3600);
 
   const [resolutionSettingsPda] = resolutionSettingsKey(resolutionName);
-  const resolutionSettingsNodes = settings().offsetFromStartTs(votingDuration).build();
+  const resolutionSettingsNodes = settings()
+    .offsetFromStartTs(votingDuration)
+    .build();
   const [proposalConfig] = proposalConfigKey(configName);
   const seed = Buffer.from(options.name, "utf-8");
   const [proposalPubkey] = proposalKey(ctx.payer.publicKey, seed);
@@ -192,13 +195,13 @@ export async function createTestProposal(
  */
 export async function createTestOrganizationProposal(
   ctx: TestCtx,
-  options: CreateProposalOptions
+  options: CreateProposalOptions,
 ): Promise<ProposalSetup> {
   const wallet = new Wallet(ctx.payer);
   const provider = new AnchorProvider(
     ctx.connection,
     wallet,
-    AnchorProvider.defaultOptions()
+    AnchorProvider.defaultOptions(),
   );
 
   const hsdProgram = await initHsd(provider);
@@ -321,5 +324,187 @@ export async function createTestOrganizationProposal(
     registrar,
     resolutionSettings: resolutionSettingsPda,
     organization: organizationPubkey,
+  };
+}
+
+/**
+ * OrganizationV0 layout (after 8-byte anchor discriminator):
+ *   num_proposals: u32          (offset 8)
+ *   authority: pubkey           (offset 12)
+ *   default_proposal_config: pubkey (offset 44)
+ */
+const ORG_AUTHORITY_OFFSET = 12;
+const ORG_DEFAULT_PROPOSAL_CONFIG_OFFSET = 44;
+
+async function surfnetSetAccount(
+  pubkey: PublicKey,
+  data: Buffer,
+  owner: PublicKey,
+  lamports: number
+): Promise<void> {
+  await fetch(getSurfpoolRpcUrl(), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "surfnet_setAccount",
+      params: [
+        pubkey.toBase58(),
+        {
+          data: data.toString("hex"),
+          owner: owner.toBase58(),
+          lamports,
+        },
+      ],
+    }),
+  });
+}
+
+/**
+ * Creates a voting proposal under the real "Helium" organization so it is
+ * discoverable by the assignProxies procedure (which scans
+ * organizationKey("Helium")'s last 10 proposals).
+ *
+ * Seizes the forked Helium org by overwriting its `authority` and
+ * `default_proposal_config` fields via surfnet_setAccount, then creates the
+ * proposal through the organization program using a freshly created config.
+ * `startedSecsAgo` lets the caller backdate `startTs` so the voting window
+ * (startTs + offsetFromStartTs) can already be in the past while the proposal
+ * stays in the Voting state (surfpool does not auto-resolve).
+ */
+export async function createHeliumOrgVotingProposal(
+  ctx: TestCtx,
+  options: CreateProposalOptions & { startedSecsAgo?: number }
+): Promise<ProposalSetup & { index: number }> {
+  const wallet = new Wallet(ctx.payer);
+  const provider = new AnchorProvider(
+    ctx.connection,
+    wallet,
+    AnchorProvider.defaultOptions()
+  );
+
+  const hsdProgram = await initHsd(provider);
+  const proposalProgram = await initProposal(provider);
+  const stateControllerProgram = await initStateController(provider);
+  const orgProgram = await initOrg(provider);
+
+  const [hntOrg] = organizationKey("Helium");
+  const orgAcc = await orgProgram.account.organizationV0.fetch(hntOrg);
+  const index = orgAcc.numProposals;
+
+  const [daoK] = daoKey(HNT_MINT);
+  const dao = await hsdProgram.account.daoV0.fetch(daoK);
+  const registrar = dao.registrar;
+
+  const shortId = Math.random().toString(36).substring(2, 8);
+  const configName = `tc-${shortId}`;
+  const resolutionName = `rs-${shortId}`;
+  const votingDuration = new BN(options.votingDurationSecs ?? 3600);
+
+  const [resolutionSettingsPda] = resolutionSettingsKey(resolutionName);
+  const resolutionSettingsNodes = settings()
+    .offsetFromStartTs(votingDuration)
+    .build();
+  const [proposalConfig] = PublicKey.findProgramAddressSync(
+    [Buffer.from("proposal_config"), Buffer.from(configName, "utf-8")],
+    PROPOSAL_PROGRAM_ID
+  );
+  const [proposalPubkey] = orgProposalKey(hntOrg, index);
+
+  const initResolutionIx = await stateControllerProgram.methods
+    .initializeResolutionSettingsV0({
+      name: resolutionName,
+      settings: { nodes: resolutionSettingsNodes },
+    })
+    .accounts({
+      payer: ctx.payer.publicKey,
+      resolutionSettings: resolutionSettingsPda,
+    })
+    .instruction();
+
+  const initConfigIx = await proposalProgram.methods
+    .initializeProposalConfigV0({
+      name: configName,
+      voteController: registrar,
+      stateController: resolutionSettingsPda,
+      onVoteHook: PublicKey.default,
+      authority: ctx.payer.publicKey,
+    })
+    .accounts({
+      payer: ctx.payer.publicKey,
+      owner: ctx.payer.publicKey,
+      proposalConfig,
+    })
+    .instruction();
+
+  await sendAndConfirmInstructions(ctx.connection, ctx.payer, [
+    initResolutionIx,
+    initConfigIx,
+  ]);
+
+  // Seize the Helium org: authority -> payer so we can create proposals, and
+  // default_proposal_config -> our config so the org accepts it.
+  const accountInfo = await ctx.connection.getAccountInfo(hntOrg);
+  if (!accountInfo) {
+    throw new Error("Helium organization account not found on fork");
+  }
+  const newData = Buffer.from(accountInfo.data);
+  ctx.payer.publicKey.toBuffer().copy(newData, ORG_AUTHORITY_OFFSET);
+  proposalConfig.toBuffer().copy(newData, ORG_DEFAULT_PROPOSAL_CONFIG_OFFSET);
+  await surfnetSetAccount(
+    hntOrg,
+    newData,
+    accountInfo.owner,
+    accountInfo.lamports
+  );
+
+  const initProposalIx = await orgProgram.methods
+    .initializeProposalV0({
+      name: options.name,
+      uri: "https://test.example.com",
+      maxChoicesPerVoter: options.maxChoicesPerVoter ?? 1,
+      choices: options.choices ?? [
+        { name: "Yes", uri: null },
+        { name: "No", uri: null },
+      ],
+      tags: ["test"],
+    })
+    .accounts({
+      payer: ctx.payer.publicKey,
+      authority: ctx.payer.publicKey,
+      owner: ctx.payer.publicKey,
+      proposal: proposalPubkey,
+      proposalConfig,
+      organization: hntOrg,
+      proposalProgram: PROPOSAL_PROGRAM_ID,
+    })
+    .instruction();
+
+  await sendAndConfirmInstructions(ctx.connection, ctx.payer, [initProposalIx]);
+
+  const startTs = Math.floor(Date.now() / 1000) - (options.startedSecsAgo ?? 0);
+  const updateStateIx = await stateControllerProgram.methods
+    .updateStateV0({
+      newState: {
+        voting: { startTs: new BN(startTs) },
+      },
+    })
+    .accounts({
+      proposal: proposalPubkey,
+      proposalConfig,
+      resolutionSettings: resolutionSettingsPda,
+    })
+    .instruction();
+
+  await sendAndConfirmInstructions(ctx.connection, ctx.payer, [updateStateIx]);
+
+  return {
+    proposalConfig,
+    proposal: proposalPubkey,
+    registrar,
+    resolutionSettings: resolutionSettingsPda,
+    organization: hntOrg,
+    index,
   };
 }

--- a/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
+++ b/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
@@ -129,6 +129,40 @@ export const useAssignProxies = () => {
         acc[proposalConfigKeys[index]] = pc;
         return acc;
       }, {} as Record<string, any>);
+      const stateControllerKeys = [
+        ...new Set(
+          Object.values(proposalConfigsByPubkey)
+            .map((pc: any) => pc?.stateController?.toBase58())
+            .filter(truthy)
+        ),
+      ];
+      const resolutionSettingsByStateController = (
+        await stateControllerProgram.account.resolutionSettingsV0.fetchMultiple(
+          stateControllerKeys
+        )
+      ).reduce((acc, rs, index) => {
+        if (rs) acc[stateControllerKeys[index]] = rs;
+        return acc;
+      }, {} as Record<string, any>);
+
+      const endTsByProposal: Record<string, BN> = {};
+      for (const op of openProposals) {
+        const config =
+          proposalConfigsByPubkey[op.account!.proposalConfig.toBase58()];
+        if (!config) continue;
+        const rs =
+          resolutionSettingsByStateController[
+            config.stateController.toBase58()
+          ];
+        if (!rs) continue;
+        const startTs = new BN((op.account as any).state.voting.startTs);
+        const offsetNode = rs.settings.nodes.find(
+          (node: { offsetFromStartTs?: { offset: BN } }) =>
+            typeof node.offsetFromStartTs !== "undefined"
+        );
+        const offset = offsetNode?.offsetFromStartTs?.offset ?? new BN(0);
+        endTsByProposal[op.pubkey.toBase58()] = startTs.add(offset);
+      }
       const myVoteMarkerKeys = positions
         .map((position) =>
           openProposals.map((op) => voteMarkerKey(position.mint, op.pubkey)[0])

--- a/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
+++ b/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
@@ -5,9 +5,18 @@ import {
   fetchBackwardsCompatibleIdl,
   truthy,
 } from "@helium/spl-utils";
-import { positionKey, ProxyAssignment, proxyVoteMarkerKey, voteMarkerKey } from "@helium/voter-stake-registry-sdk";
+import {
+  positionKey,
+  ProxyAssignment,
+  proxyVoteMarkerKey,
+  voteMarkerKey,
+} from "@helium/voter-stake-registry-sdk";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
-import { PublicKey, SystemProgram, TransactionInstruction } from "@solana/web3.js";
+import {
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+} from "@solana/web3.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import BN from "bn.js";
 import { INDEXER_WAIT } from "../constants";
@@ -23,7 +32,17 @@ import {
   init as proposalInit,
   PROGRAM_ID as PROPOSAL_PROGRAM_ID,
 } from "@helium/proposal-sdk";
-import { init as initVsr, PROGRAM_ID as VSR_PROGRAM_ID } from "@helium/voter-stake-registry-sdk";
+import {
+  init as initVsr,
+  PROGRAM_ID as VSR_PROGRAM_ID,
+} from "@helium/voter-stake-registry-sdk";
+import { init as hplCronsInit, TASK_QUEUE_ID } from "@helium/hpl-crons-sdk";
+import { init as initStateController } from "@helium/state-controller-sdk";
+import {
+  nextAvailableTaskIds,
+  taskKey,
+  init as tuktukInit,
+} from "@helium/tuktuk-sdk";
 
 export const useAssignProxies = () => {
   const { provider, registrar, voteService, refetch } = useHeliumVsrState();
@@ -63,6 +82,9 @@ export const useAssignProxies = () => {
         proposalProgramId
       );
       const vsrProgram = await initVsr(provider as any, vsrProgramId);
+      const hplCronsProgram = await hplCronsInit(provider as any);
+      const stateControllerProgram = await initStateController(provider as any);
+      const tuktukProgram = await tuktukInit(provider as any);
       const hntOrg = organizationKey("Helium")[0];
       const organization = await orgProgram.account.organizationV0.fetch(
         hntOrg
@@ -79,23 +101,39 @@ export const useAssignProxies = () => {
       )
         .map((account, index) => ({ account, pubkey: proposalKeys[index] }))
         .filter((prop) => !!prop?.account?.state.voting);
-      const proxyVoteKeys = openProposals.map((prop) => proxyVoteMarkerKey(recipient, prop.pubkey)[0]);
-      const proxyVoteAccounts = (await vsrProgram.account.proxyMarkerV0.fetchMultiple(proxyVoteKeys)).map((account, index) => ({ account, pubkey: proxyVoteKeys[index] } )).filter(v => v.account);
+      const proxyVoteKeys = openProposals.map(
+        (prop) => proxyVoteMarkerKey(recipient, prop.pubkey)[0]
+      );
+      const proxyVoteAccounts = (
+        await vsrProgram.account.proxyMarkerV0.fetchMultiple(proxyVoteKeys)
+      )
+        .map((account, index) => ({ account, pubkey: proxyVoteKeys[index] }))
+        .filter((v) => v.account);
       const proposalsByPubkey = openProposals.reduce((acc, prop) => {
         acc[prop.pubkey.toBase58()] = prop.account;
         return acc;
       }, {} as Record<string, any>);
-      const proposalConfigKeys = [...new Set(
-        openProposals
-          .map((prop) => prop.account?.proposalConfig)
-          .map((p) => p?.toBase58())
-          .filter(truthy)
-      )];
-      const proposalConfigsByPubkey = (await proposalProgram.account.proposalConfigV0.fetchMultiple(proposalConfigKeys)).reduce((acc, pc, index) => {
+      const proposalConfigKeys = [
+        ...new Set(
+          openProposals
+            .map((prop) => prop.account?.proposalConfig)
+            .map((p) => p?.toBase58())
+            .filter(truthy)
+        ),
+      ];
+      const proposalConfigsByPubkey = (
+        await proposalProgram.account.proposalConfigV0.fetchMultiple(
+          proposalConfigKeys
+        )
+      ).reduce((acc, pc, index) => {
         acc[proposalConfigKeys[index]] = pc;
         return acc;
       }, {} as Record<string, any>);
-      const myVoteMarkerKeys = positions.map(position => openProposals.map(op => voteMarkerKey(position.mint, op.pubkey)[0])).flat();
+      const myVoteMarkerKeys = positions
+        .map((position) =>
+          openProposals.map((op) => voteMarkerKey(position.mint, op.pubkey)[0])
+        )
+        .flat();
       const myVoteMarkerAccounts = (
         await vsrProgram.account.voteMarkerV0.fetchMultiple(myVoteMarkerKeys)
       )
@@ -104,7 +142,7 @@ export const useAssignProxies = () => {
         .reduce((acc, v) => {
           acc[v.pubkey.toBase58()] = v.account;
           return acc;
-        }, {} as Record<string, any>) ;
+        }, {} as Record<string, any>);
 
       let resultingAssignments: ProxyAssignment[] = [];
       let undelegated: ProxyAssignment[] = [];
@@ -233,7 +271,11 @@ export const useAssignProxies = () => {
               proxyMarker.account!.proposal
             )[0];
             const voteMarker = myVoteMarkerAccounts[voteMarkerK.toBase58()];
-            if (position.isDelegated && !voteMarker && (proxyMarker.account?.choices?.length || 0) > 0) {
+            if (
+              position.isDelegated &&
+              !voteMarker &&
+              (proxyMarker.account?.choices?.length || 0) > 0
+            ) {
               subInstructions.push(
                 await vsrProgram.methods
                   .countProxyVoteV0()

--- a/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
+++ b/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
@@ -163,13 +163,14 @@ export const useAssignProxies = () => {
         const offset = offsetNode?.offsetFromStartTs?.offset ?? new BN(0);
         endTsByProposal[op.pubkey.toBase58()] = startTs.add(offset);
       }
-      const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
-        TASK_QUEUE_ID
-      );
+      const taskQueueAcc =
+        proxyVoteAccounts.length > 0
+          ? await tuktukProgram.account.taskQueueV0.fetch(TASK_QUEUE_ID)
+          : null;
       // Worst case: every (position, openProposal) pair needs one task id.
       const maxTaskIds = positions.length * proxyVoteAccounts.length;
       const nextAvailable =
-        maxTaskIds > 0
+        taskQueueAcc && maxTaskIds > 0
           ? nextAvailableTaskIds(taskQueueAcc.taskBitmap, maxTaskIds)
           : [];
       const myVoteMarkerKeys = positions
@@ -342,7 +343,12 @@ export const useAssignProxies = () => {
 
               const endTs =
                 endTsByProposal[proxyMarker.account!.proposal.toBase58()];
-              if (endTs && nextAvailable.length > 0) {
+              if (endTs) {
+                if (nextAvailable.length === 0) {
+                  throw new Error(
+                    "No available tuktuk task IDs to queue relinquish"
+                  );
+                }
                 const freeTaskId = nextAvailable.pop()!;
                 subInstructions.push(
                   await hplCronsProgram.methods

--- a/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
+++ b/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
@@ -163,6 +163,15 @@ export const useAssignProxies = () => {
         const offset = offsetNode?.offsetFromStartTs?.offset ?? new BN(0);
         endTsByProposal[op.pubkey.toBase58()] = startTs.add(offset);
       }
+      const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
+        TASK_QUEUE_ID
+      );
+      // Worst case: every (position, openProposal) pair needs one task id.
+      const maxTaskIds = positions.length * proxyVoteAccounts.length;
+      const nextAvailable =
+        maxTaskIds > 0
+          ? nextAvailableTaskIds(taskQueueAcc.taskBitmap, maxTaskIds)
+          : [];
       const myVoteMarkerKeys = positions
         .map((position) =>
           openProposals.map((op) => voteMarkerKey(position.mint, op.pubkey)[0])

--- a/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
+++ b/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
@@ -6,10 +6,8 @@ import {
   truthy,
 } from "@helium/spl-utils";
 import {
-  positionKey,
   ProxyAssignment,
   proxyVoteMarkerKey,
-  voteMarkerKey,
 } from "@helium/voter-stake-registry-sdk";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import {
@@ -37,10 +35,11 @@ import {
   PROGRAM_ID as VSR_PROGRAM_ID,
 } from "@helium/voter-stake-registry-sdk";
 import { init as hplCronsInit, TASK_QUEUE_ID } from "@helium/hpl-crons-sdk";
-import { init as initStateController } from "@helium/state-controller-sdk";
 import {
+  customSignerKey,
   nextAvailableTaskIds,
   taskKey,
+  taskQueueAuthorityKey,
   init as tuktukInit,
 } from "@helium/tuktuk-sdk";
 
@@ -83,7 +82,6 @@ export const useAssignProxies = () => {
       );
       const vsrProgram = await initVsr(provider as any, vsrProgramId);
       const hplCronsProgram = await hplCronsInit(provider as any);
-      const stateControllerProgram = await initStateController(provider as any);
       const tuktukProgram = await tuktukInit(provider as any);
       const hntOrg = organizationKey("Helium")[0];
       const organization = await orgProgram.account.organizationV0.fetch(
@@ -104,89 +102,15 @@ export const useAssignProxies = () => {
       const proxyVoteKeys = openProposals.map(
         (prop) => proxyVoteMarkerKey(recipient, prop.pubkey)[0]
       );
-      const proxyVoteAccounts = (
-        await vsrProgram.account.proxyMarkerV0.fetchMultiple(proxyVoteKeys)
-      )
-        .map((account, index) => ({ account, pubkey: proxyVoteKeys[index] }))
-        .filter((v) => v.account);
-      const proposalsByPubkey = openProposals.reduce((acc, prop) => {
-        acc[prop.pubkey.toBase58()] = prop.account;
-        return acc;
-      }, {} as Record<string, any>);
-      const proposalConfigKeys = [
-        ...new Set(
-          openProposals
-            .map((prop) => prop.account?.proposalConfig)
-            .map((p) => p?.toBase58())
-            .filter(truthy)
-        ),
-      ];
-      const proposalConfigsByPubkey = (
-        await proposalProgram.account.proposalConfigV0.fetchMultiple(
-          proposalConfigKeys
-        )
-      ).reduce((acc, pc, index) => {
-        acc[proposalConfigKeys[index]] = pc;
-        return acc;
-      }, {} as Record<string, any>);
-      const stateControllerKeys = [
-        ...new Set(
-          Object.values(proposalConfigsByPubkey)
-            .map((pc: any) => pc?.stateController?.toBase58())
-            .filter(truthy)
-        ),
-      ];
-      const resolutionSettingsByStateController = (
-        await stateControllerProgram.account.resolutionSettingsV0.fetchMultiple(
-          stateControllerKeys
-        )
-      ).reduce((acc, rs, index) => {
-        if (rs) acc[stateControllerKeys[index]] = rs;
-        return acc;
-      }, {} as Record<string, any>);
-
-      const endTsByProposal: Record<string, BN> = {};
-      for (const op of openProposals) {
-        const config =
-          proposalConfigsByPubkey[op.account!.proposalConfig.toBase58()];
-        if (!config) continue;
-        const rs =
-          resolutionSettingsByStateController[
-            config.stateController.toBase58()
-          ];
-        if (!rs) continue;
-        const startTs = new BN((op.account as any).state.voting.startTs);
-        const offsetNode = rs.settings.nodes.find(
-          (node: { offsetFromStartTs?: { offset: BN } }) =>
-            typeof node.offsetFromStartTs !== "undefined"
-        );
-        const offset = offsetNode?.offsetFromStartTs?.offset ?? new BN(0);
-        endTsByProposal[op.pubkey.toBase58()] = startTs.add(offset);
-      }
-      const taskQueueAcc =
-        proxyVoteAccounts.length > 0
-          ? await tuktukProgram.account.taskQueueV0.fetch(TASK_QUEUE_ID)
-          : null;
-      // Worst case: every (position, openProposal) pair needs one task id.
-      const maxTaskIds = positions.length * proxyVoteAccounts.length;
-      const nextAvailable =
-        taskQueueAcc && maxTaskIds > 0
-          ? nextAvailableTaskIds(taskQueueAcc.taskBitmap, maxTaskIds)
-          : [];
-      const myVoteMarkerKeys = positions
-        .map((position) =>
-          openProposals.map((op) => voteMarkerKey(position.mint, op.pubkey)[0])
-        )
-        .flat();
-      const myVoteMarkerAccounts = (
-        await vsrProgram.account.voteMarkerV0.fetchMultiple(myVoteMarkerKeys)
-      )
-        .map((account, index) => ({ account, pubkey: myVoteMarkerKeys[index] }))
-        .filter((v) => v.account)
-        .reduce((acc, v) => {
-          acc[v.pubkey.toBase58()] = v.account;
-          return acc;
-        }, {} as Record<string, any>);
+      const proxyVoteAccounts =
+        await vsrProgram.account.proxyMarkerV0.fetchMultiple(proxyVoteKeys);
+      const activeProxyVotes = openProposals
+        .map((prop, index) => ({
+          proposalPubkey: prop.pubkey,
+          proxyMarkerPubkey: proxyVoteKeys[index],
+          marker: proxyVoteAccounts[index],
+        }))
+        .filter((v) => (v.marker?.choices?.length || 0) > 0);
 
       let resultingAssignments: ProxyAssignment[] = [];
       let undelegated: ProxyAssignment[] = [];
@@ -195,6 +119,10 @@ export const useAssignProxies = () => {
         throw new Error("Unable to voting delegate, Invalid params");
       } else {
         const instructions: TransactionInstruction[][] = [];
+        // The proxy's votes can only propagate to delegated positions, so we
+        // only kick the proxy-vote cron when at least one delegated position is
+        // in this assignment.
+        let hasDelegatedAssignment = false;
         for (const position of positions) {
           let currentProxyAssignment = position.proxy?.address;
           const proxyAssignment = position.proxy;
@@ -260,10 +188,7 @@ export const useAssignProxies = () => {
             subInstructions.push(...ixs);
           }
 
-          const {
-            instruction,
-            pubkeys: { nextProxyAssignment },
-          } = await nftProxyProgram.methods
+          const { instruction } = await nftProxyProgram.methods
             .assignProxyV0({
               expirationTime,
             })
@@ -305,69 +230,65 @@ export const useAssignProxies = () => {
           });
 
           subInstructions.push(instruction);
-          for (const proxyMarker of proxyVoteAccounts) {
-            const proposal =
-              proposalsByPubkey[proxyMarker.account!.proposal.toBase58()];
-            const proposalConfig =
-              proposalConfigsByPubkey[proposal.proposalConfig.toBase58()];
-            const voteMarkerK = voteMarkerKey(
-              position.mint,
-              proxyMarker.account!.proposal
-            )[0];
-            const voteMarker = myVoteMarkerAccounts[voteMarkerK.toBase58()];
-            if (
-              position.isDelegated &&
-              !voteMarker &&
-              (proxyMarker.account?.choices?.length || 0) > 0
-            ) {
-              subInstructions.push(
-                await vsrProgram.methods
-                  .countProxyVoteV0()
-                  .accountsPartial({
-                    payer: provider.wallet.publicKey,
-                    proxyMarker: proxyMarker.pubkey,
-                    marker: voteMarkerK,
-                    voter: proxyMarker.account!.voter,
-                    proxyAssignment: nextProxyAssignment,
-                    registrar: position.registrar,
-                    position: positionKey(position.mint)[0],
-                    proposal: proxyMarker.account!.proposal,
-                    proposalConfig: proposal.proposalConfig,
-                    stateController: proposalConfig.stateController,
-                    onVoteHook: proposalConfig.onVoteHook,
-                    proposalProgram: proposalProgramId,
-                    systemProgram: SystemProgram.programId,
-                  })
-                  .instruction()
-              );
-
-              const endTs =
-                endTsByProposal[proxyMarker.account!.proposal.toBase58()];
-              if (endTs) {
-                if (nextAvailable.length === 0) {
-                  throw new Error(
-                    "No available tuktuk task IDs to queue relinquish"
-                  );
-                }
-                const freeTaskId = nextAvailable.pop()!;
-                subInstructions.push(
-                  await hplCronsProgram.methods
-                    .queueRelinquishExpiredVoteMarkerV0({
-                      freeTaskId,
-                      triggerTs: endTs,
-                    })
-                    .accountsPartial({
-                      marker: voteMarkerK,
-                      position: positionKey(position.mint)[0],
-                      task: taskKey(TASK_QUEUE_ID, freeTaskId)[0],
-                      taskQueue: TASK_QUEUE_ID,
-                    })
-                    .instruction()
-                );
-              }
-            }
+          if (position.isDelegated) {
+            hasDelegatedAssignment = true;
           }
           instructions.push(subInstructions);
+        }
+
+        // If the proxy has already voted on an active proposal, that vote was
+        // cast before these positions were delegated to it, so the newly
+        // delegated positions aren't covered. Queueing a proxy-vote task lets
+        // the vote-service cron count the votes for them and schedule each
+        // marker's relinquish via the task-queue PDA (the only signer
+        // authorized to do so).
+        if (hasDelegatedAssignment && activeProxyVotes.length > 0) {
+          const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
+            TASK_QUEUE_ID
+          );
+          const nextAvailable = nextAvailableTaskIds(
+            taskQueueAcc.taskBitmap,
+            activeProxyVotes.length
+          );
+          const queueAuthority = PublicKey.findProgramAddressSync(
+            [Buffer.from("queue_authority")],
+            hplCronsProgram.programId
+          )[0];
+
+          const proxyVoteTaskInstructions: TransactionInstruction[] = [];
+          for (const vote of activeProxyVotes) {
+            if (nextAvailable.length === 0) {
+              throw new Error(
+                "No available tuktuk task IDs to queue proxy vote"
+              );
+            }
+            const freeTaskId = nextAvailable.pop()!;
+            proxyVoteTaskInstructions.push(
+              await hplCronsProgram.methods
+                // @ts-ignore queueProxyVoteV0 is missing from the published IDL types
+                .queueProxyVoteV0({ freeTaskId })
+                .accountsPartial({
+                  marker: vote.proxyMarkerPubkey,
+                  task: taskKey(TASK_QUEUE_ID, freeTaskId)[0],
+                  taskQueue: TASK_QUEUE_ID,
+                  payer: provider.wallet.publicKey,
+                  systemProgram: SystemProgram.programId,
+                  queueAuthority,
+                  tuktukProgram: tuktukProgram.programId,
+                  voter: recipient,
+                  pdaWallet: customSignerKey(TASK_QUEUE_ID, [
+                    Buffer.from("vote_payer"),
+                    recipient.toBuffer(),
+                  ])[0],
+                  taskQueueAuthority: taskQueueAuthorityKey(
+                    TASK_QUEUE_ID,
+                    queueAuthority
+                  )[0],
+                })
+                .instruction()
+            );
+          }
+          instructions.push(proxyVoteTaskInstructions);
         }
 
         if (onInstructions) {

--- a/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
+++ b/packages/voter-stake-registry-hooks/src/hooks/useAssignProxies.ts
@@ -339,6 +339,26 @@ export const useAssignProxies = () => {
                   })
                   .instruction()
               );
+
+              const endTs =
+                endTsByProposal[proxyMarker.account!.proposal.toBase58()];
+              if (endTs && nextAvailable.length > 0) {
+                const freeTaskId = nextAvailable.pop()!;
+                subInstructions.push(
+                  await hplCronsProgram.methods
+                    .queueRelinquishExpiredVoteMarkerV0({
+                      freeTaskId,
+                      triggerTs: endTs,
+                    })
+                    .accountsPartial({
+                      marker: voteMarkerK,
+                      position: positionKey(position.mint)[0],
+                      task: taskKey(TASK_QUEUE_ID, freeTaskId)[0],
+                      taskQueue: TASK_QUEUE_ID,
+                    })
+                    .instruction()
+                );
+              }
             }
           }
           instructions.push(subInstructions);


### PR DESCRIPTION
 When a wallet assigns a delegated position to a proxy that has already voted on an active proposal, the proxy's original sweep couldn't have included that position, so the assign flow propagates the vote onto it — but the resulting
  vote marker is never scheduled for relinquish, so it lingers after voting ends.

  This replaces that with a queueProxyVoteV0 task per active proposal the proxy voted on, queued only when a delegated position is in the assignment. queueProxyVoteV0 takes voter as a plain account (not a signer), so the assigning
  wallet can queue it. The vote-service cron then counts the votes for the newly delegated positions and requeues their relinquish via the task-queue PDA. Applied in both assign.ts and useAssignProxies.ts.

  Vote propagation becomes asynchronous — handled by the cron shortly after assignment, not inline in the assign tx.

  Tests: e2e coverage in governance.test.ts (with a createHeliumOrgVotingProposal helper that seizes the forked Helium org to create a discoverable voting proposal): a proxy casts a real proxiedVoteV1, a wallet position is delegated,
  and assignProxies is asserted to emit queueProxyVoteV0. Still needs a live surfpool run to validate.