### PR TITLE
feat: cache swap getQuote/getTokens to avoid Jupiter 429s

### DIFF
--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -17,10 +17,9 @@
     "format:fix": "prettier --check --write \"src/**/*.{js,ts,tsx}\"",
     "lint": "pnpm run format:fix && eslint src/",
     "background-service": "node scripts/start-background-service.js",
-    "test:unit": "mocha -r @swc-node/register \"tests/unit/**/*.test.ts\" --timeout 10000",
     "test:e2e": "NODE_OPTIONS='--max-old-space-size=8192' DOTENV_CONFIG_PATH=.env.test mocha -r dotenv/config -r @swc-node/register \"tests/e2e/**/*.test.ts\" --timeout 100000",
     "test:e2e:file": "NODE_OPTIONS='--max-old-space-size=8192' DOTENV_CONFIG_PATH=.env.test mocha -r dotenv/config -r @swc-node/register --timeout 100000",
-    "test:unit": "mocha -r @swc-node/register \"tests/unit/**/*.test.ts\"",
+    "test:unit": "mocha -r @swc-node/register \"tests/unit/**/*.test.ts\" --timeout 10000",
     "sequelize-cli": "sequelize-cli"
   },
   "dependencies": {

--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -17,6 +17,7 @@
     "format:fix": "prettier --check --write \"src/**/*.{js,ts,tsx}\"",
     "lint": "pnpm run format:fix && eslint src/",
     "background-service": "node scripts/start-background-service.js",
+    "test:unit": "mocha -r @swc-node/register \"tests/unit/**/*.test.ts\" --timeout 10000",
     "test:e2e": "NODE_OPTIONS='--max-old-space-size=8192' DOTENV_CONFIG_PATH=.env.test mocha -r dotenv/config -r @swc-node/register \"tests/e2e/**/*.test.ts\" --timeout 100000",
     "test:e2e:file": "NODE_OPTIONS='--max-old-space-size=8192' DOTENV_CONFIG_PATH=.env.test mocha -r dotenv/config -r @swc-node/register --timeout 100000",
     "test:unit": "mocha -r @swc-node/register \"tests/unit/**/*.test.ts\"",

--- a/packages/blockchain-api/src/lib/utils/ttl-cache.ts
+++ b/packages/blockchain-api/src/lib/utils/ttl-cache.ts
@@ -16,6 +16,12 @@ export interface TtlCacheOptions {
  * Coalescing matters more than the TTL here: bursts of identical requests
  * (e.g. a client re-requesting a quote) share one upstream call instead of
  * each hitting a rate-limited API.
+ *
+ * Note: cached values are returned by reference, so every caller served from
+ * the cache (or coalesced onto one in-flight call) receives the same object.
+ * Callers must treat the result as read-only; mutating it corrupts the entry
+ * for everyone. Callers that need to mutate should copy first (e.g. getTokens
+ * slices the cached list before reordering).
  */
 export function createTtlCache<T>({
   ttlMs,
@@ -46,8 +52,19 @@ export function createTtlCache<T>({
 
     const promise = fetcher()
       .then((value) => {
+        // Refreshing an existing key: drop it first so it re-inserts as the
+        // newest entry and doesn't count against the capacity check below.
+        entries.delete(key);
         if (entries.size >= maxEntries) {
           prune(now());
+          // Pruning only reclaims expired entries. If everything is still
+          // fresh and we're at capacity, evict oldest-first (insertion order)
+          // so maxEntries stays a hard bound rather than a soft target.
+          while (entries.size >= maxEntries) {
+            const oldest = entries.keys().next().value;
+            if (oldest === undefined) break;
+            entries.delete(oldest);
+          }
         }
         entries.set(key, { value, expiresAt: now() + ttlMs });
         return value;

--- a/packages/blockchain-api/src/lib/utils/ttl-cache.ts
+++ b/packages/blockchain-api/src/lib/utils/ttl-cache.ts
@@ -1,0 +1,62 @@
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export interface TtlCacheOptions {
+  ttlMs: number;
+  maxEntries?: number;
+  now?: () => number;
+}
+
+/**
+ * Creates a keyed in-memory cache that serves fresh values within a TTL and
+ * coalesces concurrent requests for the same key into a single in-flight call.
+ *
+ * Coalescing matters more than the TTL here: bursts of identical requests
+ * (e.g. a client re-requesting a quote) share one upstream call instead of
+ * each hitting a rate-limited API.
+ */
+export function createTtlCache<T>({
+  ttlMs,
+  maxEntries = 1000,
+  now = Date.now,
+}: TtlCacheOptions) {
+  const entries = new Map<string, CacheEntry<T>>();
+  const inFlight = new Map<string, Promise<T>>();
+
+  function prune(current: number): void {
+    for (const [key, entry] of entries) {
+      if (entry.expiresAt <= current) {
+        entries.delete(key);
+      }
+    }
+  }
+
+  return function dedupe(key: string, fetcher: () => Promise<T>): Promise<T> {
+    const hit = entries.get(key);
+    if (hit && hit.expiresAt > now()) {
+      return Promise.resolve(hit.value);
+    }
+
+    const pending = inFlight.get(key);
+    if (pending) {
+      return pending;
+    }
+
+    const promise = fetcher()
+      .then((value) => {
+        if (entries.size >= maxEntries) {
+          prune(now());
+        }
+        entries.set(key, { value, expiresAt: now() + ttlMs });
+        return value;
+      })
+      .finally(() => {
+        inFlight.delete(key);
+      });
+
+    inFlight.set(key, promise);
+    return promise;
+  };
+}

--- a/packages/blockchain-api/src/server/api/routers/swap/procedures/getQuote.ts
+++ b/packages/blockchain-api/src/server/api/routers/swap/procedures/getQuote.ts
@@ -1,6 +1,13 @@
-import { QuoteResponseSchema } from "@helium/blockchain-api";
+import { QuoteResponse, QuoteResponseSchema } from "@helium/blockchain-api";
 import { publicProcedure } from "../../../procedures";
 import { env } from "@/lib/env";
+import { createTtlCache } from "@/lib/utils/ttl-cache";
+
+// Quotes are polled repeatedly and often re-requested with identical params.
+// A short TTL plus in-flight coalescing collapses those bursts into a single
+// Jupiter call, which is what was tripping Jupiter's 429 rate limiting.
+const QUOTE_CACHE_TTL_MS = 2000;
+const quoteCache = createTtlCache<QuoteResponse>({ ttlMs: QUOTE_CACHE_TTL_MS });
 
 /**
  * Get a quote for swapping tokens from Jupiter.
@@ -9,53 +16,61 @@ export const getQuote = publicProcedure.swap.getQuote.handler(
   async ({ input, errors }) => {
     const { inputMint, outputMint, amount, swapMode, slippageBps } = input;
 
-    // Get quote from Jupiter
-    const quoteUrl = new URL(`${env.JUPITER_API_URL}/swap/v1/quote`);
-    quoteUrl.searchParams.set("inputMint", inputMint);
-    quoteUrl.searchParams.set("outputMint", outputMint);
-    quoteUrl.searchParams.set("amount", amount);
-    quoteUrl.searchParams.set("swapMode", swapMode);
-    quoteUrl.searchParams.set("slippageBps", slippageBps.toString());
+    const cacheKey = `${inputMint}:${outputMint}:${amount}:${swapMode}:${slippageBps}`;
 
-    const quoteResponse = await fetch(quoteUrl.toString(), {
-      headers: {
-        "x-api-key": env.JUPITER_API_KEY,
-      },
-    });
+    return quoteCache(cacheKey, async () => {
+      // Get quote from Jupiter
+      const quoteUrl = new URL(`${env.JUPITER_API_URL}/swap/v1/quote`);
+      quoteUrl.searchParams.set("inputMint", inputMint);
+      quoteUrl.searchParams.set("outputMint", outputMint);
+      quoteUrl.searchParams.set("amount", amount);
+      quoteUrl.searchParams.set("swapMode", swapMode);
+      quoteUrl.searchParams.set("slippageBps", slippageBps.toString());
 
-    if (!quoteResponse.ok) {
-      const errorText = await quoteResponse.text();
-      console.error("Jupiter API error:", errorText);
+      const quoteResponse = await fetch(quoteUrl.toString(), {
+        headers: {
+          "x-api-key": env.JUPITER_API_KEY,
+        },
+      });
 
-      // TOKEN_NOT_TRADABLE is a client issue (e.g. wallet requesting a non-tradable token),
-      // not a server error — return 400 so it doesn't get sent to Sentry.
-      if (errorText.includes("TOKEN_NOT_TRADABLE")) {
-        throw errors.BAD_REQUEST({
-          message: `Token is not tradable`,
+      if (!quoteResponse.ok) {
+        const errorText = await quoteResponse.text();
+        console.error("Jupiter API error:", errorText);
+
+        // TOKEN_NOT_TRADABLE is a client issue (e.g. wallet requesting a non-tradable token),
+        // not a server error — return 400 so it doesn't get sent to Sentry.
+        if (errorText.includes("TOKEN_NOT_TRADABLE")) {
+          throw errors.BAD_REQUEST({
+            message: `Token is not tradable`,
+          });
+        }
+
+        // Surface Jupiter rate limiting as a 429 so clients can back off instead
+        // of us spamming Sentry with JUPITER_ERROR 500s.
+        if (quoteResponse.status === 429) {
+          throw errors.RATE_LIMITED();
+        }
+
+        throw errors.JUPITER_ERROR({
+          message: `Failed to get quote from Jupiter: HTTP ${quoteResponse.status}: ${errorText.slice(0, 500)}`,
         });
       }
 
-      // Surface Jupiter rate limiting as a 429 so clients can back off instead
-      // of us spamming Sentry with JUPITER_ERROR 500s.
-      if (quoteResponse.status === 429) {
-        throw errors.RATE_LIMITED();
+      const raw = await quoteResponse.json();
+
+      // Validate the response from Jupiter
+      const {
+        data: quote,
+        success,
+        error,
+      } = QuoteResponseSchema.safeParse(raw);
+      if (!success) {
+        console.error("Invalid Jupiter response:", error);
+        throw errors.JUPITER_ERROR({
+          message: "Invalid response from Jupiter API",
+        });
       }
-
-      throw errors.JUPITER_ERROR({
-        message: `Failed to get quote from Jupiter: HTTP ${quoteResponse.status}: ${errorText.slice(0, 500)}`,
-      });
-    }
-
-    const raw = await quoteResponse.json();
-
-    // Validate the response from Jupiter
-    const { data: quote, success, error } = QuoteResponseSchema.safeParse(raw);
-    if (!success) {
-      console.error("Invalid Jupiter response:", error);
-      throw errors.JUPITER_ERROR({
-        message: "Invalid response from Jupiter API",
-      });
-    }
-    return quote;
+      return quote;
+    });
   },
 );

--- a/packages/blockchain-api/src/server/api/routers/swap/procedures/getTokens.ts
+++ b/packages/blockchain-api/src/server/api/routers/swap/procedures/getTokens.ts
@@ -6,9 +6,13 @@ import { createTtlCache } from "@/lib/utils/ttl-cache";
 
 // The verified token list changes rarely and hits the same rate-limited Jupiter
 // API as quotes. A long TTL plus in-flight coalescing keeps these requests from
-// drawing down Jupiter's budget.
+// drawing down Jupiter's budget. The upstream fetch ignores `limit` (it always
+// pulls the full verified list), so the cache is keyed independent of `limit`
+// and we slice per request — that way requests with differing limits still
+// coalesce onto a single Jupiter call.
 const TOKENS_CACHE_TTL_MS = 2 * 60 * 1000;
-const tokensCache = createTtlCache<{ tokens: Token[] }>({
+const TOKENS_CACHE_KEY = "verified";
+const tokensCache = createTtlCache<Token[]>({
   ttlMs: TOKENS_CACHE_TTL_MS,
 });
 
@@ -19,7 +23,7 @@ export const getTokens = publicProcedure.swap.getTokens.handler(
   async ({ input, errors }) => {
     const { limit } = input;
 
-    return tokensCache(String(limit), async () => {
+    const allTokens = await tokensCache(TOKENS_CACHE_KEY, async () => {
       // Use Jupiter's Token API V2 endpoint for verified tokens
       const jupiterUrl = new URL(`${env.JUPITER_API_URL}/tokens/v2/tag`);
       jupiterUrl.searchParams.set("query", "verified");
@@ -48,46 +52,50 @@ export const getTokens = publicProcedure.swap.getTokens.handler(
         tags?: string[];
       }[] = await jupiterResponse.json();
 
-      // Transform the V2 response format to our expected format
-      const validatedTokens: Token[] = jupiterTokens
-        .slice(0, limit)
-        .map((token) => ({
-          address: token.id,
-          symbol: token.symbol,
-          name: token.name,
-          decimals: token.decimals,
-          logoURI: token.icon,
-          tags: token.tags || [],
-        }));
-
-      // Add HNT token at the top if it's not already in the list
-      const hntToken: Token = {
-        address: TOKEN_MINTS.HNT,
-        symbol: "HNT",
-        name: "Helium",
-        decimals: 8,
-        logoURI: "https://cryptologos.cc/logos/helium-hnt-logo.png",
-        tags: ["helium", "iot", "crypto"],
-      };
-
-      // Check if HNT is already in the list
-      const hasHNT = validatedTokens.some((token) => token.symbol === "HNT");
-
-      // Add HNT at the top if not present
-      if (!hasHNT) {
-        validatedTokens.unshift(hntToken);
-      } else {
-        // Move HNT to the top if it exists
-        const hntIndex = validatedTokens.findIndex(
-          (token) => token.symbol === "HNT",
-        );
-        if (hntIndex > 0) {
-          const hnt = validatedTokens.splice(hntIndex, 1)[0];
-          validatedTokens.unshift(hnt);
-        }
-      }
-
-      return { tokens: validatedTokens };
+      // Transform the V2 response format to our expected format. We cache the
+      // full list (no `limit` slice) so callers with any limit share one fetch;
+      // the per-request slice happens below.
+      return jupiterTokens.map((token) => ({
+        address: token.id,
+        symbol: token.symbol,
+        name: token.name,
+        decimals: token.decimals,
+        logoURI: token.icon,
+        tags: token.tags || [],
+      }));
     });
+
+    // slice() returns a fresh array, so the HNT reordering below never mutates
+    // the shared cached list (see the shared-reference note in ttl-cache.ts).
+    const validatedTokens = allTokens.slice(0, limit);
+
+    // Add HNT token at the top if it's not already in the list
+    const hntToken: Token = {
+      address: TOKEN_MINTS.HNT,
+      symbol: "HNT",
+      name: "Helium",
+      decimals: 8,
+      logoURI: "https://cryptologos.cc/logos/helium-hnt-logo.png",
+      tags: ["helium", "iot", "crypto"],
+    };
+
+    // Check if HNT is already in the list
+    const hasHNT = validatedTokens.some((token) => token.symbol === "HNT");
+
+    // Add HNT at the top if not present
+    if (!hasHNT) {
+      validatedTokens.unshift(hntToken);
+    } else {
+      // Move HNT to the top if it exists
+      const hntIndex = validatedTokens.findIndex(
+        (token) => token.symbol === "HNT",
+      );
+      if (hntIndex > 0) {
+        const hnt = validatedTokens.splice(hntIndex, 1)[0];
+        validatedTokens.unshift(hnt);
+      }
+    }
+
+    return { tokens: validatedTokens };
   },
 );

--- a/packages/blockchain-api/src/server/api/routers/swap/procedures/getTokens.ts
+++ b/packages/blockchain-api/src/server/api/routers/swap/procedures/getTokens.ts
@@ -2,6 +2,15 @@ import { publicProcedure } from "../../../procedures";
 import type { Token } from "@helium/blockchain-api";
 import { env } from "@/lib/env";
 import { TOKEN_MINTS } from "@/lib/constants/tokens";
+import { createTtlCache } from "@/lib/utils/ttl-cache";
+
+// The verified token list changes rarely and hits the same rate-limited Jupiter
+// API as quotes. A long TTL plus in-flight coalescing keeps these requests from
+// drawing down Jupiter's budget.
+const TOKENS_CACHE_TTL_MS = 2 * 60 * 1000;
+const tokensCache = createTtlCache<{ tokens: Token[] }>({
+  ttlMs: TOKENS_CACHE_TTL_MS,
+});
 
 /**
  * Get list of verified tokens available for swapping from Jupiter.
@@ -10,73 +19,75 @@ export const getTokens = publicProcedure.swap.getTokens.handler(
   async ({ input, errors }) => {
     const { limit } = input;
 
-    // Use Jupiter's Token API V2 endpoint for verified tokens
-    const jupiterUrl = new URL(`${env.JUPITER_API_URL}/tokens/v2/tag`);
-    jupiterUrl.searchParams.set("query", "verified");
+    return tokensCache(String(limit), async () => {
+      // Use Jupiter's Token API V2 endpoint for verified tokens
+      const jupiterUrl = new URL(`${env.JUPITER_API_URL}/tokens/v2/tag`);
+      jupiterUrl.searchParams.set("query", "verified");
 
-    const jupiterResponse = await fetch(jupiterUrl.toString(), {
-      headers: {
-        "User-Agent": "my-helium-api/1.0",
-        "x-api-key": env.JUPITER_API_KEY,
-      },
-    });
-
-    if (!jupiterResponse.ok) {
-      const errorText = await jupiterResponse.text();
-      console.error("Jupiter Token API error:", errorText);
-      throw errors.JUPITER_ERROR({
-        message: `Failed to fetch tokens from Jupiter: HTTP ${jupiterResponse.status}`,
+      const jupiterResponse = await fetch(jupiterUrl.toString(), {
+        headers: {
+          "User-Agent": "my-helium-api/1.0",
+          "x-api-key": env.JUPITER_API_KEY,
+        },
       });
-    }
 
-    const jupiterTokens: {
-      id: string;
-      symbol: string;
-      name: string;
-      decimals: number;
-      icon?: string;
-      tags?: string[];
-    }[] = await jupiterResponse.json();
-
-    // Transform the V2 response format to our expected format
-    const validatedTokens: Token[] = jupiterTokens
-      .slice(0, limit)
-      .map((token) => ({
-        address: token.id,
-        symbol: token.symbol,
-        name: token.name,
-        decimals: token.decimals,
-        logoURI: token.icon,
-        tags: token.tags || [],
-      }));
-
-    // Add HNT token at the top if it's not already in the list
-    const hntToken: Token = {
-      address: TOKEN_MINTS.HNT,
-      symbol: "HNT",
-      name: "Helium",
-      decimals: 8,
-      logoURI: "https://cryptologos.cc/logos/helium-hnt-logo.png",
-      tags: ["helium", "iot", "crypto"],
-    };
-
-    // Check if HNT is already in the list
-    const hasHNT = validatedTokens.some((token) => token.symbol === "HNT");
-
-    // Add HNT at the top if not present
-    if (!hasHNT) {
-      validatedTokens.unshift(hntToken);
-    } else {
-      // Move HNT to the top if it exists
-      const hntIndex = validatedTokens.findIndex(
-        (token) => token.symbol === "HNT",
-      );
-      if (hntIndex > 0) {
-        const hnt = validatedTokens.splice(hntIndex, 1)[0];
-        validatedTokens.unshift(hnt);
+      if (!jupiterResponse.ok) {
+        const errorText = await jupiterResponse.text();
+        console.error("Jupiter Token API error:", errorText);
+        throw errors.JUPITER_ERROR({
+          message: `Failed to fetch tokens from Jupiter: HTTP ${jupiterResponse.status}`,
+        });
       }
-    }
 
-    return { tokens: validatedTokens };
+      const jupiterTokens: {
+        id: string;
+        symbol: string;
+        name: string;
+        decimals: number;
+        icon?: string;
+        tags?: string[];
+      }[] = await jupiterResponse.json();
+
+      // Transform the V2 response format to our expected format
+      const validatedTokens: Token[] = jupiterTokens
+        .slice(0, limit)
+        .map((token) => ({
+          address: token.id,
+          symbol: token.symbol,
+          name: token.name,
+          decimals: token.decimals,
+          logoURI: token.icon,
+          tags: token.tags || [],
+        }));
+
+      // Add HNT token at the top if it's not already in the list
+      const hntToken: Token = {
+        address: TOKEN_MINTS.HNT,
+        symbol: "HNT",
+        name: "Helium",
+        decimals: 8,
+        logoURI: "https://cryptologos.cc/logos/helium-hnt-logo.png",
+        tags: ["helium", "iot", "crypto"],
+      };
+
+      // Check if HNT is already in the list
+      const hasHNT = validatedTokens.some((token) => token.symbol === "HNT");
+
+      // Add HNT at the top if not present
+      if (!hasHNT) {
+        validatedTokens.unshift(hntToken);
+      } else {
+        // Move HNT to the top if it exists
+        const hntIndex = validatedTokens.findIndex(
+          (token) => token.symbol === "HNT",
+        );
+        if (hntIndex > 0) {
+          const hnt = validatedTokens.splice(hntIndex, 1)[0];
+          validatedTokens.unshift(hnt);
+        }
+      }
+
+      return { tokens: validatedTokens };
+    });
   },
 );

--- a/packages/blockchain-api/tests/unit/ttl-cache.test.ts
+++ b/packages/blockchain-api/tests/unit/ttl-cache.test.ts
@@ -1,0 +1,143 @@
+import { expect } from "chai";
+import { createTtlCache } from "../../src/lib/utils/ttl-cache";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createTtlCache", () => {
+  it("coalesces concurrent calls for the same key into one fetch", async () => {
+    const cache = createTtlCache<string>({ ttlMs: 1000 });
+    const gate = deferred<string>();
+    let fetchCalls = 0;
+    const fetcher = () => {
+      fetchCalls++;
+      return gate.promise;
+    };
+
+    const calls = [
+      cache("a", fetcher),
+      cache("a", fetcher),
+      cache("a", fetcher),
+    ];
+    gate.resolve("VALUE");
+    const results = await Promise.all(calls);
+
+    expect(fetchCalls).to.equal(1);
+    expect(results).to.deep.equal(["VALUE", "VALUE", "VALUE"]);
+  });
+
+  it("serves a cached value within TTL without calling the fetcher again", async () => {
+    let clock = 1000;
+    const cache = createTtlCache<string>({ ttlMs: 1000, now: () => clock });
+    let fetchCalls = 0;
+    const fetcher = async () => {
+      fetchCalls++;
+      return "VALUE";
+    };
+
+    expect(await cache("a", fetcher)).to.equal("VALUE");
+    clock += 500;
+    expect(await cache("a", fetcher)).to.equal("VALUE");
+
+    expect(fetchCalls).to.equal(1);
+  });
+
+  it("refetches once the cached value has expired", async () => {
+    let clock = 1000;
+    const cache = createTtlCache<string>({ ttlMs: 1000, now: () => clock });
+    let fetchCalls = 0;
+    const fetcher = async () => {
+      fetchCalls++;
+      return `VALUE_${fetchCalls}`;
+    };
+
+    expect(await cache("a", fetcher)).to.equal("VALUE_1");
+    clock += 1001;
+    expect(await cache("a", fetcher)).to.equal("VALUE_2");
+
+    expect(fetchCalls).to.equal(2);
+  });
+
+  it("keys entries independently", async () => {
+    const cache = createTtlCache<string>({ ttlMs: 1000 });
+
+    expect(await cache("a", async () => "A")).to.equal("A");
+    expect(await cache("b", async () => "B")).to.equal("B");
+    // Cached, distinct values.
+    expect(await cache("a", async () => "OTHER")).to.equal("A");
+    expect(await cache("b", async () => "OTHER")).to.equal("B");
+  });
+
+  it("does not cache fetcher errors and retries on the next call", async () => {
+    const cache = createTtlCache<string>({ ttlMs: 1000 });
+    let fetchCalls = 0;
+    const fetcher = async () => {
+      fetchCalls++;
+      if (fetchCalls === 1) throw new Error("upstream 429");
+      return "VALUE";
+    };
+
+    let firstError: unknown;
+    try {
+      await cache("a", fetcher);
+    } catch (error) {
+      firstError = error;
+    }
+    expect(firstError).to.be.instanceOf(Error);
+
+    // In-flight entry must be cleared so the retry actually re-fetches.
+    expect(await cache("a", fetcher)).to.equal("VALUE");
+    expect(fetchCalls).to.equal(2);
+  });
+
+  it("propagates the same error to all coalesced callers without extra fetches", async () => {
+    const cache = createTtlCache<string>({ ttlMs: 1000 });
+    const gate = deferred<string>();
+    let fetchCalls = 0;
+    const fetcher = () => {
+      fetchCalls++;
+      return gate.promise;
+    };
+
+    const calls = [
+      cache("a", fetcher).catch((e) => e),
+      cache("a", fetcher).catch((e) => e),
+    ];
+    gate.reject(new Error("upstream 429"));
+    const results = await Promise.all(calls);
+
+    expect(fetchCalls).to.equal(1);
+    expect((results[0] as Error).message).to.equal("upstream 429");
+    expect((results[1] as Error).message).to.equal("upstream 429");
+  });
+
+  it("evicts expired entries when maxEntries is exceeded", async () => {
+    let clock = 1000;
+    const cache = createTtlCache<string>({
+      ttlMs: 100,
+      maxEntries: 2,
+      now: () => clock,
+    });
+
+    await cache("a", async () => "A");
+    await cache("b", async () => "B");
+    clock += 101; // a and b now expired
+    // Inserting c triggers a prune since size (2) >= maxEntries (2).
+    await cache("c", async () => "C");
+
+    // a expired and should have been pruned, forcing a refetch.
+    let refetched = false;
+    await cache("a", async () => {
+      refetched = true;
+      return "A2";
+    });
+    expect(refetched).to.equal(true);
+  });
+});

--- a/packages/blockchain-api/tests/unit/ttl-cache.test.ts
+++ b/packages/blockchain-api/tests/unit/ttl-cache.test.ts
@@ -140,4 +140,32 @@ describe("createTtlCache", () => {
     });
     expect(refetched).to.equal(true);
   });
+
+  it("stays bounded by evicting oldest-first when entries are all fresh", async () => {
+    let clock = 1000;
+    const cache = createTtlCache<string>({
+      ttlMs: 10_000, // long TTL: nothing expires during the test
+      maxEntries: 2,
+      now: () => clock,
+    });
+
+    await cache("a", async () => "A");
+    clock += 1;
+    await cache("b", async () => "B");
+    clock += 1;
+    // Inserting c is over capacity with nothing expired, so the oldest (a) is evicted.
+    await cache("c", async () => "C");
+
+    // b and c remain cached (these are hits and don't touch the write path).
+    expect(await cache("b", async () => "OTHER")).to.equal("B");
+    expect(await cache("c", async () => "OTHER")).to.equal("C");
+
+    // a was evicted and must refetch.
+    let aRefetched = false;
+    await cache("a", async () => {
+      aRefetched = true;
+      return "A2";
+    });
+    expect(aRefetched).to.equal(true);
+  });
 });

--- a/tests/dc-auto-topoff.ts
+++ b/tests/dc-auto-topoff.ts
@@ -56,6 +56,7 @@ import {
 import {
   createDcaServer,
   runAllTasks as runAllTasksUtil,
+  calculateExpectedOutput,
 } from "./utils/dca-test-server";
 import { Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { customSignerKey } from "@helium/tuktuk-sdk";
@@ -671,7 +672,19 @@ describe("dc-auto-topoff", () => {
         provider.connection,
         getAssociatedTokenAddressSync(hntMint, autoTopOff, true)
       );
-      const expectedAfterFirstSwap = startingHnt.add(hntPerSwap);
+      // The swap output is derived forward from dcaSwapAmount (the same way the
+      // DCA server computes it), not the idealized hntPerSwap target. Because
+      // dcaSwapAmount is rounded (truncate + `+1`) with a *100 decimal scaling,
+      // the roundtrip overshoots hntPerSwap by up to ~inputPrice/outputPrice*100
+      // bones, which varies with the live (cloned) oracle price ratio. Assert
+      // against the actual server output so the test is price-independent.
+      const expectedAfterFirstSwap = startingHnt.add(
+        calculateExpectedOutput(
+          dcaSwapAmount,
+          inputPriceUpdate,
+          outputPriceUpdate
+        )
+      );
       // Allow for 1 bone tolerance due to rounding in DCA calculations
       const actualAmount = new anchor.BN(
         hntAccountAfterFirstSwap.amount.toString()


### PR DESCRIPTION
Bursts of identical swap.getQuote requests (polling + duplicate fires) each hit Jupiter directly, tripping its 429 rate limiter. getTokens hits the same Jupiter API and shares that budget.

Add an in-memory TTL cache with in-flight request coalescing so identical concurrent requests share a single upstream call and repeat requests are served from cache:

- getQuote: 2s TTL (quotes are time-sensitive)
- getTokens: 2m TTL (verified token list changes rarely)

Coalescing is the primary lever — concurrent identical requests collapse to one Jupiter call regardless of TTL. Errors are not cached, so a 429 isn't sticky and retries work. The cache is per-replica; memory is bounded via maxEntries with lazy pruning of expired entries.

Add unit tests covering coalescing, TTL hit/expiry, error pass-through, and eviction.