### PR TITLE
fix(blockchain-api): batch governance vote validation to fix 504 for large proxy voters

### DIFF
--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -46,6 +46,7 @@ jobs:
     env:
       NODE_ENV: test
       NEXT_PORT: 3000
+      SOLANA_CLI_VERSION: 2.1.6
       SURFPOOL_RPC_URL: http://127.0.0.1:8899
       ASSET_ENDPOINT: ${{ secrets.ASSET_ENDPOINT }}
       NEXT_PUBLIC_SOLANA_CLUSTER: mainnet

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/validate-ownership.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/validate-ownership.ts
@@ -1,4 +1,4 @@
-import { Connection, PublicKey } from "@solana/web3.js";
+import { AccountInfo, Connection, PublicKey } from "@solana/web3.js";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 
 export interface OwnershipValidationResult {
@@ -39,6 +39,34 @@ export async function validatePositionOwnership(
     isOwner: tokenAccountInfo !== null,
     tokenAccount,
   };
+}
+
+/**
+ * Batched ownership check for many positions at once.
+ *
+ * Equivalent to calling {@link validatePositionOwnership} per mint, but issues
+ * one `getMultipleAccounts` per 100 ATAs instead of one `getAccountInfo` per
+ * position. For a wallet voting a large proxied set this turns N sequential
+ * round-trips into ceil(N/100) batched ones. Returns `isOwner` aligned by index
+ * with `positionMints`.
+ */
+export async function validatePositionOwnershipBatch(
+  connection: Connection,
+  positionMints: PublicKey[],
+  wallet: PublicKey,
+): Promise<boolean[]> {
+  const tokenAccounts = positionMints.map((mint) =>
+    getAssociatedTokenAddressSync(mint, wallet, true),
+  );
+
+  const CHUNK_SIZE = 100;
+  const infos: (AccountInfo<Buffer> | null)[] = [];
+  for (let i = 0; i < tokenAccounts.length; i += CHUNK_SIZE) {
+    const chunk = tokenAccounts.slice(i, i + CHUNK_SIZE);
+    infos.push(...(await connection.getMultipleAccountsInfo(chunk)));
+  }
+
+  return infos.map((info) => info !== null);
 }
 
 export async function requirePositionOwnership<T extends OwnershipErrorHandler>(

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/voting/relinquish-vote.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/voting/relinquish-vote.ts
@@ -28,7 +28,7 @@ import { PublicKey, SystemProgram } from "@solana/web3.js";
 import BN from "bn.js";
 import {
   TASK_QUEUE,
-  validatePositionOwnership,
+  validatePositionOwnershipBatch,
   buildBatchedTransactions,
 } from "../helpers";
 import type { InstructionGroup } from "../helpers";
@@ -69,10 +69,65 @@ export const relinquishVote = publicProcedure.governance.relinquishVote.handler(
       vsrProgram.account.voteMarkerV0.fetchMultiple(markerKeys),
     ]);
 
-    const registrarCache = new Map<
-      string,
-      Awaited<ReturnType<typeof vsrProgram.account.registrar.fetch>>
+    // Batched ownership + proxy-assignment resolution (see vote.ts): one
+    // getMultipleAccounts per 100 instead of ~2 sequential RPCs per position, so
+    // a large proxied relinquish doesn't exceed the gateway timeout.
+    const isOwnerByIndex = await validatePositionOwnershipBatch(
+      connection,
+      positionMintPubkeys,
+      walletPubkey,
+    );
+
+    const registrarKeySet = new Set<string>();
+    positionAccounts.forEach(
+      (acc: (typeof positionAccounts)[number], i: number) => {
+        if (acc && !isOwnerByIndex[i]) {
+          registrarKeySet.add(acc.registrar.toBase58());
+        }
+      },
+    );
+    const registrarKeysToFetch: string[] = Array.from(registrarKeySet);
+    const registrarAccounts = registrarKeysToFetch.length
+      ? await vsrProgram.account.registrar.fetchMultiple(
+          registrarKeysToFetch.map((k: string) => new PublicKey(k)),
+        )
+      : [];
+    const registrarByKey = new Map<string, (typeof registrarAccounts)[number]>(
+      registrarKeysToFetch.map(
+        (k: string, i: number) => [k, registrarAccounts[i]] as const,
+      ),
+    );
+
+    const proxyAssignmentIndexes: number[] = [];
+    const proxyAssignmentKeys: PublicKey[] = [];
+    for (let i = 0; i < positionMints.length; i++) {
+      const acc = positionAccounts[i];
+      if (acc && !isOwnerByIndex[i]) {
+        const registrar = registrarByKey.get(acc.registrar.toBase58());
+        if (registrar) {
+          proxyAssignmentIndexes.push(i);
+          proxyAssignmentKeys.push(
+            proxyAssignmentKey(
+              registrar.proxyConfig,
+              positionMintPubkeys[i],
+              walletPubkey,
+            )[0],
+          );
+        }
+      }
+    }
+    const proxyAssignmentAccounts = proxyAssignmentKeys.length
+      ? await proxyProgram.account.proxyAssignmentV0.fetchMultiple(
+          proxyAssignmentKeys,
+        )
+      : [];
+    const proxyAssignmentByIndex = new Map<
+      number,
+      (typeof proxyAssignmentAccounts)[number]
     >();
+    proxyAssignmentIndexes.forEach((idx, j) => {
+      proxyAssignmentByIndex.set(idx, proxyAssignmentAccounts[j]);
+    });
 
     const groups: InstructionGroup[] = [];
     let hasProxies = false;
@@ -86,31 +141,8 @@ export const relinquishVote = publicProcedure.governance.relinquishVote.handler(
         });
       }
 
-      const { isOwner } = await validatePositionOwnership(
-        connection,
-        positionMintPubkeys[i],
-        walletPubkey,
-      );
-
-      if (!isOwner) {
-        const registrarKey = positionAcc.registrar.toBase58();
-        let registrar = registrarCache.get(registrarKey);
-        if (!registrar) {
-          registrar = await vsrProgram.account.registrar.fetch(
-            positionAcc.registrar,
-          );
-          registrarCache.set(registrarKey, registrar);
-        }
-        const proxyAssignmentAddr = proxyAssignmentKey(
-          registrar.proxyConfig,
-          positionMintPubkeys[i],
-          walletPubkey,
-        )[0];
-        const proxyAssignment =
-          await proxyProgram.account.proxyAssignmentV0.fetchNullable(
-            proxyAssignmentAddr,
-          );
-
+      if (!isOwnerByIndex[i]) {
+        const proxyAssignment = proxyAssignmentByIndex.get(i);
         if (!proxyAssignment) {
           throw errors.BAD_REQUEST({
             message: `Wallet does not own or have proxy for position ${positionMints[i]}`,

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/voting/vote.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/voting/vote.ts
@@ -33,7 +33,7 @@ import {
 import BN from "bn.js";
 import {
   TASK_QUEUE,
-  validatePositionOwnership,
+  validatePositionOwnershipBatch,
   buildBatchedTransactions,
 } from "../helpers";
 import type { InstructionGroup } from "../helpers";
@@ -128,10 +128,69 @@ export const vote = publicProcedure.governance.vote.handler(
       vsrProgram.account.voteMarkerV0.fetchMultiple(markerKeys),
     ]);
 
-    const registrarCache = new Map<
-      string,
-      Awaited<ReturnType<typeof vsrProgram.account.registrar.fetch>>
+    // Ownership for every position in one batched call (ceil(N/100) round-trips
+    // instead of one getAccountInfo per position).
+    const isOwnerByIndex = await validatePositionOwnershipBatch(
+      connection,
+      positionMintPubkeys,
+      walletPubkey,
+    );
+
+    // For non-owned positions we must confirm a proxy assignment exists. Resolve
+    // each position's registrar (→ proxyConfig), then fetch all proxy assignments
+    // in one batched call instead of one fetchNullable per position. Without this,
+    // a large proxied voter triggers ~2 sequential RPCs per position and the
+    // request exceeds the gateway timeout.
+    const registrarKeySet = new Set<string>();
+    positionAccounts.forEach(
+      (acc: (typeof positionAccounts)[number], i: number) => {
+        if (acc && !isOwnerByIndex[i]) {
+          registrarKeySet.add(acc.registrar.toBase58());
+        }
+      },
+    );
+    const registrarKeysToFetch: string[] = Array.from(registrarKeySet);
+    const registrarAccounts = registrarKeysToFetch.length
+      ? await vsrProgram.account.registrar.fetchMultiple(
+          registrarKeysToFetch.map((k: string) => new PublicKey(k)),
+        )
+      : [];
+    const registrarByKey = new Map<string, (typeof registrarAccounts)[number]>(
+      registrarKeysToFetch.map(
+        (k: string, i: number) => [k, registrarAccounts[i]] as const,
+      ),
+    );
+
+    const proxyAssignmentIndexes: number[] = [];
+    const proxyAssignmentKeys: PublicKey[] = [];
+    for (let i = 0; i < positionMints.length; i++) {
+      const acc = positionAccounts[i];
+      if (acc && !isOwnerByIndex[i]) {
+        const registrar = registrarByKey.get(acc.registrar.toBase58());
+        if (registrar) {
+          proxyAssignmentIndexes.push(i);
+          proxyAssignmentKeys.push(
+            proxyAssignmentKey(
+              registrar.proxyConfig,
+              positionMintPubkeys[i],
+              walletPubkey,
+            )[0],
+          );
+        }
+      }
+    }
+    const proxyAssignmentAccounts = proxyAssignmentKeys.length
+      ? await proxyProgram.account.proxyAssignmentV0.fetchMultiple(
+          proxyAssignmentKeys,
+        )
+      : [];
+    const proxyAssignmentByIndex = new Map<
+      number,
+      (typeof proxyAssignmentAccounts)[number]
     >();
+    proxyAssignmentIndexes.forEach((idx, j) => {
+      proxyAssignmentByIndex.set(idx, proxyAssignmentAccounts[j]);
+    });
 
     for (let i = 0; i < positionMints.length; i++) {
       const positionMint = positionMints[i];
@@ -145,33 +204,11 @@ export const vote = publicProcedure.governance.vote.handler(
         });
       }
 
-      const { isOwner } = await validatePositionOwnership(
-        connection,
-        positionMintPubkey,
-        walletPubkey,
-      );
+      const isOwner = isOwnerByIndex[i];
 
       let isProxied = false;
       if (!isOwner) {
-        const registrarKey = positionAcc.registrar.toBase58();
-        let registrar = registrarCache.get(registrarKey);
-        if (!registrar) {
-          registrar = await vsrProgram.account.registrar.fetch(
-            positionAcc.registrar,
-          );
-          registrarCache.set(registrarKey, registrar);
-        }
-        const proxyConfig = registrar.proxyConfig;
-        const proxyAssignmentAddr = proxyAssignmentKey(
-          proxyConfig,
-          positionMintPubkey,
-          walletPubkey,
-        )[0];
-        const proxyAssignment =
-          await proxyProgram.account.proxyAssignmentV0.fetchNullable(
-            proxyAssignmentAddr,
-          );
-
+        const proxyAssignment = proxyAssignmentByIndex.get(i);
         if (!proxyAssignment) {
           throw errors.BAD_REQUEST({
             message: `Wallet does not own or have proxy for position ${positionMint}`,


### PR DESCRIPTION
## Problem

The governance `vote` and `relinquishVote` handlers can't build a transaction for wallets with many delegated positions — the request returns **504 Gateway Time-out** and the vote never goes through. The largest proxy voter (~1,094 delegated positions) hits this every time; small wallets are unaffected.

Reproduced directly against production (the build endpoint needs no signature):

| positionMints | result |
|---|---|
| 1 | HTTP 200 in **1.6s** |
| 1094 | HTTP **504** in **60.7s** (nginx gateway timeout) |

## Root cause

Both handlers validate each position mint with **two sequential RPC calls** inside a loop:
- `validatePositionOwnership` → `getAccountInfo` on the ATA, and
- `proxyAssignmentV0.fetchNullable` for non-owned positions.

That's ~2 round-trips per position, run sequentially. At 1,094 positions that's **~2,200 sequential RPCs** in one request handler, which blows past the gateway timeout. All of that work collapses into a single `proxiedVoteV1` instruction.

## Fix

Batch the lookups up front, then classify in memory:
- `validatePositionOwnershipBatch` — one `getMultipleAccounts` per 100 ATAs instead of one `getAccountInfo` per position.
- one `fetchMultiple` for the distinct registrars (→ `proxyConfig`).
- one `fetchMultiple` for the proxy assignments.

The instruction-building path (single `proxiedVoteV1` for the proxy + one `voteV0` per owned position, plus the queue tasks) is **unchanged**, so the produced transactions are identical. Same change applied to `vote.ts` and `relinquish-vote.ts`.

## Verification

Replayed against mainnet for the 1,094-position wallet:
- classification identical to the old path: **1,094 proxied, `hasProxies=true`, 0 missing, 0 owned**
- **~45 RPC calls** instead of ~2,200
- **~6s** instead of a 60s gateway timeout

The existing `tests/e2e/governance.test.ts` covers `vote`/`relinquishVote` for single/multi positions; this change preserves that behavior. There is no existing test at the large-proxy scale that triggers the timeout — a regression test that votes with a large proxied set would guard against this returning.