### PR TITLE
Prevent duplicate Jito bundle submissions (-32602)

### DIFF
--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -19,6 +19,7 @@
     "background-service": "node scripts/start-background-service.js",
     "test:e2e": "NODE_OPTIONS='--max-old-space-size=8192' DOTENV_CONFIG_PATH=.env.test mocha -r dotenv/config -r @swc-node/register \"tests/e2e/**/*.test.ts\" --timeout 100000",
     "test:e2e:file": "NODE_OPTIONS='--max-old-space-size=8192' DOTENV_CONFIG_PATH=.env.test mocha -r dotenv/config -r @swc-node/register --timeout 100000",
+    "test:unit": "mocha -r @swc-node/register \"tests/unit/**/*.test.ts\"",
     "sequelize-cli": "sequelize-cli"
   },
   "dependencies": {

--- a/packages/blockchain-api/src/lib/background-jobs/transaction-resubmission.ts
+++ b/packages/blockchain-api/src/lib/background-jobs/transaction-resubmission.ts
@@ -2,24 +2,28 @@ import PendingTransaction from "../models/pending-transaction";
 import TransactionBatch from "../models/transaction-batch";
 import {
   getPendingTransactionsForResubmission,
+  reapStalePendingBatches,
   resubmitTransactionBatch,
 } from "../utils/transaction-resubmission";
 import { checkAndUpdateBatchStatus } from "../utils/transaction-status-checker";
 
 interface ResubmissionServiceConfig {
   intervalMs: number;
+  reaperIntervalMs: number;
   maxRetries: number;
   enabled: boolean;
 }
 
 class TransactionResubmissionService {
   private intervalId: NodeJS.Timeout | null = null;
+  private reaperIntervalId: NodeJS.Timeout | null = null;
   private isRunning = false;
   private config: ResubmissionServiceConfig;
 
   constructor(
     config: ResubmissionServiceConfig = {
       intervalMs: 2000, // 2 seconds
+      reaperIntervalMs: 30000, // 30 seconds
       maxRetries: 10,
       enabled: true,
     },
@@ -53,6 +57,14 @@ class TransactionResubmissionService {
         console.error("Error in transaction resubmission service:", error);
       }
     }, this.config.intervalMs);
+
+    this.reaperIntervalId = setInterval(async () => {
+      try {
+        await reapStalePendingBatches();
+      } catch (error) {
+        console.error("Error in stale batch reaper:", error);
+      }
+    }, this.config.reaperIntervalMs);
   }
 
   /**
@@ -62,6 +74,10 @@ class TransactionResubmissionService {
     if (this.intervalId) {
       clearInterval(this.intervalId);
       this.intervalId = null;
+    }
+    if (this.reaperIntervalId) {
+      clearInterval(this.reaperIntervalId);
+      this.reaperIntervalId = null;
     }
     this.isRunning = false;
     console.log("Transaction resubmission service stopped");

--- a/packages/blockchain-api/src/lib/utils/claim-rewards-tag.ts
+++ b/packages/blockchain-api/src/lib/utils/claim-rewards-tag.ts
@@ -1,0 +1,23 @@
+import { createHash } from "crypto";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * Deterministic per-batch dedup tag derived from the batch's hotspot set.
+ *
+ * Same hotspot set -> same tag (dedups true duplicate submits), while distinct
+ * hasMore batches get distinct tags (no false short-circuit / silent partial).
+ * The partial unique index on (tag, payer) WHERE status='pending' uses this to
+ * gate concurrent submits.
+ */
+export function batchTag(wallet: string, assets: PublicKey[]): string {
+  const hash = createHash("sha256")
+    .update(
+      assets
+        .map((a) => a.toBase58())
+        .sort()
+        .join(",")
+    )
+    .digest("hex")
+    .slice(0, 16);
+  return `claim_rewards:${wallet}:${hash}`;
+}

--- a/packages/blockchain-api/src/lib/utils/submission-helpers.ts
+++ b/packages/blockchain-api/src/lib/utils/submission-helpers.ts
@@ -1,0 +1,54 @@
+import type { SubmissionType } from "../models/transaction-batch";
+
+// Minimal structural shape of a Solana signature status so this module stays
+// free of heavy runtime imports and is trivially unit-testable.
+export interface MinimalSignatureStatus {
+  err: unknown;
+  confirmationStatus?: string | null;
+}
+
+/**
+ * Decide whether the real (non-tip) transactions of a Jito bundle have all
+ * landed on-chain, given their signature statuses in submission order. Used to
+ * treat a bundle rejection (e.g. -32602 "already processed transaction") as
+ * success when the transactions actually processed.
+ *
+ * `statuses` aligns 1:1 with `transactionMetadata` (both indexed by the bundle's
+ * transaction order). Tip transactions are ignored; the bundle counts as landed
+ * only if every real transaction is confirmed/finalized with no error.
+ */
+export function isBundleLanded(
+  statuses: Array<MinimalSignatureStatus | null>,
+  transactionMetadata?: Array<Record<string, unknown> | undefined>,
+): boolean {
+  const realStatuses = statuses.filter(
+    (_, i) => transactionMetadata?.[i]?.type !== "jito_tip",
+  );
+  const toCheck = realStatuses.length > 0 ? realStatuses : statuses;
+
+  if (toCheck.length === 0) return false;
+
+  return toCheck.every(
+    (status) =>
+      status != null &&
+      status.err == null &&
+      (status.confirmationStatus === "confirmed" ||
+        status.confirmationStatus === "finalized"),
+  );
+}
+
+/**
+ * Predict the submission type for a batch reservation that is recorded before
+ * the batch is actually submitted. Mirrors the branching in
+ * submitTransactionBatch so the reservation row matches the eventual result.
+ */
+export function predictSubmissionType(params: {
+  transactionCount: number;
+  useJitoBundle: boolean;
+  parallel: boolean;
+}): SubmissionType {
+  const { transactionCount, useJitoBundle, parallel } = params;
+  if (transactionCount === 1) return "single";
+  if (useJitoBundle) return "jito_bundle";
+  return parallel ? "parallel" : "sequential";
+}

--- a/packages/blockchain-api/src/lib/utils/transaction-resubmission.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-resubmission.ts
@@ -8,6 +8,13 @@ import PendingTransaction from "../models/pending-transaction";
 import TransactionBatch from "../models/transaction-batch";
 import { getChewingGlassExplorerUrl, getExplorerUrl } from "./explorer";
 import { submitTransactionBatch } from "./transaction-submission";
+import { checkAndUpdateBatchStatus } from "./transaction-status-checker";
+
+// A batch that has been pending this long has either landed/failed on-chain
+// (and will be resolved by the status check) or is a leaked reservation. Either
+// way it must leave "pending" so the (tag, payer) submission lock is released.
+// Comfortably longer than a blockhash lifetime (~60-90s).
+const STALE_PENDING_BATCH_MS = 2 * 60 * 1000;
 
 export interface ResubmissionResult {
   success: boolean;
@@ -222,7 +229,9 @@ export async function resubmitTransactionBatch(
             Buffer.from(pendingTx.serializedTransaction, "base64"),
           );
           explorerLinks.push(getExplorerUrl(transaction));
-          chewingGlassExplorerLinks.push(getChewingGlassExplorerUrl(transaction));
+          chewingGlassExplorerLinks.push(
+            getChewingGlassExplorerUrl(transaction),
+          );
         }
       }
     } catch {
@@ -245,7 +254,10 @@ export async function resubmitTransactionBatch(
         cluster: batch.cluster,
         tag: batch.tag,
         explorer_links: explorerLinks.length > 0 ? explorerLinks : undefined,
-        chewing_glass_explorer_links: chewingGlassExplorerLinks.length > 0 ? chewingGlassExplorerLinks : undefined,
+        chewing_glass_explorer_links:
+          chewingGlassExplorerLinks.length > 0
+            ? chewingGlassExplorerLinks
+            : undefined,
       },
       contexts: {
         transaction: {
@@ -304,4 +316,76 @@ export async function getPendingTransactionsForResubmission(): Promise<{
   }));
 
   return { batches };
+}
+
+/**
+ * Force a stale batch and its still-pending transactions to "expired" so the
+ * partial unique index on (tag, payer) where status='pending' no longer blocks
+ * new submissions for that tag.
+ */
+async function expirePendingBatch(batch: TransactionBatch): Promise<void> {
+  const dbTransaction = await sequelize.transaction();
+  try {
+    await PendingTransaction.update(
+      { status: "expired" },
+      {
+        where: { batchId: batch.id, status: "pending" },
+        transaction: dbTransaction,
+      },
+    );
+    batch.status = "expired";
+    await batch.save({ transaction: dbTransaction });
+    await dbTransaction.commit();
+  } catch (error) {
+    await dbTransaction.rollback();
+    throw error;
+  }
+}
+
+/**
+ * Reap batches stuck in "pending" past STALE_PENDING_BATCH_MS.
+ *
+ * The tag-based submission lock keys off pending batches, and Jito batches are
+ * never advanced by the resubmission loop (it excludes them) — they only resolve
+ * when a client polls their status. A batch can therefore leak as pending if a
+ * client stops polling, or if a submission crashes/rolls back after the batch
+ * row was reserved. With deterministic tags (e.g. claim_rewards:<wallet>) a leak
+ * would permanently block that tag, so this releases the lock.
+ *
+ * Includes Jito batches (unlike resubmission). Batches with real transactions get
+ * one last on-chain/bundle status check that can resolve them to confirmed/failed;
+ * anything still pending after that (including leaked reservations that never
+ * recorded transactions) is expired.
+ */
+export async function reapStalePendingBatches(): Promise<void> {
+  defineAssociations();
+
+  const cutoff = new Date(Date.now() - STALE_PENDING_BATCH_MS);
+  const staleBatches = await TransactionBatch.findAll({
+    where: {
+      status: "pending",
+      updatedAt: { [Op.lt]: cutoff },
+    },
+    include: [
+      {
+        model: PendingTransaction,
+        as: "transactions",
+        required: false,
+      },
+    ],
+  });
+
+  for (const batch of staleBatches) {
+    try {
+      if ((batch.transactions ?? []).length > 0) {
+        const result = await checkAndUpdateBatchStatus(batch, "confirmed");
+        if (result.batchStatus !== "pending") {
+          continue;
+        }
+      }
+      await expirePendingBatch(batch);
+    } catch (error) {
+      console.error(`Error reaping stale batch ${batch.id}:`, error);
+    }
+  }
 }

--- a/packages/blockchain-api/src/lib/utils/transaction-submission.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-submission.ts
@@ -11,6 +11,7 @@ import {
   JitoBundleContext,
   jitoBlockEngineRequest,
 } from "./jito";
+import { isBundleLanded } from "./submission-helpers";
 
 export class SingleTransactionSubmissionError extends Error {
   public readonly explorerLink: string | null;
@@ -88,10 +89,16 @@ async function requireBundleHasTipAccount(
       Buffer.from(serialized, "base64"),
     );
     const keys = tx.message.staticAccountKeys;
-    const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = tx.message.header;
-    const writableSignedCount = numRequiredSignatures - numReadonlySignedAccounts;
+    const {
+      numRequiredSignatures,
+      numReadonlySignedAccounts,
+      numReadonlyUnsignedAccounts,
+    } = tx.message.header;
+    const writableSignedCount =
+      numRequiredSignatures - numReadonlySignedAccounts;
     const unsignedStart = numRequiredSignatures;
-    const writableUnsignedCount = keys.length - numRequiredSignatures - numReadonlyUnsignedAccounts;
+    const writableUnsignedCount =
+      keys.length - numRequiredSignatures - numReadonlyUnsignedAccounts;
 
     for (let i = 0; i < writableSignedCount; i++) {
       if (cachedTipAccountSet.has(keys[i].toBase58())) return;
@@ -117,11 +124,32 @@ async function requireBundleHasTipAccount(
 
 function isBlockhashNotFoundError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return message.includes("Blockhash not found") || message.includes("blockhash not found");
+  return (
+    message.includes("Blockhash not found") ||
+    message.includes("blockhash not found")
+  );
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Check whether the real (non-tip) transactions of a Jito bundle are already
+ * confirmed on-chain. Lets us treat a bundle rejection (e.g. -32602 "already
+ * processed transaction") as success when the transactions actually landed,
+ * without coupling to Jito's error text.
+ */
+async function bundleTransactionsLanded(
+  connection: Connection,
+  signatures: string[],
+  transactionMetadata?: Array<Record<string, unknown> | undefined>,
+): Promise<boolean> {
+  const { value } = await connection.getSignatureStatuses(signatures, {
+    searchTransactionHistory: true,
+  });
+
+  return isBundleLanded(value, transactionMetadata);
 }
 
 export interface TransactionBatchPayload {
@@ -229,18 +257,40 @@ export async function submitTransactionBatch(
       await requireBundleHasTipAccount(payload.transactions, payload.tag);
       await simulateJitoBundle(payload.transactions, bundleContext);
 
-      const jitoBundleId = await submitJitoBundle(payload.transactions, bundleContext);
-      return {
-        batchId,
-        submissionType: "jito_bundle",
-        jitoBundleId,
-        signatures: payload.transactions.map((tx) =>
-          bs58.encode(
-            VersionedTransaction.deserialize(Buffer.from(tx, "base64"))
-              .signatures[0],
-          ),
+      const signatures = payload.transactions.map((tx) =>
+        bs58.encode(
+          VersionedTransaction.deserialize(Buffer.from(tx, "base64"))
+            .signatures[0],
         ),
-      };
+      );
+
+      try {
+        const jitoBundleId = await submitJitoBundle(
+          payload.transactions,
+          bundleContext,
+        );
+        return {
+          batchId,
+          submissionType: "jito_bundle",
+          jitoBundleId,
+          signatures,
+        };
+      } catch (error) {
+        // Jito rejects a bundle (e.g. -32602 "already processed transaction")
+        // when a transaction in it has already landed. Trust the ledger, not the
+        // error text: if the real (non-tip) transactions are confirmed on-chain,
+        // the work succeeded and the rejection is moot.
+        if (
+          await bundleTransactionsLanded(
+            connection,
+            signatures,
+            payload.transactionMetadata,
+          )
+        ) {
+          return { batchId, submissionType: "jito_bundle", signatures };
+        }
+        throw error;
+      }
     } else {
       // Devnet/Localnet: use parallel or sequential based on payload.parallel
       if (payload.parallel) {

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimRewards.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimRewards.ts
@@ -51,6 +51,7 @@ import {
   getMintForNetwork,
   getLazyDistributorForNetwork,
 } from "@/lib/utils/network-mint";
+import { batchTag } from "@/lib/utils/claim-rewards-tag";
 
 // Minimum lamports the on-chain program requires in the PDA wallet before
 // queuing a wallet claim task. Matches CLAIMER_MIN_LAMPORTS in
@@ -209,7 +210,7 @@ export const claimRewards = publicProcedure.hotspots.claimRewards.handler(
           transactionData: {
             transactions: [],
             parallel: false,
-            tag: `claim_rewards:${walletAddress}`,
+            tag: `claim_rewards:${walletAddress}:empty`,
             actionMetadata: {
               type: "claim_rewards",
               hotspotCount: 0,
@@ -300,7 +301,7 @@ export const claimRewards = publicProcedure.hotspots.claimRewards.handler(
           // Sequential: init and distribute ixs for the same recipient may land
           // in different packed txs; parallel submission races them.
           parallel: false,
-          tag: `claim_rewards:${walletAddress}`,
+          tag: batchTag(walletAddress, assets),
           actionMetadata: {
             type: "claim_rewards",
             hotspotCount: allClaimable.length,

--- a/packages/blockchain-api/src/server/api/routers/transactions/procedures/submit.ts
+++ b/packages/blockchain-api/src/server/api/routers/transactions/procedures/submit.ts
@@ -2,12 +2,18 @@ import { sequelize } from "@/lib/db";
 import { env } from "@/lib/env";
 import PendingTransaction from "@/lib/models/pending-transaction";
 import TransactionBatch from "@/lib/models/transaction-batch";
-import { getChewingGlassExplorerUrl, getExplorerUrl } from "@/lib/utils/explorer";
+import {
+  getChewingGlassExplorerUrl,
+  getExplorerUrl,
+} from "@/lib/utils/explorer";
 import { getCluster } from "@/lib/solana";
 import {
   BundleSimulationError,
   JitoBundleSubmissionError,
+  shouldUseJitoBundle,
 } from "@/lib/utils/jito";
+import { predictSubmissionType } from "@/lib/utils/submission-helpers";
+import { v4 as uuidv4 } from "uuid";
 import {
   JitoMissingTipError,
   SingleTransactionSubmissionError,
@@ -325,27 +331,61 @@ export const submit = publicProcedure.transactions.submit.handler(
       }
     }
 
-    // Check for existing pending transaction with same tag+payer
-    if (tag) {
-      const existingBatch = await TransactionBatch.findOne({
-        where: {
-          tag,
-          payer,
-          status: "pending",
-        },
-      });
-
-      if (existingBatch) {
-        return {
-          batchId: existingBatch.id,
-          message: `Transaction with tag "${tag}" already exists and is pending`,
-        };
-      }
-    }
-
+    const cluster = getCluster();
     const serializedTransactions = transactions.map(
       (tx) => tx.serializedTransaction,
     );
+    // Derive actionType from first transaction metadata or actionMetadata
+    const actionType =
+      (actionMetadata?.type as string) ||
+      transactions[0]?.metadata?.type ||
+      undefined;
+
+    const batchId = uuidv4();
+
+    // Reserve the (tag, payer) slot BEFORE submitting so we never have more
+    // than one bundle in flight per tag. The partial unique index on
+    // (tag, payer) where status='pending' makes this atomic across concurrent
+    // or duplicate requests — the loser short-circuits to the in-flight batch
+    // instead of submitting a second, identical bundle (which Jito rejects with
+    // -32602 "already processed transaction").
+    if (tag) {
+      const predictedSubmissionType = predictSubmissionType({
+        transactionCount: transactions.length,
+        useJitoBundle: shouldUseJitoBundle(transactions.length, cluster),
+        parallel,
+      });
+
+      try {
+        await TransactionBatch.create({
+          id: batchId,
+          parallel,
+          status: "pending",
+          submissionType: predictedSubmissionType,
+          cluster,
+          tag,
+          payer,
+          actionType,
+          actionMetadata,
+        });
+      } catch (error) {
+        if (
+          (error as { name?: string })?.name ===
+          "SequelizeUniqueConstraintError"
+        ) {
+          const existingBatch = await TransactionBatch.findOne({
+            where: { tag, payer, status: "pending" },
+          });
+          if (existingBatch) {
+            return {
+              batchId: existingBatch.id,
+              message: `Transaction with tag "${tag}" already exists and is pending`,
+            };
+          }
+        }
+        throw error;
+      }
+    }
 
     let result;
     try {
@@ -357,6 +397,14 @@ export const submit = publicProcedure.transactions.submit.handler(
         transactionMetadata: transactions.map((tx) => tx.metadata),
       });
     } catch (error) {
+      // Release the reservation so a failed submission doesn't leave the tag
+      // locked as pending forever.
+      if (tag) {
+        await TransactionBatch.destroy({ where: { id: batchId } }).catch(
+          () => {},
+        );
+      }
+
       captureSubmissionError(error, {
         batchSize: serializedTransactions.length,
         parallel,
@@ -391,7 +439,6 @@ export const submit = publicProcedure.transactions.submit.handler(
       });
     }
 
-    const cluster = getCluster();
     const connection = new Connection(env.SOLANA_RPC_URL);
     const { lastValidBlockHeight } = await connection.getLatestBlockhash({
       commitment: "finalized",
@@ -401,28 +448,33 @@ export const submit = publicProcedure.transactions.submit.handler(
     const dbTransaction = await sequelize.transaction();
 
     try {
-      // Create the batch record
-      // Derive actionType from first transaction metadata or actionMetadata
-      const actionType =
-        (actionMetadata?.type as string) ||
-        transactions[0]?.metadata?.type ||
-        undefined;
-
-      await TransactionBatch.create(
-        {
-          id: result.batchId,
-          parallel,
-          status: "pending",
-          submissionType: result.submissionType,
-          jitoBundleId: result.jitoBundleId,
-          cluster,
-          tag,
-          payer,
-          actionType,
-          actionMetadata,
-        },
-        { transaction: dbTransaction },
-      );
+      if (tag) {
+        // Finalize the reservation created above with the real submission
+        // details now that the bundle/transactions have been submitted.
+        await TransactionBatch.update(
+          {
+            submissionType: result.submissionType,
+            jitoBundleId: result.jitoBundleId,
+          },
+          { where: { id: batchId }, transaction: dbTransaction },
+        );
+      } else {
+        await TransactionBatch.create(
+          {
+            id: batchId,
+            parallel,
+            status: "pending",
+            submissionType: result.submissionType,
+            jitoBundleId: result.jitoBundleId,
+            cluster,
+            tag,
+            payer,
+            actionType,
+            actionMetadata,
+          },
+          { transaction: dbTransaction },
+        );
+      }
 
       // Create individual transaction records
       const pendingTransactionPromises = transactions.map(async (txData, i) => {
@@ -435,12 +487,12 @@ export const submit = publicProcedure.transactions.submit.handler(
 
         return PendingTransaction.create(
           {
-            signature: signature || `${result.batchId}-${i}`,
+            signature: signature || `${batchId}-${i}`,
             blockhash: transaction.message.recentBlockhash,
             lastValidBlockHeight,
             status: "pending",
             type: txData.metadata?.type || "batch",
-            batchId: result.batchId,
+            batchId,
             payer,
             metadata: txData.metadata,
             serializedTransaction: txData.serializedTransaction,
@@ -456,20 +508,9 @@ export const submit = publicProcedure.transactions.submit.handler(
     } catch (error: unknown) {
       // Rollback the transaction on any error
       await dbTransaction.rollback();
-
-      // Handle unique constraint violation for tag+payer when status is pending
-      if (
-        (error as { name?: string })?.name ===
-          "SequelizeUniqueConstraintError" &&
-        tag
-      ) {
-        throw errors.CONFLICT({
-          message: `A pending transaction with tag "${tag}" already exists for this payer`,
-        });
-      }
       throw error;
     }
 
-    return { batchId: result.batchId };
+    return { batchId };
   },
 );

--- a/packages/blockchain-api/tests/e2e/rewards.test.ts
+++ b/packages/blockchain-api/tests/e2e/rewards.test.ts
@@ -26,6 +26,7 @@ import { signAndSubmitTransactionData } from "./helpers/tx";
 import { runAllTasks } from "./helpers/tuktuk";
 import { sleep } from "@helium/spl-utils";
 import { createORPCClient } from "@orpc/client";
+import { batchTag } from "@/lib/utils/claim-rewards-tag";
 import { RPCLink } from "@orpc/client/fetch";
 import type { appRouter } from "@/server/api";
 import type { RouterClient } from "@orpc/server";
@@ -246,5 +247,35 @@ describe("rewards endpoints", () => {
     const afterTotal = BigInt(afterAcc.totalRewards.toString());
     const delta = afterTotal - beforeTotal;
     expect(delta).to.equal(BigInt(502501516));
+  });
+});
+
+describe("batchTag", () => {
+  const wallet = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
+  const a = new PublicKey("11111111111111111111111111111111");
+  const b = new PublicKey("So11111111111111111111111111111111111111112");
+  const c = new PublicKey("SysvarC1ock11111111111111111111111111111111");
+
+  it("is order-independent for the same hotspot set", () => {
+    expect(batchTag(wallet, [a, b, c])).to.equal(batchTag(wallet, [c, a, b]));
+  });
+
+  it("is stable across calls", () => {
+    expect(batchTag(wallet, [a, b])).to.equal(batchTag(wallet, [a, b]));
+  });
+
+  it("produces distinct tags for distinct hotspot sets", () => {
+    expect(batchTag(wallet, [a, b])).to.not.equal(batchTag(wallet, [a, c]));
+  });
+
+  it("namespaces by wallet", () => {
+    const otherWallet = "FtPNpkqU7n8X9rTBrL7DkN1Pi9wQ9Pr1Y9HoYxXyo7Mc";
+    expect(batchTag(wallet, [a])).to.not.equal(batchTag(otherWallet, [a]));
+  });
+
+  it("includes the claim_rewards prefix and wallet", () => {
+    expect(batchTag(wallet, [a])).to.match(
+      new RegExp(`^claim_rewards:${wallet}:[0-9a-f]{16}$`),
+    );
   });
 });

--- a/packages/blockchain-api/tests/unit/submission-helpers.test.ts
+++ b/packages/blockchain-api/tests/unit/submission-helpers.test.ts
@@ -1,0 +1,123 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import {
+  isBundleLanded,
+  predictSubmissionType,
+  type MinimalSignatureStatus,
+} from "../../src/lib/utils/submission-helpers";
+
+const confirmed: MinimalSignatureStatus = {
+  err: null,
+  confirmationStatus: "confirmed",
+};
+const finalized: MinimalSignatureStatus = {
+  err: null,
+  confirmationStatus: "finalized",
+};
+const processed: MinimalSignatureStatus = {
+  err: null,
+  confirmationStatus: "processed",
+};
+const failed: MinimalSignatureStatus = {
+  err: { InstructionError: [0, "Custom"] },
+  confirmationStatus: "confirmed",
+};
+
+const tipMeta = { type: "jito_tip" };
+const claimMeta = { type: "claim_rewards" };
+
+describe("isBundleLanded", () => {
+  it("returns true when all real transactions are confirmed", () => {
+    expect(
+      isBundleLanded([confirmed, confirmed], [claimMeta, claimMeta]),
+    ).to.equal(true);
+  });
+
+  it("treats finalized as landed", () => {
+    expect(isBundleLanded([finalized], [claimMeta])).to.equal(true);
+  });
+
+  it("ignores the tip transaction's status", () => {
+    // Real txs landed; tip not found (null) — still landed.
+    expect(
+      isBundleLanded(
+        [confirmed, confirmed, null],
+        [claimMeta, claimMeta, tipMeta],
+      ),
+    ).to.equal(true);
+  });
+
+  it("returns false when a real transaction is not found (null)", () => {
+    expect(isBundleLanded([confirmed, null], [claimMeta, claimMeta])).to.equal(
+      false,
+    );
+  });
+
+  it("returns false when a real transaction has an error", () => {
+    expect(
+      isBundleLanded([confirmed, failed], [claimMeta, claimMeta]),
+    ).to.equal(false);
+  });
+
+  it("returns false when only processed (not yet confirmed)", () => {
+    expect(isBundleLanded([processed], [claimMeta])).to.equal(false);
+  });
+
+  it("does not let a landed tip mask an unlanded real transaction", () => {
+    // Tip finalized, real tx missing — must be false.
+    expect(isBundleLanded([null, finalized], [claimMeta, tipMeta])).to.equal(
+      false,
+    );
+  });
+
+  it("checks all transactions when metadata is absent", () => {
+    expect(isBundleLanded([confirmed, confirmed])).to.equal(true);
+    expect(isBundleLanded([confirmed, null])).to.equal(false);
+  });
+
+  it("returns false for an empty status list", () => {
+    expect(isBundleLanded([])).to.equal(false);
+  });
+});
+
+describe("predictSubmissionType", () => {
+  it("returns 'single' for a single transaction regardless of other flags", () => {
+    expect(
+      predictSubmissionType({
+        transactionCount: 1,
+        useJitoBundle: true,
+        parallel: true,
+      }),
+    ).to.equal("single");
+  });
+
+  it("returns 'jito_bundle' for multiple transactions when Jito is used", () => {
+    expect(
+      predictSubmissionType({
+        transactionCount: 3,
+        useJitoBundle: true,
+        parallel: false,
+      }),
+    ).to.equal("jito_bundle");
+  });
+
+  it("returns 'parallel' for multiple non-Jito parallel transactions", () => {
+    expect(
+      predictSubmissionType({
+        transactionCount: 2,
+        useJitoBundle: false,
+        parallel: true,
+      }),
+    ).to.equal("parallel");
+  });
+
+  it("returns 'sequential' for multiple non-Jito sequential transactions", () => {
+    expect(
+      predictSubmissionType({
+        transactionCount: 2,
+        useJitoBundle: false,
+        parallel: false,
+      }),
+    ).to.equal("sequential");
+  });
+});


### PR DESCRIPTION
  **Problem**

  Sentry shows Jito `-32602 "already processed transaction"` rejections. Concurrent/duplicate submits with the same tag (double-tap, retry, paginated `hasMore`) both passed the non-atomic `findOne` dedup and fired identical bundles at
  Jito — the loser was rejected wholesale.

  It's a **false positive**: the first bundle landed and the claim succeeded, but the error bubbles up and the UI shows "Something went wrong."

  **Fix**

  Reserve a per-claim DB slot before the bundle reaches Jito so duplicates converge instead of racing.

  - **Dedup tag** — `batchTag` = `claim_rewards:<wallet>:<content-hash>`, derived from the claim's hotspot set so paginated batches dedup correctly. A partial unique index on `(tag, payer) WHERE status='pending'` allows one in-flight
  submit per claim.
  - **Reserve-before-submit** — insert the pending batch row up front; the unique index serializes concurrent requests, so the loser returns the in-flight `batchId` instead of firing a second bundle. The reservation is released on
  submission failure.
  - **On-chain truth over error text** — on Jito bundle failure, verify the real (non-tip) signatures on-chain and treat the bundle as success if they landed, rather than parsing Jito's error string.
  - **Reaper** — a background job expires batches stuck `pending` past a threshold so a leaked reservation can't permanently lock a tag.

  **Refactor**

  Extracted `isBundleLanded` / `predictSubmissionType` into `submission-helpers.ts` as single sources of truth, with unit tests (`test:unit` script).