### PR TITLE
HIP 149: on-chain implementation (Decisions 1, 2, 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "modular-governance",
  "mpl-token-metadata",
  "no-emit",
+ "pyth-solana-receiver-sdk",
  "rust_decimal",
  "shared-utils",
  "solana-program",

--- a/packages/helium-admin-cli/src/create-council-fanout.ts
+++ b/packages/helium-admin-cli/src/create-council-fanout.ts
@@ -1,0 +1,175 @@
+import * as anchor from "@coral-xyz/anchor";
+import { TASK_QUEUE_ID } from "@helium/hpl-crons-sdk";
+import { init as initMfan } from "@helium/mini-fanout-sdk";
+import { HNT_MINT, sendInstructionsWithPriorityFee } from "@helium/spl-utils";
+import {
+  init as initTuktuk,
+  nextAvailableTaskIds,
+  taskKey,
+} from "@helium/tuktuk-sdk";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import {
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import os from "os";
+import yargs from "yargs/yargs";
+import { loadKeypair } from "./utils";
+
+// HIP 149 Decision 4: create the Advisory Council compensation fanout. The supplement mint in
+// helium-sub-daos splits off 1.25% to this fanout's HNT token account; the fanout's tuktuk
+// crank then distributes it pro-rata among the seated community members.
+//
+// After creating it, paste the printed "Council fanout token account" into
+// COUNCIL_FANOUT_TOKEN_ACCOUNT in programs/helium-sub-daos/src/supplement.rs (the same
+// patch-time edit that sets INFLATION_START), then set the cron's council_vault to it.
+//
+// Operational rules (see HIP 149 Decision 4):
+//   - `owner` MUST be the governance multisig, never the Receiving Entity. It is the only
+//     authority that can edit the seated-member set; the community seats/removes members by
+//     vote and the multisig executes the corresponding update.
+//   - On a seat change, CRANK before updating the member vec, so accrual maps to the set that
+//     was seated when it accrued (a vacant seat's share then redistributes to the seated
+//     members from that point forward, per the HIP).
+//   - Keep the fanout funded with lamports; it pays its own crank reward and silently
+//     unschedules itself if it runs dry.
+export async function run(args: any = process.argv) {
+  const yarg = yargs(args).options({
+    wallet: {
+      alias: "k",
+      describe: "Anchor wallet keypair",
+      default: `${os.homedir()}/.config/solana/id.json`,
+    },
+    url: {
+      alias: "u",
+      default: "http://127.0.0.1:8899",
+      describe: "The solana url",
+    },
+    owner: {
+      type: "string",
+      required: true,
+      describe:
+        "Fanout owner = governance multisig (Squads vault). Edits the seated-member set. NEVER the Receiving Entity.",
+    },
+    members: {
+      type: "string",
+      required: true,
+      describe:
+        "Comma-separated seated community-member wallet addresses (the receiving wallets), KYC-confirmed. Each gets an equal share.",
+    },
+    schedule: {
+      type: "string",
+      default: "0 0 0 * * *",
+      describe:
+        "Cron schedule (sec min hour day month dow) for the distribution crank. Default daily at 00:00 UTC; keep it short to bound accrual-timing on seat changes.",
+    },
+    seed: {
+      type: "string",
+      default: "hip149-council",
+      describe: "Fanout seed (part of the PDA). Stable per fanout.",
+    },
+    fundingLamports: {
+      type: "number",
+      default: 100_000_000,
+      describe:
+        "Lamports to seed the fanout with so it can pay its own crank reward.",
+    },
+  });
+  const argv = await yarg.argv;
+  process.env.ANCHOR_WALLET = argv.wallet;
+  process.env.ANCHOR_PROVIDER_URL = argv.url;
+  anchor.setProvider(anchor.AnchorProvider.local(argv.url));
+  const provider = anchor.getProvider() as anchor.AnchorProvider;
+  const wallet = new anchor.Wallet(loadKeypair(argv.wallet));
+
+  const program = await initMfan(provider);
+  const tuktukProgram = await initTuktuk(provider);
+
+  const owner = new PublicKey(argv.owner);
+  const members = argv.members
+    .split(",")
+    .map((m) => m.trim())
+    .filter(Boolean)
+    .map((m) => new PublicKey(m));
+  if (members.length === 0) {
+    throw new Error("at least one seated member wallet is required");
+  }
+
+  // Equal pro-rata weight per seated member; the fanout normalizes over whatever is in the
+  // vec, so dropping a member on removal redistributes their share to the rest.
+  const shares = members.map((wallet) => ({
+    wallet,
+    share: { share: { amount: 1 } },
+  }));
+
+  const instructions: TransactionInstruction[] = [];
+
+  const {
+    instruction: initIx,
+    pubkeys: { miniFanout },
+  } = await program.methods
+    .initializeMiniFanoutV0({
+      seed: Buffer.from(argv.seed, "utf-8"),
+      shares,
+      schedule: argv.schedule,
+      preTask: null,
+    })
+    .accounts({
+      payer: wallet.publicKey,
+      owner,
+      taskQueue: TASK_QUEUE_ID,
+      rentRefund: owner,
+      mint: HNT_MINT,
+    })
+    .prepare();
+  instructions.push(initIx);
+
+  // Fund the fanout so it can pay its own crank reward and stay scheduled.
+  instructions.push(
+    SystemProgram.transfer({
+      fromPubkey: wallet.publicKey,
+      toPubkey: miniFanout!,
+      lamports: argv.fundingLamports,
+    })
+  );
+
+  // Schedule the first distribution task; the fanout self-reschedules thereafter.
+  const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
+    TASK_QUEUE_ID
+  );
+  const [taskId, preTaskId] = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 2);
+  instructions.push(
+    await program.methods
+      .scheduleTaskV0({ taskId, preTaskId })
+      .accounts({
+        payer: wallet.publicKey,
+        miniFanout: miniFanout!,
+        task: taskKey(TASK_QUEUE_ID, taskId)[0],
+        preTask: taskKey(TASK_QUEUE_ID, preTaskId)[0],
+      })
+      .instruction()
+  );
+
+  await sendInstructionsWithPriorityFee(provider, instructions, {
+    computeUnitLimit: 500000,
+  });
+
+  const tokenAccount = getAssociatedTokenAddressSync(
+    HNT_MINT,
+    miniFanout!,
+    true
+  );
+
+  console.log("Council fanout created.");
+  console.log(`  owner (governance multisig): ${owner.toBase58()}`);
+  console.log(`  mini fanout:                 ${miniFanout!.toBase58()}`);
+  console.log(`  schedule:                    ${argv.schedule}`);
+  console.log(`  members (${members.length}):`);
+  members.forEach((m) => console.log(`    - ${m.toBase58()}`));
+  console.log("");
+  console.log(
+    "  >>> Council fanout token account (set COUNCIL_FANOUT_TOKEN_ACCOUNT):"
+  );
+  console.log(`      ${tokenAccount.toBase58()}`);
+}

--- a/packages/helium-admin-cli/src/end-epoch.ts
+++ b/packages/helium-admin-cli/src/end-epoch.ts
@@ -11,6 +11,7 @@ import {
   daoKey,
   init as initDao,
   subDaoEpochInfoKey,
+  subDaoKey,
 } from "@helium/helium-sub-daos-sdk";
 import {
   init as initLazy,
@@ -21,6 +22,7 @@ import { init as initBurn } from "@helium/no-emit-sdk";
 import { init as initRewards } from "@helium/rewards-oracle-sdk";
 import {
   HNT_MINT,
+  HNT_PYTH_PRICE_FEED,
   IOT_MINT,
   MOBILE_MINT,
   createMintInstructions,
@@ -97,6 +99,9 @@ export async function run(args: any = process.argv) {
       },
     ]);
 
+    // HIP 149 backstop: the Mobile sub-DAO whose epoch info every calculate pass reads.
+    const [mobileSubDao] = subDaoKey(MOBILE_MINT);
+
     let targetTs = argv.from
       ? new BN(argv.from)
       : subDaos.reduce(
@@ -137,7 +142,29 @@ export async function run(args: any = process.argv) {
                 [
                   await heliumSubDaosProgram.methods
                     .calculateUtilityScoreV0({ epoch })
-                    .accountsPartial({ subDao: subDao.publicKey })
+                    .accountsPartial({
+                      subDao: subDao.publicKey,
+                      // HIP 149 backstop: maintained on-chain HNT/USD Pyth push account.
+                      hntPriceOracle: HNT_PYTH_PRICE_FEED,
+                    })
+                    // The backstop reads the Mobile sub-DAO's current/previous epoch info
+                    // (dc_burned + smoothed percent share) regardless of which sub-DAO is
+                    // being scored, so total_rewards is identical on every pass.
+                    .remainingAccounts([
+                      {
+                        pubkey: subDaoEpochInfoKey(mobileSubDao, targetTs)[0],
+                        isSigner: false,
+                        isWritable: false,
+                      },
+                      {
+                        pubkey: subDaoEpochInfoKey(
+                          mobileSubDao,
+                          targetTs.sub(new BN(EPOCH_LENGTH))
+                        )[0],
+                        isSigner: false,
+                        isWritable: false,
+                      },
+                    ])
                     .instruction(),
                 ],
                 {
@@ -183,7 +210,11 @@ export async function run(args: any = process.argv) {
                 [
                   await heliumSubDaosProgram.methods
                     .issueRewardsV0({ epoch })
-                    .accountsPartial({ subDao: subDao.publicKey })
+                    .accountsPartial({
+                      subDao: subDao.publicKey,
+                      supplementVault: null,
+                      councilVault: null,
+                    })
                     .instruction(),
                 ],
                 {

--- a/packages/helium-admin-cli/src/start-cron.ts
+++ b/packages/helium-admin-cli/src/start-cron.ts
@@ -1,5 +1,8 @@
 import * as anchor from "@coral-xyz/anchor";
-import { sendInstructionsWithPriorityFee } from "@helium/spl-utils";
+import {
+  HNT_PYTH_PRICE_FEED,
+  sendInstructionsWithPriorityFee,
+} from "@helium/spl-utils";
 import {
   compileTransaction,
   customSignerKey,
@@ -108,6 +111,11 @@ export async function run(args: any = process.argv) {
           dao,
           iotSubDao,
           mobileSubDao,
+          // HIP 149 backstop: the maintained on-chain HNT/USD Pyth push account (the
+          // same feed the price oracle pulls from Hermes). The cron forwards it into
+          // each calculate_utility_score_v0; a stale/missing price degrades to a
+          // dormant backstop epoch on-chain, never a halt.
+          hntPriceOracle: HNT_PYTH_PRICE_FEED,
           systemProgram: SystemProgram.programId,
         })
         .instruction(),

--- a/packages/spl-utils/src/constants.ts
+++ b/packages/spl-utils/src/constants.ts
@@ -12,7 +12,8 @@ export const MOBILE_MINT = new PublicKey(
 
 export const IOT_MINT = new PublicKey("iotEVVZLEywoTn1QdwNPddxPWszn3zFhEot3MfL9fns");
 
-// TODO: Replace with actual HNT feed
+// Mainnet HNT/USD Pyth pull-oracle push account (shard 0 for HNT_PRICE_FEED_ID),
+// kept continuously fresh on-chain.
 export const HNT_PYTH_PRICE_FEED = new PublicKey(
   "4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33"
 );

--- a/programs/helium-sub-daos/Cargo.toml
+++ b/programs/helium-sub-daos/Cargo.toml
@@ -34,6 +34,7 @@ treasury-management = { path = "../treasury-management", features = ["cpi"] }
 modular-governance = { workspace = true }
 solana-program = { workspace = true }
 default-env = { workspace = true }
+pyth-solana-receiver-sdk = { workspace = true }
 
 time = "0.3.17"
 solana-security-txt = { workspace = true }

--- a/programs/helium-sub-daos/src/backstop.rs
+++ b/programs/helium-sub-daos/src/backstop.rs
@@ -30,6 +30,19 @@ use anchor_lang::prelude::*;
 /// The backstop keys off the Mobile sub-DAO's `dc_burned` and percent share.
 pub const MOBILE_SUB_DAO: Pubkey = pubkey!("Gm9xDCJawDEKDrrQW6haw94gABaYzQwCq4ZQU8h8bd22");
 
+/// The canonical mainnet HNT/USD Pyth push account (shard 0 for `HNT_PRICE_FEED_ID`),
+/// kept continuously fresh on-chain and mirrored in `spl-utils`' `HNT_PYTH_PRICE_FEED`.
+/// `calculate_utility_score_v0` pins the supplied price account to this key so a caller
+/// cannot substitute a different (stale-but-valid) HNT price update to steer the backstop.
+///
+/// Operational constraint: this constant and the account the end-epoch cron forwards must
+/// move together. A closed or stale canonical account fails safe (the content checks in
+/// `read_hnt_price` make the epoch dormant, issuance continues). But repointing the cron
+/// at a *different* account without also upgrading this constant hard-fails the pin
+/// (`InvalidPriceOracle`) and halts issuance. To rotate the Pyth feed account, upgrade this
+/// constant and update the cron in the same rollout.
+pub const HNT_PYTH_PRICE_FEED: Pubkey = pubkey!("4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33");
+
 /// Mobile data bucket fraction (HIP 149 Decision 3), as a percentage. Hardcoded.
 pub const MOBILE_DATA_BUCKET_PERCENT: u128 = 70;
 
@@ -49,9 +62,17 @@ pub struct BackstopInput {
   /// `10^(hnt_decimals - pyth_exponent - 5)`, the DC->HNT scale factor (mirrors
   /// `mint_data_credits_v0`). With 8 HNT decimals and a -8 exponent this is `10^11`.
   pub decimals_factor: u128,
-  /// Confidence-adjusted Pyth HNT price (`ema_price - 2 * ema_conf`), guaranteed `> 0`
-  /// by the caller. Same convention as `mint_data_credits_v0`.
-  pub hnt_price_with_conf: u64,
+  /// Lower-bound Pyth HNT price (`ema_price - 2 * ema_conf`), guaranteed `> 0` by the
+  /// caller. Used for the floor/top-up: a lower price converts the USD target into more
+  /// HNT, which is the conservative direction for a minimum. Same convention as
+  /// `mint_data_credits_v0`.
+  pub hnt_price_floor: u64,
+  /// EMA (point-estimate) Pyth HNT price, no confidence adjustment. Used for the earnings
+  /// cap so it binds at exactly `3.0 x carrier_paid_USD` at the point price. The floor uses
+  /// the lower bound (never underpay a minimum); the cap uses the point price (land on the
+  /// HIP's 3.0x rather than biasing the ceiling in either direction with the confidence
+  /// width) (I-01).
+  pub hnt_price_cap: u64,
 }
 
 /// Result of the backstop computation for one epoch.
@@ -90,11 +111,12 @@ pub fn compute_backstop(input: &BackstopInput) -> BackstopOutput {
 
   // carrier_paid_USD = dc_burned x 1e-5. The cap is 3.0x of it (dc_burned*3 in DC units);
   // the floor target (0.5x) is computed below, after the share guard, since it's only
-  // used on the top-up path.
+  // used on the top-up path. The cap uses the EMA point price so it binds at exactly 3.0x;
+  // the floor uses the lower (confidence-adjusted) price so a minimum is never underpaid.
   let deployer_cap_hnt = scale_dc_to_hnt(
     (input.mobile_dc_burned as u128).saturating_mul(3),
     input.decimals_factor,
-    input.hnt_price_with_conf,
+    input.hnt_price_cap,
   );
 
   // Total emission unaffected by the backstop: schedule + the existing re-emit.
@@ -115,7 +137,7 @@ pub fn compute_backstop(input: &BackstopInput) -> BackstopOutput {
   let target_hnt = scale_dc_to_hnt(
     (input.mobile_dc_burned / 2) as u128,
     input.decimals_factor,
-    input.hnt_price_with_conf,
+    input.hnt_price_floor,
   );
 
   // deployer_baseline = (emission + existing_re_emit) x mobile_share x 0.70.
@@ -130,13 +152,17 @@ pub fn compute_backstop(input: &BackstopInput) -> BackstopOutput {
   // Reverses the same scale used in deployer_baseline. The alpha division sizes a
   // DAO-level mint so the slice reaching Mobile data deployers equals the shortfall.
   let shortfall = (target_hnt as u128).saturating_sub(deployer_baseline as u128);
+  // If the demand doesn't fit in u64 the inputs are already outside any real range (an
+  // absurdly low price). Fail safe to no top-up for the epoch (I-02) rather than treating
+  // the overflow as "use the whole burn budget"; this matches read_hnt_price, which makes
+  // the backstop dormant on any price that can't be trusted.
   let top_up_demand: u64 = shortfall
     .saturating_mul(u32::MAX as u128)
     .saturating_mul(100)
     .checked_div(share.saturating_mul(MOBILE_DATA_BUCKET_PERCENT))
     .unwrap_or(0)
     .try_into()
-    .unwrap_or(u64::MAX);
+    .unwrap_or(0);
 
   // Burn-bounded: the top-up may use only the burn beyond what the existing re-emit
   // already consumes (HIP 149 shared-budget bound). With existing_re_emit =
@@ -201,6 +227,8 @@ mod tests {
   }
 
   fn base_input(price_dollars: f64, smoothed: u64) -> BackstopInput {
+    // Zero-confidence case: floor and cap prices coincide, so the existing worked
+    // examples are unchanged by the floor/cap price split (I-01).
     BackstopInput {
       emission: EMISSION,
       smoothed_hnt_burned: smoothed,
@@ -208,7 +236,8 @@ mod tests {
       mobile_dc_burned: DC_BURNED,
       mobile_share: SHARE_8927,
       decimals_factor: DECIMALS_FACTOR,
-      hnt_price_with_conf: hnt_price(price_dollars),
+      hnt_price_floor: hnt_price(price_dollars),
+      hnt_price_cap: hnt_price(price_dollars),
     }
   }
 
@@ -290,6 +319,23 @@ mod tests {
     assert!(
       (hnt(out.deployer_cap_hnt) - 10_920.0).abs() < 5.0,
       "cap_hnt {} should be ~10,920 HNT",
+      hnt(out.deployer_cap_hnt)
+    );
+  }
+
+  #[test]
+  fn cap_uses_its_own_price_not_the_floor_price() {
+    // I-01: the cap converts its 3.0x USD ceiling at the EMA point price, independent of
+    // the floor's lower (confidence-adjusted) price. EMA $1.00, floor price $0.90. The cap
+    // in HNT is 3 x $9,100 / $1.00 = 27,300 HNT (exactly 3.0x at the point price), not
+    // 3 x $9,100 / $0.90 = 30,333 HNT (what sharing the floor's lower price would give).
+    let mut input = base_input(1.00, NET_CAP);
+    input.hnt_price_floor = hnt_price(0.90);
+    input.hnt_price_cap = hnt_price(1.00);
+    let out = compute_backstop(&input);
+    assert!(
+      (hnt(out.deployer_cap_hnt) - 27_300.0).abs() < 5.0,
+      "cap_hnt {} should use the EMA point price (~27,300 HNT), not the floor's lower price (~30,333)",
       hnt(out.deployer_cap_hnt)
     );
   }

--- a/programs/helium-sub-daos/src/backstop.rs
+++ b/programs/helium-sub-daos/src/backstop.rs
@@ -1,0 +1,364 @@
+//! HIP 149 Decision 1: the Mobile data deployer earnings backstop.
+//!
+//! Two coupled mechanisms, both keyed off the per-epoch carrier-paid burn signal
+//! `mobile_sub_dao_epoch_info.dc_burned` (DC has 5 decimals, 1 DC = $0.00001, so
+//! `dc_burned` is a direct USD measure of carrier consumption):
+//!
+//! - **Floor (target minimum / top-up).** When the Mobile data deployer baseline
+//!   falls below half the carrier-paid USD, the protocol re-emits burned HNT to
+//!   top deployers up to that target. Computed here in `calculate_utility_score_v0`
+//!   and added to DAO-level `total_rewards`. Bounded by recent HNT destruction so
+//!   it never grows net supply, and sharing one burn budget with the existing
+//!   HIP 20 net-emissions re-emit (the two paths never re-mint the same destroyed
+//!   HNT twice).
+//! - **Cap (earnings ceiling / overflow-to-stakers).** When the Mobile data bucket
+//!   would pay deployers more than three times the carrier-paid USD, the excess is
+//!   redirected from the rewards escrow to the shared delegator pool. Applied in
+//!   `issue_rewards_v0`; this module only computes the ceiling (`deployer_cap_hnt`).
+//!
+//! The floor and the cap are mutually exclusive within an epoch (the floor sits at
+//! a sixth of the cap).
+//!
+//! Parameters (50% floor share, 300% cap, 0.70 Mobile data bucket) are hardcoded;
+//! changing them requires a community HIP and program upgrade. `alpha` (the fraction
+//! of total emission reaching Mobile data deployers) is computed each epoch from the
+//! on-chain Mobile percent share, not a parameter.
+
+use anchor_lang::prelude::*;
+
+/// The Mobile sub-DAO PDA on mainnet (`["sub_dao", MOBILE_MINT]` under this program).
+/// The backstop keys off the Mobile sub-DAO's `dc_burned` and percent share.
+pub const MOBILE_SUB_DAO: Pubkey = pubkey!("Gm9xDCJawDEKDrrQW6haw94gABaYzQwCq4ZQU8h8bd22");
+
+/// Mobile data bucket fraction (HIP 149 Decision 3), as a percentage. Hardcoded.
+pub const MOBILE_DATA_BUCKET_PERCENT: u128 = 70;
+
+/// Inputs to the backstop computation, all already read from on-chain state and
+/// the Pyth price account by the caller.
+pub struct BackstopInput {
+  /// HIP 20 emission schedule value for the end of this epoch.
+  pub emission: u64,
+  /// 7-epoch moving average of HNT destroyed on-chain (the existing HIP 20 variable).
+  pub smoothed_hnt_burned: u64,
+  /// DAO net-emissions cap governing the existing carrier-burn re-emit.
+  pub net_emissions_cap: u64,
+  /// Mobile sub-DAO `dc_burned` accumulator for this epoch (carrier-paid DC).
+  pub mobile_dc_burned: u64,
+  /// Mobile sub-DAO 30-epoch EMA percent share (`previous_percentage`), scaled by `u32::MAX`.
+  pub mobile_share: u32,
+  /// `10^(hnt_decimals - pyth_exponent - 5)`, the DC->HNT scale factor (mirrors
+  /// `mint_data_credits_v0`). With 8 HNT decimals and a -8 exponent this is `10^11`.
+  pub decimals_factor: u128,
+  /// Confidence-adjusted Pyth HNT price (`ema_price - 2 * ema_conf`), guaranteed `> 0`
+  /// by the caller. Same convention as `mint_data_credits_v0`.
+  pub hnt_price_with_conf: u64,
+}
+
+/// Result of the backstop computation for one epoch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct BackstopOutput {
+  /// The existing HIP 20 carrier-burn re-emit, `min(smoothed_hnt_burned, net_emissions_cap)`.
+  pub existing_re_emit: u64,
+  /// The target-minimum top-up to add to DAO-level `total_rewards` this epoch.
+  pub top_up: u64,
+  /// DAO-level total rewards: `emission + existing_re_emit + top_up`.
+  pub total_rewards: u64,
+  /// The Mobile data deployer earnings ceiling in HNT (`3 x carrier_paid_USD`).
+  pub deployer_cap_hnt: u64,
+}
+
+/// Convert a DC count to HNT lamports at the confidence-adjusted Pyth price, exactly
+/// as `mint_data_credits_v0` converts DC to the HNT it burns:
+/// `hnt = dc * decimals_factor / price`.
+fn scale_dc_to_hnt(dc_amount: u128, decimals_factor: u128, hnt_price_with_conf: u64) -> u64 {
+  dc_amount
+    .saturating_mul(decimals_factor)
+    .checked_div(hnt_price_with_conf as u128)
+    .unwrap_or(0)
+    .try_into()
+    .unwrap_or(u64::MAX)
+}
+
+/// Compute the HIP 149 Decision 1 backstop for one epoch.
+///
+/// The floor tops Mobile data deployers up to `0.5 x carrier_paid_USD`; the cap
+/// (returned as `deployer_cap_hnt`) holds them at no more than `3.0 x carrier_paid_USD`.
+/// The top-up is bounded by `max(0, smoothed_hnt_burned - net_emissions_cap)` so that,
+/// together with the existing re-emit, re-emission never exceeds recent HNT destruction.
+pub fn compute_backstop(input: &BackstopInput) -> BackstopOutput {
+  let existing_re_emit = std::cmp::min(input.smoothed_hnt_burned, input.net_emissions_cap);
+
+  // carrier_paid_USD = dc_burned x 1e-5. The cap is 3.0x of it (dc_burned*3 in DC units);
+  // the floor target (0.5x) is computed below, after the share guard, since it's only
+  // used on the top-up path.
+  let deployer_cap_hnt = scale_dc_to_hnt(
+    (input.mobile_dc_burned as u128).saturating_mul(3),
+    input.decimals_factor,
+    input.hnt_price_with_conf,
+  );
+
+  // Total emission unaffected by the backstop: schedule + the existing re-emit.
+  let base_total = input.emission.saturating_add(existing_re_emit);
+
+  // mobile_share == 0 (genesis or a fully un-delegated Mobile sub-DAO) would divide by
+  // zero below; fall back to the existing re-emit only.
+  if input.mobile_share == 0 {
+    return BackstopOutput {
+      existing_re_emit,
+      top_up: 0,
+      total_rewards: base_total,
+      deployer_cap_hnt,
+    };
+  }
+
+  // Floor target: 0.5x carrier-paid USD (dc_burned/2 in DC units), in HNT.
+  let target_hnt = scale_dc_to_hnt(
+    (input.mobile_dc_burned / 2) as u128,
+    input.decimals_factor,
+    input.hnt_price_with_conf,
+  );
+
+  // deployer_baseline = (emission + existing_re_emit) x mobile_share x 0.70.
+  // mobile_share is scaled by u32::MAX; both divisors are nonzero constants.
+  let share = input.mobile_share as u128;
+  let deployer_baseline = (base_total as u128).saturating_mul(share) / (u32::MAX as u128)
+    * MOBILE_DATA_BUCKET_PERCENT
+    / 100;
+
+  // top_up_demand = (target_hnt - deployer_baseline) / alpha
+  //              = shortfall x u32::MAX x 100 / (mobile_share x 70).
+  // Reverses the same scale used in deployer_baseline. The alpha division sizes a
+  // DAO-level mint so the slice reaching Mobile data deployers equals the shortfall.
+  let shortfall = (target_hnt as u128).saturating_sub(deployer_baseline as u128);
+  let top_up_demand: u64 = shortfall
+    .saturating_mul(u32::MAX as u128)
+    .saturating_mul(100)
+    .checked_div(share.saturating_mul(MOBILE_DATA_BUCKET_PERCENT))
+    .unwrap_or(0)
+    .try_into()
+    .unwrap_or(u64::MAX);
+
+  // Burn-bounded: the top-up may use only the burn beyond what the existing re-emit
+  // already consumes (HIP 149 shared-budget bound). With existing_re_emit =
+  // min(smoothed, cap), this burn budget is max(0, smoothed - cap), and the two paths
+  // sum to at most smoothed_hnt_burned.
+  let burn_budget = input
+    .smoothed_hnt_burned
+    .saturating_sub(input.net_emissions_cap);
+  let top_up = std::cmp::min(top_up_demand, burn_budget);
+
+  BackstopOutput {
+    existing_re_emit,
+    top_up,
+    total_rewards: base_total.saturating_add(top_up),
+    deployer_cap_hnt,
+  }
+}
+
+/// The HIP 149 earnings-cap overflow: the portion of the Mobile data bucket above the
+/// deployer ceiling, redirected from the rewards escrow to the shared delegator pool.
+///
+/// `rewards_amount` is the Mobile sub-DAO's emission this epoch; the data bucket is 0.70
+/// of it. A zero ceiling (no carrier burn / no price oracle this epoch) disables the
+/// redirect, so the full data bucket flows to deployers as before.
+///
+/// Clamped to `escrow` (the deployer portion, `rewards_amount - delegator slice`) so the
+/// redirect can never draw more than the escrow holds: with a high `delegator_rewards_percent`
+/// the 70% data bucket can exceed the escrow, and without this the caller's escrow subtraction
+/// would underflow and panic.
+pub fn staker_overflow(rewards_amount: u64, deployer_cap_hnt: u64, escrow: u64) -> u64 {
+  if deployer_cap_hnt == 0 {
+    return 0;
+  }
+  let data_bucket = (rewards_amount as u128)
+    .saturating_mul(MOBILE_DATA_BUCKET_PERCENT)
+    .checked_div(100)
+    .unwrap_or(0) as u64;
+  data_bucket.saturating_sub(deployer_cap_hnt).min(escrow)
+}
+
+#[cfg(test)]
+// HNT amounts are written as whole-HNT then 8 decimals (e.g. 1_644_00000000) for
+// readability against the spec's HNT figures; same precedent as the treasury mint
+// literal in calculate_utility_score_v0.rs.
+#[allow(clippy::inconsistent_digit_grouping)]
+mod tests {
+  use super::*;
+
+  // Worked examples from helium-next/specs/supply.md, adjusted to HIP 149's
+  // shared-budget burn bound. Mobile sub-DAO ~89/11 split => mobile_share ~0.8927.
+  const SHARE_8927: u32 = ((0.8927_f64) * (u32::MAX as f64)) as u32; // alpha ~ 0.625
+  const NET_CAP: u64 = 1_644_00000000; // ~1,644 HNT/epoch in bones (8 decimals)
+  const EMISSION: u64 = 20_548_00000000; // ~20,548 HNT/epoch
+  const DECIMALS_FACTOR: u128 = 100_000_000_000; // 10^11 (8 hnt decimals, -8 expo)
+
+  // carrier pays $9,100/day => 910,000,000 DC ($1 = 1e5 DC).
+  const DC_BURNED: u64 = 910_000_000;
+
+  fn hnt_price(dollars: f64) -> u64 {
+    // Pyth price with 8-decimal (-8) exponent.
+    (dollars * 1e8) as u64
+  }
+
+  fn base_input(price_dollars: f64, smoothed: u64) -> BackstopInput {
+    BackstopInput {
+      emission: EMISSION,
+      smoothed_hnt_burned: smoothed,
+      net_emissions_cap: NET_CAP,
+      mobile_dc_burned: DC_BURNED,
+      mobile_share: SHARE_8927,
+      decimals_factor: DECIMALS_FACTOR,
+      hnt_price_with_conf: hnt_price(price_dollars),
+    }
+  }
+
+  // Convert HNT bones back to whole HNT for readable asserts.
+  fn hnt(bones: u64) -> f64 {
+    bones as f64 / 1e8
+  }
+
+  #[test]
+  fn neither_binds_inside_band() {
+    // HNT $1, R_payer $0.10. Baseline ~$0.15/GB sits well above the floor and below
+    // the cap, so no top-up and no overflow.
+    let out = compute_backstop(&base_input(1.0, NET_CAP)); // smoothed = cap => re_emit binds, burn_budget 0
+    assert_eq!(out.top_up, 0, "no top-up inside the band");
+    // deployer baseline ~13,870 HNT; cap_hnt = 3 x $9,100 / $1 = 27,300 HNT.
+    let data_bucket = hnt(out.total_rewards) * 0.8927 * 0.70;
+    assert!(data_bucket < hnt(out.deployer_cap_hnt), "below the cap");
+  }
+
+  #[test]
+  fn floor_binds_steady_state() {
+    // HNT $0.10 steady state: carrier still pays $9,100, Nova burns ~91,000 HNT/day,
+    // so smoothed settles at ~91,000 HNT. Target fully delivered.
+    let smoothed = 91_000_00000000;
+    let out = compute_backstop(&base_input(0.10, smoothed));
+    // target_hnt = 0.5 x $9,100 / $0.10 = 45,500 HNT.
+    // deployer total delivered = baseline + top_up x alpha should reach 45,500 HNT.
+    let alpha = 0.8927 * 0.70;
+    let baseline = hnt(EMISSION + NET_CAP) * alpha;
+    let delivered = baseline + hnt(out.top_up) * alpha;
+    assert!(
+      (delivered - 45_500.0).abs() < 50.0,
+      "delivered {delivered} HNT should reach the 45,500 HNT target"
+    );
+  }
+
+  #[test]
+  fn burn_bound_binds_during_transient() {
+    // Just after a crash from $1 to $0.10: smoothed still reflects pre-crash burns
+    // (~9,100 HNT/day). The shared-budget bound caps the top-up at smoothed - net_cap.
+    let smoothed = 9_100_00000000;
+    let out = compute_backstop(&base_input(0.10, smoothed));
+    let expected_top_up = smoothed - NET_CAP; // burn budget, since demand far exceeds it
+    assert_eq!(
+      out.top_up, expected_top_up,
+      "top-up clamped to the shared burn budget (smoothed - net_emissions_cap)"
+    );
+    // Sanity: combined re-emission never exceeds smoothed_hnt_burned.
+    assert!(out.existing_re_emit + out.top_up <= smoothed);
+  }
+
+  #[test]
+  fn combined_reemission_never_exceeds_burns() {
+    // Property: existing_re_emit + top_up <= smoothed_hnt_burned for any smoothed.
+    for smoothed in [
+      0u64,
+      300,
+      NET_CAP,
+      NET_CAP + 1,
+      50_000_00000000,
+      91_000_00000000,
+    ] {
+      let out = compute_backstop(&base_input(0.10, smoothed));
+      assert!(
+        out.existing_re_emit + out.top_up <= smoothed,
+        "smoothed={smoothed}: re_emit {} + top_up {} exceeds the burn budget",
+        out.existing_re_emit,
+        out.top_up
+      );
+    }
+  }
+
+  #[test]
+  fn cap_ceiling_computed_for_overflow() {
+    // HNT $2.50: baseline ~$0.38/GB exceeds the $0.30/GB cap. The ceiling in HNT is
+    // 3 x $9,100 / $2.50 = 10,920 HNT. The redirect itself happens in issue_rewards_v0.
+    let out = compute_backstop(&base_input(2.50, NET_CAP));
+    assert_eq!(out.top_up, 0, "no top-up when HNT is expensive");
+    assert!(
+      (hnt(out.deployer_cap_hnt) - 10_920.0).abs() < 5.0,
+      "cap_hnt {} should be ~10,920 HNT",
+      hnt(out.deployer_cap_hnt)
+    );
+  }
+
+  #[test]
+  fn staker_overflow_redirects_above_cap() {
+    // rewards_amount such that the data bucket (70%) is 13,870 HNT; cap 10,920 HNT.
+    let rewards_amount = (13_870_00000000_u64 * 100) / 70; // data bucket = 13,870 HNT
+    let cap = 10_920_00000000;
+    let overflow = staker_overflow(rewards_amount, cap, rewards_amount);
+    assert!(
+      (hnt(overflow) - 2_950.0).abs() < 5.0,
+      "overflow {} HNT should be ~2,950",
+      hnt(overflow)
+    );
+  }
+
+  #[test]
+  fn staker_overflow_none_inside_band() {
+    let rewards_amount = (13_870_00000000_u64 * 100) / 70;
+    // cap well above the bucket (HNT cheap): no redirect.
+    assert_eq!(
+      staker_overflow(rewards_amount, 27_300_00000000, rewards_amount),
+      0
+    );
+  }
+
+  #[test]
+  fn staker_overflow_disabled_when_cap_zero() {
+    // No carrier burn / no price oracle => ceiling 0 => the whole bucket stays with
+    // deployers (no accidental redirect of everything to stakers).
+    assert_eq!(staker_overflow(20_000_00000000, 0, 20_000_00000000), 0);
+  }
+
+  #[test]
+  fn staker_overflow_clamped_to_escrow() {
+    // Tiny ceiling would push the redirect to ~the whole 70% data bucket, but a high
+    // delegator slice leaves a smaller escrow. The redirect clamps to the escrow so the
+    // caller's escrow subtraction can't underflow.
+    let rewards_amount = 100_000_00000000_u64;
+    let escrow = 10_000_00000000; // delegators took 90% this epoch
+    let overflow = staker_overflow(rewards_amount, 1, escrow);
+    assert_eq!(overflow, escrow, "redirect never exceeds the escrow");
+  }
+
+  #[test]
+  fn mobile_share_zero_falls_back_to_re_emit() {
+    let mut input = base_input(0.10, 91_000_00000000);
+    input.mobile_share = 0;
+    let out = compute_backstop(&input);
+    assert_eq!(out.top_up, 0, "no top-up when mobile_share is 0");
+    assert_eq!(out.total_rewards, EMISSION + NET_CAP);
+  }
+
+  #[test]
+  fn floor_and_cap_mutually_exclusive() {
+    // The floor (0.5x) sits below the cap (3.0x) of the same carrier-paid USD, so they
+    // can never both bind. Sweep prices: whenever top_up > 0, the data bucket is below
+    // the cap ceiling; whenever the bucket exceeds the cap, top_up == 0.
+    for price in [0.05, 0.10, 0.20, 0.33, 1.0, 1.97, 2.5, 5.0] {
+      let out = compute_backstop(&base_input(price, 91_000_00000000));
+      let data_bucket = (out.total_rewards as u128) * (SHARE_8927 as u128) / (u32::MAX as u128)
+        * MOBILE_DATA_BUCKET_PERCENT
+        / 100;
+      let over_cap = (data_bucket as u64) > out.deployer_cap_hnt;
+      assert!(
+        !(out.top_up > 0 && over_cap),
+        "price {price}: floor and cap bound simultaneously"
+      );
+    }
+  }
+}

--- a/programs/helium-sub-daos/src/error.rs
+++ b/programs/helium-sub-daos/src/error.rs
@@ -64,4 +64,16 @@ pub enum ErrorCode {
 
   #[msg("Cannot extend an expired position")]
   CannotExtendExpiredPosition,
+
+  #[msg("Supplement window is active but no supplement vault was provided")]
+  SupplementVaultMissing,
+
+  #[msg("Supplement vault is not owned by the configured supplement vault owner")]
+  InvalidSupplementVault,
+
+  #[msg("Supplement window is active but no Council compensation vault was provided")]
+  CouncilVaultMissing,
+
+  #[msg("Council compensation vault does not match the configured Council fanout token account")]
+  InvalidCouncilVault,
 }

--- a/programs/helium-sub-daos/src/error.rs
+++ b/programs/helium-sub-daos/src/error.rs
@@ -68,7 +68,7 @@ pub enum ErrorCode {
   #[msg("Supplement window is active but no supplement vault was provided")]
   SupplementVaultMissing,
 
-  #[msg("Supplement vault is not owned by the configured supplement vault owner")]
+  #[msg("Supplement vault does not match the configured supplement vault token account")]
   InvalidSupplementVault,
 
   #[msg("Supplement window is active but no Council compensation vault was provided")]
@@ -76,4 +76,13 @@ pub enum ErrorCode {
 
   #[msg("Council compensation vault does not match the configured Council fanout token account")]
   InvalidCouncilVault,
+
+  #[msg("HNT price oracle account is required for the backstop but was not supplied")]
+  PriceOracleMissing,
+
+  #[msg("HNT price oracle account does not match the canonical HNT Pyth price feed")]
+  InvalidPriceOracle,
+
+  #[msg("The Mobile sub-DAO epoch-info accounts required by the backstop were not supplied")]
+  MobileEpochInfoMissing,
 }

--- a/programs/helium-sub-daos/src/instructions/calculate_utility_score_v0.rs
+++ b/programs/helium-sub-daos/src/instructions/calculate_utility_score_v0.rs
@@ -2,10 +2,17 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token};
 use circuit_breaker::CircuitBreaker;
 use no_emit::{NoEmit, NotEmittedCounterV0};
+use pyth_solana_receiver_sdk::price_update::{PriceUpdateV2, VerificationLevel};
 use shared_utils::{precise_number::PreciseNumber, try_from};
 use voter_stake_registry::state::Registrar;
 
-use crate::{current_epoch, error::ErrorCode, state::*, update_subdao_vehnt, EPOCH_LENGTH};
+use crate::{
+  backstop::{compute_backstop, BackstopInput, MOBILE_SUB_DAO},
+  current_epoch,
+  error::ErrorCode,
+  state::*,
+  update_subdao_vehnt, EPOCH_LENGTH,
+};
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Default)]
 pub struct CalculateUtilityScoreArgsV0 {
@@ -13,6 +20,13 @@ pub struct CalculateUtilityScoreArgsV0 {
 }
 
 pub const TESTING: bool = std::option_env!("TESTING").is_some();
+
+// Mirror of `data_credits::mint_data_credits_v0::HNT_PRICE_FEED_ID`. Duplicated here
+// (rather than imported) because data-credits depends on this crate, not the reverse.
+pub const HNT_PRICE_FEED_ID: [u8; 32] = [
+  0x64, 0x9f, 0xdd, 0x7e, 0xc0, 0x8e, 0x8e, 0x2a, 0x20, 0xf4, 0x25, 0x72, 0x98, 0x54, 0xe9, 0x02,
+  0x93, 0xdc, 0xbe, 0x23, 0x76, 0xab, 0xc4, 0x71, 0x97, 0xa1, 0x4d, 0xa6, 0xff, 0x33, 0x97, 0x56,
+];
 
 #[derive(Accounts)]
 #[instruction(args: CalculateUtilityScoreArgsV0)]
@@ -76,12 +90,19 @@ pub struct CalculateUtilityScoreV0<'info> {
   /// CHECK: May not have ever been initialized
   pub not_emitted_counter: UncheckedAccount<'info>,
   pub no_emit_program: Program<'info, NoEmit>,
+  /// CHECK: HIP 149 backstop HNT/USD Pyth price. Optional, and fully validated in the
+  /// handler (feed id, Full verification, staleness, positivity) — any problem makes the
+  /// backstop go dormant for the epoch rather than fail the instruction, so a missing or
+  /// stale price can never halt reward issuance. No declarative constraints for that
+  /// reason; an attacker can at most disable the backstop (same as omitting it), never
+  /// inject a price.
+  pub hnt_price_oracle: Option<UncheckedAccount<'info>>,
 }
 
 const SMOOTHING_FACTOR: u64 = 7;
 
-pub fn handler(
-  ctx: Context<CalculateUtilityScoreV0>,
+pub fn handler<'info>(
+  ctx: Context<'_, '_, 'info, 'info, CalculateUtilityScoreV0<'info>>,
   args: CalculateUtilityScoreArgsV0,
 ) -> Result<()> {
   let end_of_epoch_ts = i64::try_from(args.epoch + 1).unwrap() * EPOCH_LENGTH;
@@ -154,22 +175,77 @@ pub fn handler(
     ctx.accounts.dao_epoch_info.cumulative_not_emitted = cumulative_not_emitted;
   }
 
-  ctx.accounts.dao_epoch_info.total_rewards = ctx
+  let emission_ts = ctx
     .accounts
     .dao
     .emission_schedule
     .get_emissions_at(end_of_epoch_ts)
-    .unwrap()
-    .checked_add(std::cmp::min(
-      ctx.accounts.dao_epoch_info.smoothed_hnt_burned,
-      ctx.accounts.dao.net_emissions_cap,
-    ))
     .unwrap();
+  let net_emissions_cap = ctx.accounts.dao.net_emissions_cap;
+  let smoothed = ctx.accounts.dao_epoch_info.smoothed_hnt_burned;
+
+  // HIP 149 Decision 1 backstop. When a valid, fresh Pyth HNT price and the Mobile
+  // signals are both available, size the deployer target-minimum top-up (added on top of
+  // the existing carrier-burn re-emit) and the earnings-cap ceiling (stored for
+  // issue_rewards_v0 to apply on the Mobile pass). Both passes (IoT and Mobile) read the
+  // same Mobile signals and compute the same total_rewards, so the result is independent
+  // of sub-DAO ordering.
+  //
+  // Fail-safe: if the price is missing/stale/malformed or the Mobile epoch-info accounts
+  // aren't supplied, the backstop is dormant for the epoch (baseline emission + existing
+  // re-emit, no top-up, no cap) rather than failing the instruction. A stale price can
+  // never halt reward issuance, and the HIP already treats the target as a best-effort
+  // per-epoch aim, not a hard guarantee.
+  let hnt_price = read_hnt_price(&ctx);
+  let backstop = match (hnt_price, mobile_signals(&ctx, args.epoch)) {
+    (Some((decimals_factor, hnt_price_with_conf)), Some((mobile_dc_burned, mobile_share))) => {
+      compute_backstop(&BackstopInput {
+        emission: emission_ts,
+        smoothed_hnt_burned: smoothed,
+        net_emissions_cap,
+        mobile_dc_burned,
+        mobile_share,
+        decimals_factor,
+        hnt_price_with_conf,
+      })
+    }
+    _ => {
+      let existing_re_emit = std::cmp::min(smoothed, net_emissions_cap);
+      crate::backstop::BackstopOutput {
+        existing_re_emit,
+        top_up: 0,
+        total_rewards: emission_ts.checked_add(existing_re_emit).unwrap(),
+        deployer_cap_hnt: 0,
+      }
+    }
+  };
+
+  ctx.accounts.dao_epoch_info.total_rewards = backstop.total_rewards;
+  ctx.accounts.dao_epoch_info.deployer_cap_hnt = backstop.deployer_cap_hnt;
 
   ctx.accounts.dao_epoch_info.epoch = args.epoch;
 
   ctx.accounts.dao_epoch_info.current_hnt_supply = curr_supply
     .checked_add(ctx.accounts.dao_epoch_info.total_rewards)
+    .unwrap();
+
+  // HIP 149 Decision 2 supply-tracking correction. issue_rewards_v0 mints the supplement
+  // this epoch (supplement_per_subdao per sub-DAO pass, split between the Receiving Entity
+  // vault and the Council fanout, so num_sub_daos passes sum to the full daily amount, the
+  // split notwithstanding). Record that total in
+  // current_hnt_supply so next epoch's prev_supply is accurate; otherwise the mint reads
+  // as "negative burn", drives smoothed_hnt_burned to zero across its window, and disables
+  // both the floor top-up and the HIP 20 net-emissions re-emit. Tracking it here (and only
+  // here) keeps total_hnt_burned self-correcting -- adding it to total_hnt_burned as well
+  // would double-count. Mirrors the audited 2024-2025 treasury-mint block below.
+  let supplement_this_epoch =
+    crate::supplement::supplement_per_subdao(Clock::get()?.unix_timestamp)
+      .saturating_mul(ctx.accounts.dao.num_sub_daos as u64);
+  ctx.accounts.dao_epoch_info.current_hnt_supply = ctx
+    .accounts
+    .dao_epoch_info
+    .current_hnt_supply
+    .checked_add(supplement_this_epoch)
     .unwrap();
 
   // Until August 1st, 2025, emit the 2.9M HNT to the treasury.
@@ -289,4 +365,107 @@ pub fn handler(
   }
 
   Ok(())
+}
+
+/// Maximum age of the HNT price for it to feed the backstop. A daily mechanism tolerates
+/// staleness (intra-day drift is small), and a too-old price simply makes the backstop
+/// dormant rather than wrong. Generous under TESTING so posted test prices never expire.
+const PRICE_MAX_AGE_SECS: i64 = 60 * 60;
+
+/// Read the confidence-adjusted HNT price and DC->HNT scale factor from the optional Pyth
+/// account, mirroring `mint_data_credits_v0`'s price math. Returns `None` (backstop
+/// dormant this epoch) for any reason the price can't be trusted: not supplied, wrong
+/// owner/type, wrong feed, not Full-verified, stale, or non-positive. Never errors, so a
+/// bad price can't halt reward issuance.
+fn read_hnt_price<'info>(
+  ctx: &Context<'_, '_, '_, 'info, CalculateUtilityScoreV0<'info>>,
+) -> Option<(u128, u64)> {
+  let oracle = ctx.accounts.hnt_price_oracle.as_ref()?;
+  let price_update = try_from!(Account<PriceUpdateV2>, oracle).ok()?;
+
+  if price_update.verification_level != VerificationLevel::Full {
+    return None;
+  }
+  let message = price_update.price_message;
+  if message.feed_id != HNT_PRICE_FEED_ID {
+    return None;
+  }
+
+  let now = Clock::get().ok()?.unix_timestamp;
+  let max_age = if TESTING {
+    6_000_000
+  } else {
+    PRICE_MAX_AGE_SECS
+  };
+  if message.publish_time.saturating_add(max_age) < now {
+    return None;
+  }
+
+  // Remove the confidence to use the most conservative (lower) price, exactly as
+  // mint_data_credits_v0 does. A lower price yields a larger top-up; the burn bound
+  // still caps total re-emission at recent destruction.
+  let hnt_price_with_conf = message
+    .ema_price
+    .checked_sub(i64::try_from(message.ema_conf.checked_mul(2)?).ok()?)?;
+  if hnt_price_with_conf <= 0 {
+    return None;
+  }
+
+  // decimals_factor = 10^(hnt_decimals - expo - 5); converts a DC count to HNT lamports.
+  let exponent = i32::from(ctx.accounts.hnt_mint.decimals) - message.exponent - 5;
+  let decimals_factor = 10_u128.checked_pow(u32::try_from(exponent).ok()?)?;
+
+  Some((decimals_factor, u64::try_from(hnt_price_with_conf).ok()?))
+}
+
+/// Read the Mobile sub-DAO's per-epoch `dc_burned` and 30-epoch EMA percent share, or
+/// `None` (backstop dormant) if the Mobile epoch-info accounts aren't available.
+///
+/// In production these come from the Mobile sub-DAO's current- and previous-epoch
+/// `SubDaoEpochInfoV0` accounts, located in `remaining_accounts` by their PDAs (pinned to
+/// the hardcoded mainnet `MOBILE_SUB_DAO`). Under TESTING the sub-DAO being processed
+/// plays the role of Mobile, so the named current/previous epoch-info accounts are used
+/// directly.
+fn mobile_signals<'info>(
+  ctx: &Context<'_, '_, 'info, 'info, CalculateUtilityScoreV0<'info>>,
+  epoch: u64,
+) -> Option<(u64, u32)> {
+  if TESTING {
+    return Some((
+      ctx.accounts.sub_dao_epoch_info.dc_burned,
+      ctx.accounts.prev_sub_dao_epoch_info.previous_percentage,
+    ));
+  }
+
+  let curr_pda = Pubkey::find_program_address(
+    &[
+      b"sub_dao_epoch_info",
+      MOBILE_SUB_DAO.as_ref(),
+      &epoch.to_le_bytes(),
+    ],
+    &crate::ID,
+  )
+  .0;
+  let prev_pda = Pubkey::find_program_address(
+    &[
+      b"sub_dao_epoch_info",
+      MOBILE_SUB_DAO.as_ref(),
+      &(epoch - 1).to_le_bytes(),
+    ],
+    &crate::ID,
+  )
+  .0;
+
+  let curr_acc = ctx
+    .remaining_accounts
+    .iter()
+    .find(|acc| acc.key() == curr_pda)?;
+  let prev_acc = ctx
+    .remaining_accounts
+    .iter()
+    .find(|acc| acc.key() == prev_pda)?;
+
+  let curr = Account::<SubDaoEpochInfoV0>::try_from(curr_acc).ok()?;
+  let prev = Account::<SubDaoEpochInfoV0>::try_from(prev_acc).ok()?;
+  Some((curr.dc_burned, prev.previous_percentage))
 }

--- a/programs/helium-sub-daos/src/instructions/calculate_utility_score_v0.rs
+++ b/programs/helium-sub-daos/src/instructions/calculate_utility_score_v0.rs
@@ -90,12 +90,16 @@ pub struct CalculateUtilityScoreV0<'info> {
   /// CHECK: May not have ever been initialized
   pub not_emitted_counter: UncheckedAccount<'info>,
   pub no_emit_program: Program<'info, NoEmit>,
-  /// CHECK: HIP 149 backstop HNT/USD Pyth price. Optional, and fully validated in the
-  /// handler (feed id, Full verification, staleness, positivity) — any problem makes the
-  /// backstop go dormant for the epoch rather than fail the instruction, so a missing or
-  /// stale price can never halt reward issuance. No declarative constraints for that
-  /// reason; an attacker can at most disable the backstop (same as omitting it), never
-  /// inject a price.
+  /// CHECK: HIP 149 backstop HNT/USD Pyth price. Optional in the account struct (so the
+  /// TESTING dormant-path calls may omit it), but in production the handler requires it to
+  /// be present and pinned to the canonical HNT_PYTH_PRICE_FEED account. Requiring and
+  /// pinning it — rather than treating omission as "go dormant" — is what stops a
+  /// permissionless caller from front-running the cron and suppressing the backstop by
+  /// omitting or substituting the price (M-02/I-04). The price *contents* still fail safe:
+  /// a malformed, unverified, stale, or non-positive price makes the backstop dormant for
+  /// the epoch (handled in read_hnt_price) rather than halting reward issuance. The pinned
+  /// account is maintained continuously on-chain, so its presence is always satisfiable on
+  /// the honest path.
   pub hnt_price_oracle: Option<UncheckedAccount<'info>>,
 }
 
@@ -191,24 +195,45 @@ pub fn handler<'info>(
   // same Mobile signals and compute the same total_rewards, so the result is independent
   // of sub-DAO ordering.
   //
-  // Fail-safe: if the price is missing/stale/malformed or the Mobile epoch-info accounts
-  // aren't supplied, the backstop is dormant for the epoch (baseline emission + existing
-  // re-emit, no top-up, no cap) rather than failing the instruction. A stale price can
-  // never halt reward issuance, and the HIP already treats the target as a best-effort
-  // per-epoch aim, not a hard guarantee.
-  let hnt_price = read_hnt_price(&ctx);
-  let backstop = match (hnt_price, mobile_signals(&ctx, args.epoch)) {
-    (Some((decimals_factor, hnt_price_with_conf)), Some((mobile_dc_burned, mobile_share))) => {
-      compute_backstop(&BackstopInput {
-        emission: emission_ts,
-        smoothed_hnt_burned: smoothed,
-        net_emissions_cap,
-        mobile_dc_burned,
-        mobile_share,
-        decimals_factor,
-        hnt_price_with_conf,
-      })
-    }
+  // The price account and the Mobile epoch-info accounts are mandatory inputs (the price
+  // is pinned above; the Mobile accounts error via mobile_signals if omitted), so a
+  // permissionless caller cannot front-run the cron and suppress the backstop by leaving
+  // them out (M-02). What stays fail-safe is the price *content*: a malformed, unverified,
+  // stale, or non-positive price makes the backstop dormant for the epoch (baseline
+  // emission + existing re-emit, no top-up, no cap) rather than halting reward issuance.
+  // The HIP already treats the target as a best-effort per-epoch aim, not a hard guarantee.
+  //
+  // In production the price account must be present and pinned to the canonical HNT feed;
+  // omission or substitution is rejected here rather than silently going dormant, which is
+  // what closes the permissionless-suppression path (M-02/I-04). Relaxed under TESTING,
+  // where the dormant-path tests intentionally omit the oracle. Rotating the pinned feed
+  // account requires upgrading HNT_PYTH_PRICE_FEED and the cron together — see that
+  // constant's docs for the halt-vs-dormant cases.
+  if !TESTING {
+    let oracle = ctx
+      .accounts
+      .hnt_price_oracle
+      .as_ref()
+      .ok_or_else(|| error!(ErrorCode::PriceOracleMissing))?;
+    require!(
+      oracle.key() == crate::backstop::HNT_PYTH_PRICE_FEED,
+      ErrorCode::InvalidPriceOracle
+    );
+  }
+  let backstop = match (read_hnt_price(&ctx), mobile_signals(&ctx, args.epoch)?) {
+    (
+      Some((decimals_factor, hnt_price_floor, hnt_price_cap)),
+      Some((mobile_dc_burned, mobile_share)),
+    ) => compute_backstop(&BackstopInput {
+      emission: emission_ts,
+      smoothed_hnt_burned: smoothed,
+      net_emissions_cap,
+      mobile_dc_burned,
+      mobile_share,
+      decimals_factor,
+      hnt_price_floor,
+      hnt_price_cap,
+    }),
     _ => {
       let existing_re_emit = std::cmp::min(smoothed, net_emissions_cap);
       crate::backstop::BackstopOutput {
@@ -372,14 +397,16 @@ pub fn handler<'info>(
 /// dormant rather than wrong. Generous under TESTING so posted test prices never expire.
 const PRICE_MAX_AGE_SECS: i64 = 60 * 60;
 
-/// Read the confidence-adjusted HNT price and DC->HNT scale factor from the optional Pyth
-/// account, mirroring `mint_data_credits_v0`'s price math. Returns `None` (backstop
-/// dormant this epoch) for any reason the price can't be trusted: not supplied, wrong
-/// owner/type, wrong feed, not Full-verified, stale, or non-positive. Never errors, so a
-/// bad price can't halt reward issuance.
+/// Read the DC->HNT scale factor and the lower/upper confidence-adjusted HNT prices from
+/// the (pinned, required) Pyth account, mirroring `mint_data_credits_v0`'s price math.
+/// Returns `(decimals_factor, price_floor, price_cap)`, or `None` (backstop dormant this
+/// epoch) for any reason the price *content* can't be trusted: wrong type, wrong feed, not
+/// Full-verified, stale, or non-positive. Never errors, so a bad price can't halt reward
+/// issuance. Account presence and identity are enforced by the caller (required account +
+/// pin), so the only remaining reason to bail here is untrustworthy content.
 fn read_hnt_price<'info>(
   ctx: &Context<'_, '_, '_, 'info, CalculateUtilityScoreV0<'info>>,
-) -> Option<(u128, u64)> {
+) -> Option<(u128, u64, u64)> {
   let oracle = ctx.accounts.hnt_price_oracle.as_ref()?;
   let price_update = try_from!(Account<PriceUpdateV2>, oracle).ok()?;
 
@@ -401,13 +428,16 @@ fn read_hnt_price<'info>(
     return None;
   }
 
-  // Remove the confidence to use the most conservative (lower) price, exactly as
-  // mint_data_credits_v0 does. A lower price yields a larger top-up; the burn bound
-  // still caps total re-emission at recent destruction.
-  let hnt_price_with_conf = message
-    .ema_price
-    .checked_sub(i64::try_from(message.ema_conf.checked_mul(2)?).ok()?)?;
-  if hnt_price_with_conf <= 0 {
+  // Two prices for the two mechanisms. The floor/top-up uses the lower confidence bound
+  // (`ema_price - 2 * ema_conf`), exactly as mint_data_credits_v0 does: a lower price
+  // yields a larger top-up, the conservative direction for a minimum, and the burn bound
+  // still caps total re-emission at recent destruction. The cap uses the EMA point price
+  // (no confidence adjustment) so it binds at exactly 3.0x the payer rate rather than
+  // biasing the ceiling in either direction by the confidence width (I-01).
+  let conf_2 = i64::try_from(message.ema_conf.checked_mul(2)?).ok()?;
+  let price_floor = message.ema_price.checked_sub(conf_2)?;
+  let price_cap = message.ema_price;
+  if price_floor <= 0 || price_cap <= 0 {
     return None;
   }
 
@@ -415,11 +445,21 @@ fn read_hnt_price<'info>(
   let exponent = i32::from(ctx.accounts.hnt_mint.decimals) - message.exponent - 5;
   let decimals_factor = 10_u128.checked_pow(u32::try_from(exponent).ok()?)?;
 
-  Some((decimals_factor, u64::try_from(hnt_price_with_conf).ok()?))
+  Some((
+    decimals_factor,
+    u64::try_from(price_floor).ok()?,
+    u64::try_from(price_cap).ok()?,
+  ))
 }
 
-/// Read the Mobile sub-DAO's per-epoch `dc_burned` and 30-epoch EMA percent share, or
-/// `None` (backstop dormant) if the Mobile epoch-info accounts aren't available.
+/// Read the Mobile sub-DAO's per-epoch `dc_burned` and 30-epoch EMA percent share.
+///
+/// Returns `Err(MobileEpochInfoMissing)` if the caller omitted the Mobile epoch-info
+/// accounts, so a permissionless caller cannot front-run the cron and suppress the
+/// backstop by leaving them out (M-02). The cron and admin end-epoch always forward them,
+/// and they are public PDAs, so requiring their presence never blocks the honest path.
+/// Returns `Ok(None)` (backstop dormant, no halt) when the accounts are present but not
+/// yet initialized (e.g. a zero-burn epoch), and `Ok(Some(..))` when they are readable.
 ///
 /// In production these come from the Mobile sub-DAO's current- and previous-epoch
 /// `SubDaoEpochInfoV0` accounts, located in `remaining_accounts` by their PDAs (pinned to
@@ -429,12 +469,12 @@ fn read_hnt_price<'info>(
 fn mobile_signals<'info>(
   ctx: &Context<'_, '_, 'info, 'info, CalculateUtilityScoreV0<'info>>,
   epoch: u64,
-) -> Option<(u64, u32)> {
+) -> Result<Option<(u64, u32)>> {
   if TESTING {
-    return Some((
+    return Ok(Some((
       ctx.accounts.sub_dao_epoch_info.dc_burned,
       ctx.accounts.prev_sub_dao_epoch_info.previous_percentage,
-    ));
+    )));
   }
 
   let curr_pda = Pubkey::find_program_address(
@@ -459,13 +499,21 @@ fn mobile_signals<'info>(
   let curr_acc = ctx
     .remaining_accounts
     .iter()
-    .find(|acc| acc.key() == curr_pda)?;
+    .find(|acc| acc.key() == curr_pda)
+    .ok_or_else(|| error!(ErrorCode::MobileEpochInfoMissing))?;
   let prev_acc = ctx
     .remaining_accounts
     .iter()
-    .find(|acc| acc.key() == prev_pda)?;
+    .find(|acc| acc.key() == prev_pda)
+    .ok_or_else(|| error!(ErrorCode::MobileEpochInfoMissing))?;
 
-  let curr = Account::<SubDaoEpochInfoV0>::try_from(curr_acc).ok()?;
-  let prev = Account::<SubDaoEpochInfoV0>::try_from(prev_acc).ok()?;
-  Some((curr.dc_burned, prev.previous_percentage))
+  // Present but not yet initialized (e.g. no carrier burn this epoch) -> dormant, not an
+  // error, so a low-activity epoch can never halt reward issuance.
+  match (
+    Account::<SubDaoEpochInfoV0>::try_from(curr_acc).ok(),
+    Account::<SubDaoEpochInfoV0>::try_from(prev_acc).ok(),
+  ) {
+    (Some(curr), Some(prev)) => Ok(Some((curr.dc_burned, prev.previous_percentage))),
+    _ => Ok(None),
+  }
 }

--- a/programs/helium-sub-daos/src/instructions/issue_rewards_v0.rs
+++ b/programs/helium-sub-daos/src/instructions/issue_rewards_v0.rs
@@ -77,8 +77,9 @@ pub struct IssueRewardsV0<'info> {
   pub prev_sub_dao_epoch_info: Box<Account<'info, SubDaoEpochInfoV0>>,
   // HIP 149 Decision 2 supplement vault (the Receiving Entity's Squads vault HNT account).
   // Optional so pre-supplement callers/tests need not pass it; required only when the
-  // supplement window is active (enforced in the handler). Validated there: HNT mint, and
-  // owned by SUPPLEMENT_VAULT_OWNER (relaxed under TESTING).
+  // supplement window is active (enforced in the handler). Validated there: key equals
+  // SUPPLEMENT_VAULT_TOKEN_ACCOUNT (relaxed under TESTING). The HNT mint is enforced by the
+  // mint CPI.
   #[account(mut)]
   pub supplement_vault: Option<Box<Account<'info, TokenAccount>>>,
   // HIP 149 Decision 4 Council-compensation fanout (a mini_fanout PDA-owned HNT account that
@@ -287,7 +288,7 @@ pub fn handler(ctx: Context<IssueRewardsV0>, args: IssueRewardsArgsV0) -> Result
       .as_ref()
       .ok_or_else(|| error!(ErrorCode::SupplementVaultMissing))?;
     require!(
-      TESTING || vault.owner == crate::supplement::SUPPLEMENT_VAULT_OWNER,
+      TESTING || vault.key() == crate::supplement::SUPPLEMENT_VAULT_TOKEN_ACCOUNT,
       ErrorCode::InvalidSupplementVault
     );
     // Council fanout (the 1.25% carve-out). Always required while active, even if the

--- a/programs/helium-sub-daos/src/instructions/issue_rewards_v0.rs
+++ b/programs/helium-sub-daos/src/instructions/issue_rewards_v0.rs
@@ -75,6 +75,18 @@ pub struct IssueRewardsV0<'info> {
     bump = prev_sub_dao_epoch_info.bump_seed,
   )]
   pub prev_sub_dao_epoch_info: Box<Account<'info, SubDaoEpochInfoV0>>,
+  // HIP 149 Decision 2 supplement vault (the Receiving Entity's Squads vault HNT account).
+  // Optional so pre-supplement callers/tests need not pass it; required only when the
+  // supplement window is active (enforced in the handler). Validated there: HNT mint, and
+  // owned by SUPPLEMENT_VAULT_OWNER (relaxed under TESTING).
+  #[account(mut)]
+  pub supplement_vault: Option<Box<Account<'info, TokenAccount>>>,
+  // HIP 149 Decision 4 Council-compensation fanout (a mini_fanout PDA-owned HNT account that
+  // splits the 1.25% carve-out among the seated community members). Optional/required on the
+  // same terms as supplement_vault. Validated in the handler: key equals
+  // COUNCIL_FANOUT_TOKEN_ACCOUNT (relaxed under TESTING).
+  #[account(mut)]
+  pub council_vault: Option<Box<Account<'info, TokenAccount>>>,
 }
 
 fn to_prec(n: Option<u128>) -> Option<PreciseNumber> {
@@ -84,40 +96,33 @@ fn to_prec(n: Option<u128>) -> Option<PreciseNumber> {
 }
 
 impl<'info> IssueRewardsV0<'info> {
-  pub fn mint_delegation_rewards_ctx(&self) -> CpiContext<'_, '_, '_, 'info, MintV0<'info>> {
+  /// CpiContext to mint HNT (through the HNT circuit breaker, signed by the DAO) to
+  /// `to`. All HNT mints in this instruction differ only in the destination.
+  fn mint_hnt_to_ctx(
+    &self,
+    to: AccountInfo<'info>,
+  ) -> CpiContext<'_, '_, '_, 'info, MintV0<'info>> {
     let cpi_accounts = MintV0 {
       mint: self.hnt_mint.to_account_info(),
-      to: self.delegator_pool.to_account_info(),
+      to,
       mint_authority: self.dao.to_account_info(),
       circuit_breaker: self.hnt_circuit_breaker.to_account_info(),
       token_program: self.token_program.to_account_info(),
     };
 
     CpiContext::new(self.circuit_breaker_program.to_account_info(), cpi_accounts)
+  }
+
+  pub fn mint_delegation_rewards_ctx(&self) -> CpiContext<'_, '_, '_, 'info, MintV0<'info>> {
+    self.mint_hnt_to_ctx(self.delegator_pool.to_account_info())
   }
 
   pub fn mint_treasury_emissions_ctx(&self) -> CpiContext<'_, '_, '_, 'info, MintV0<'info>> {
-    let cpi_accounts = MintV0 {
-      mint: self.hnt_mint.to_account_info(),
-      to: self.treasury.to_account_info(),
-      mint_authority: self.dao.to_account_info(),
-      circuit_breaker: self.hnt_circuit_breaker.to_account_info(),
-      token_program: self.token_program.to_account_info(),
-    };
-
-    CpiContext::new(self.circuit_breaker_program.to_account_info(), cpi_accounts)
+    self.mint_hnt_to_ctx(self.treasury.to_account_info())
   }
 
   pub fn mint_rewards_emissions_ctx(&self) -> CpiContext<'_, '_, '_, 'info, MintV0<'info>> {
-    let cpi_accounts = MintV0 {
-      mint: self.hnt_mint.to_account_info(),
-      to: self.rewards_escrow.to_account_info(),
-      mint_authority: self.dao.to_account_info(),
-      circuit_breaker: self.hnt_circuit_breaker.to_account_info(),
-      token_program: self.token_program.to_account_info(),
-    };
-
-    CpiContext::new(self.circuit_breaker_program.to_account_info(), cpi_accounts)
+    self.mint_hnt_to_ctx(self.rewards_escrow.to_account_info())
   }
 }
 
@@ -194,7 +199,7 @@ pub fn handler(ctx: Context<IssueRewardsV0>, args: IssueRewardsArgsV0) -> Result
     .unwrap();
   let max_percent = 100_u64.checked_mul(10_0000000).unwrap();
 
-  let delegation_rewards_amount = (rewards_amount as u128)
+  let delegation_rewards_amount: u64 = (rewards_amount as u128)
     .checked_mul(u128::from(ctx.accounts.dao.delegator_rewards_percent))
     .unwrap()
     .checked_div(max_percent as u128) // 100% with 2 decimals accuracy
@@ -202,20 +207,46 @@ pub fn handler(ctx: Context<IssueRewardsV0>, args: IssueRewardsArgsV0) -> Result
     .try_into()
     .unwrap();
 
-  if delegation_rewards_amount > 0 {
-    msg!("Minting {} delegation rewards", delegation_rewards_amount);
+  // HIP 149 Decision 1 earnings cap. On the Mobile sub-DAO pass, hold Mobile data
+  // deployers at no more than three times the carrier-paid USD: any HNT in the data
+  // bucket above the ceiling stored by calculate_utility_score_v0 (deployer_cap_hnt)
+  // is redirected from the rewards escrow to the shared delegator pool. This is a
+  // bucket-to-bucket move inside the already-split sub-DAO emission: total_rewards is
+  // unchanged, the HNT is paid to veHNT delegators instead of deployers, and staker
+  // claims already key off the DAO-level delegation_rewards_issued. A zero ceiling
+  // (no carrier burn this epoch, or no price oracle) disables the redirect.
+  let is_mobile = TESTING || ctx.accounts.sub_dao.key() == crate::backstop::MOBILE_SUB_DAO;
+  let escrow_before_overflow = rewards_amount
+    .checked_sub(delegation_rewards_amount)
+    .unwrap();
+  let staker_overflow: u64 = if is_mobile {
+    crate::backstop::staker_overflow(
+      rewards_amount,
+      ctx.accounts.dao_epoch_info.deployer_cap_hnt,
+      escrow_before_overflow,
+    )
+  } else {
+    0
+  };
+
+  let delegation_pool_amount = delegation_rewards_amount
+    .checked_add(staker_overflow)
+    .unwrap();
+
+  if delegation_pool_amount > 0 {
+    msg!("Minting {} delegation rewards", delegation_pool_amount);
     mint_v0(
       ctx
         .accounts
         .mint_delegation_rewards_ctx()
         .with_signer(&[dao_seeds!(ctx.accounts.dao)]),
       MintArgsV0 {
-        amount: delegation_rewards_amount, // send some dnt emissions to delegation pool
+        amount: delegation_pool_amount, // delegator slice + any HIP 149 earnings-cap overflow
       },
     )?;
   }
 
-  let escrow_amount = rewards_amount - delegation_rewards_amount;
+  let escrow_amount = escrow_before_overflow.checked_sub(staker_overflow).unwrap();
   msg!("Minting {} to rewards escrow", escrow_amount);
   mint_v0(
     ctx
@@ -230,10 +261,69 @@ pub fn handler(ctx: Context<IssueRewardsV0>, args: IssueRewardsArgsV0) -> Result
   ctx.accounts.sub_dao_epoch_info.hnt_rewards_issued = escrow_amount;
   ctx.accounts.dao_epoch_info.num_rewards_issued += 1;
   ctx.accounts.sub_dao_epoch_info.rewards_issued_at = Some(Clock::get()?.unix_timestamp);
-  ctx.accounts.dao_epoch_info.delegation_rewards_issued += delegation_rewards_amount;
-  ctx.accounts.sub_dao_epoch_info.delegation_rewards_issued = delegation_rewards_amount;
+  ctx.accounts.dao_epoch_info.delegation_rewards_issued += delegation_pool_amount;
+  ctx.accounts.sub_dao_epoch_info.delegation_rewards_issued = delegation_pool_amount;
   ctx.accounts.dao_epoch_info.done_issuing_rewards =
     ctx.accounts.dao.num_sub_daos == ctx.accounts.dao_epoch_info.num_rewards_issued;
+
+  // HIP 149 Decision 2 + 4: mint this sub-DAO's slice of the operations-and-growth supplement
+  // while the supplement window is active. Each sub-DAO pass mints supplement_per_subdao, so
+  // num_sub_daos passes sum to the full daily rate (which calculate_utility_score_v0 records
+  // in current_hnt_supply). The slice is split, per HIP 149 Decision 4, into a 1.25% Council
+  // compensation carve-out (to the Council fanout) and the remainder (to the Receiving Entity
+  // vault); the two sum to supplement_per_subdao, so the supply-tracking correction is
+  // unchanged and total minted is unaffected. Both mints go through the HNT circuit breaker
+  // like the reward mints, so the breaker must be sized for the full supplement. Dormant (no
+  // mint, vaults not required) whenever the hardcoded window is inactive.
+  let supplement = crate::supplement::supplement_per_subdao(curr_ts);
+  if supplement > 0 {
+    let council_amount = crate::supplement::council_cut(supplement);
+    let vault_amount = supplement.saturating_sub(council_amount);
+
+    // Receiving Entity vault (the 98.75% remainder).
+    let vault = ctx
+      .accounts
+      .supplement_vault
+      .as_ref()
+      .ok_or_else(|| error!(ErrorCode::SupplementVaultMissing))?;
+    require!(
+      TESTING || vault.owner == crate::supplement::SUPPLEMENT_VAULT_OWNER,
+      ErrorCode::InvalidSupplementVault
+    );
+    // Council fanout (the 1.25% carve-out). Always required while active, even if the
+    // tapered amount rounds the carve-out to zero, so the destination is unambiguous.
+    let council = ctx
+      .accounts
+      .council_vault
+      .as_ref()
+      .ok_or_else(|| error!(ErrorCode::CouncilVaultMissing))?;
+    require!(
+      TESTING || council.key() == crate::supplement::COUNCIL_FANOUT_TOKEN_ACCOUNT,
+      ErrorCode::InvalidCouncilVault
+    );
+
+    msg!("Minting {vault_amount} supplement, {council_amount} Council compensation");
+    mint_v0(
+      ctx
+        .accounts
+        .mint_hnt_to_ctx(vault.to_account_info())
+        .with_signer(&[dao_seeds!(ctx.accounts.dao)]),
+      MintArgsV0 {
+        amount: vault_amount,
+      },
+    )?;
+    if council_amount > 0 {
+      mint_v0(
+        ctx
+          .accounts
+          .mint_hnt_to_ctx(council.to_account_info())
+          .with_signer(&[dao_seeds!(ctx.accounts.dao)]),
+        MintArgsV0 {
+          amount: council_amount,
+        },
+      )?;
+    }
+  }
 
   Ok(())
 }

--- a/programs/helium-sub-daos/src/lib.rs
+++ b/programs/helium-sub-daos/src/lib.rs
@@ -4,14 +4,18 @@ use {default_env::default_env, solana_security_txt::security_txt};
 
 declare_id!("hdaoVTCqhfHHo75XdAMxBKdUqvq1i5bF23sisBqVgGR");
 
+pub mod backstop;
 pub mod create_account;
 pub mod error;
 pub mod instructions;
 pub mod state;
+pub mod supplement;
 pub mod utils;
 
+pub use backstop::*;
 pub use instructions::*;
 pub use state::*;
+pub use supplement::*;
 pub use utils::*;
 
 #[cfg(not(feature = "no-entrypoint"))]
@@ -71,8 +75,8 @@ pub mod helium_sub_daos {
     track_dc_burn_v0::handler(ctx, args)
   }
 
-  pub fn calculate_utility_score_v0(
-    ctx: Context<CalculateUtilityScoreV0>,
+  pub fn calculate_utility_score_v0<'info>(
+    ctx: Context<'_, '_, 'info, 'info, CalculateUtilityScoreV0<'info>>,
     args: CalculateUtilityScoreArgsV0,
   ) -> Result<()> {
     calculate_utility_score_v0::handler(ctx, args)

--- a/programs/helium-sub-daos/src/state.rs
+++ b/programs/helium-sub-daos/src/state.rs
@@ -176,6 +176,13 @@ pub struct DaoEpochInfoV0 {
   pub cumulative_not_emitted: u64,
   pub not_emitted: u64,
   pub smoothed_hnt_burned: u64,
+  // HIP 149 Decision 1 backstop. The Mobile data deployer earnings ceiling in HNT
+  // (3 x carrier-paid USD this epoch, converted at the epoch's HNT price).
+  // issue_rewards_v0 reads this on the Mobile pass to redirect any overflow above
+  // the cap from the rewards escrow to the shared delegator pool. The price itself
+  // is not stored: it is recoverable as (dc_burned * 3 * decimals_factor) /
+  // deployer_cap_hnt, or from the public Pyth feed at the epoch timestamp.
+  pub deployer_cap_hnt: u64,
 }
 
 impl DaoEpochInfoV0 {

--- a/programs/helium-sub-daos/src/supplement.rs
+++ b/programs/helium-sub-daos/src/supplement.rs
@@ -1,0 +1,166 @@
+//! HIP 149 Decision 2: the operations-and-growth supplement.
+//!
+//! A per-epoch HNT mint into a Receiving-Entity Squads vault, bounded at deploy by two
+//! hardcoded timestamps: a flat-rate first window (~12 months at ~196,000 HNT/day total)
+//! followed by a linear taper to zero (~24 months). Both windows self-terminate; no vote
+//! or manual halt is needed to end them.
+//!
+//! The mint happens in `issue_rewards_v0`, once per sub-DAO pass, each minting
+//! `supplement_per_subdao(now)` so the two passes sum to the full daily rate.
+//! `calculate_utility_score_v0` adds the same total back into `current_hnt_supply` so the
+//! supplement isn't misread as burned HNT (see the supply-tracking note there).
+//!
+//! All parameters are hardcoded; changing them requires a community-voted program
+//! upgrade. Several are **patch-time** values set just before the mainnet deploy — by
+//! default they leave the supplement INACTIVE (a far-future start), so the program is safe
+//! to ship before they're finalized.
+
+use anchor_lang::prelude::*;
+
+const EPOCH_LENGTH: i64 = 24 * 60 * 60;
+
+// ── Patch-time constants ─────────────────────────────────────────────────────────────
+// PATCH-TIME: set INFLATION_START to the real mint-start unix timestamp (the upgrade slot
+// + ~2 weeks, the Council pre-mint review window) before the mainnet deploy. The default
+// is a far-future sentinel (2100-01-01) so the supplement stays dormant until deliberately
+// configured — shipping without setting it mints nothing, and the test suite (which runs
+// at present-day wall-clock) sees a zero supplement and is unaffected.
+pub const INFLATION_START: i64 = 4_102_444_800;
+
+/// End of the flat window (~12 months / ~360 epochs after the start).
+pub const INFLATION_FLAT_END: i64 = INFLATION_START + 360 * EPOCH_LENGTH;
+
+/// End of the taper window (~24 months / ~720 epochs after the flat window).
+pub const INFLATION_TAPER_END: i64 = INFLATION_START + (360 + 720) * EPOCH_LENGTH;
+
+/// Flat per-epoch mint **per sub-DAO**. Two sub-DAO passes per epoch sum to ~196,000
+/// HNT/day. (98,000 HNT in bones.)
+pub const INFLATION_FLAT_PER_EPOCH_PER_SUBDAO: u64 = 98_000 * 100_000_000;
+
+/// Taper starting per-epoch-per-sub-DAO rate; equal to the flat rate for a smooth handoff,
+/// then decaying linearly to zero across the taper window.
+pub const INFLATION_TAPER_INITIAL_PER_EPOCH_PER_SUBDAO: u64 = INFLATION_FLAT_PER_EPOCH_PER_SUBDAO;
+
+// PATCH-TIME: the Receiving Entity's Squads vault that receives the supplement. Placeholder
+// (the system program id); set to the real vault before deploy. issue_rewards_v0 checks the
+// supplied supplement token account is owned by this key (relaxed under TESTING).
+pub const SUPPLEMENT_VAULT_OWNER: Pubkey = pubkey!("11111111111111111111111111111111");
+
+// ── HIP 149 Decision 4: Advisory Council compensation carve-out ─────────────────────────
+/// The community-nominated Council seats share 1.25% of the supplement (HIP 149 Decision 4).
+/// This is a carve-out *of* the per-epoch supplement, not an addition: issue_rewards_v0 mints
+/// this share to the Council fanout and the remainder to the Receiving Entity vault, so the
+/// two sum to the full per-epoch supplement and the supply-tracking correction is unchanged.
+/// Expressed in basis points; the HIP caps the total at 1.25%, so this is a ceiling.
+pub const COUNCIL_COMPENSATION_BPS: u64 = 125;
+
+// PATCH-TIME: the Council compensation fanout's HNT token account (a mini_fanout PDA-owned
+// ATA). Placeholder (the system program id); set to the real fanout token account before
+// deploy. issue_rewards_v0 requires the supplied Council token account to equal this key
+// (relaxed under TESTING). The fanout's `owner` (who edits the seated-member set) is the
+// governance multisig, never the Receiving Entity; see the create-council-fanout tooling.
+pub const COUNCIL_FANOUT_TOKEN_ACCOUNT: Pubkey = pubkey!("11111111111111111111111111111111");
+
+/// The Council compensation carve-out (1.25%) of a per-sub-DAO supplement amount. The
+/// remainder (`supplement - council_cut`) goes to the Receiving Entity vault.
+pub fn council_cut(supplement_per_subdao: u64) -> u64 {
+  ((supplement_per_subdao as u128) * (COUNCIL_COMPENSATION_BPS as u128) / 10_000) as u64
+}
+
+/// Per-sub-DAO supplement mint for `now`, using the configured windows/rates.
+/// Zero outside both windows.
+pub fn supplement_per_subdao(now: i64) -> u64 {
+  supplement_amount(
+    now,
+    INFLATION_START,
+    INFLATION_FLAT_END,
+    INFLATION_TAPER_END,
+    INFLATION_FLAT_PER_EPOCH_PER_SUBDAO,
+    INFLATION_TAPER_INITIAL_PER_EPOCH_PER_SUBDAO,
+  )
+}
+
+/// Pure windowing math (parameterized for testing): flat rate during the first window,
+/// linear taper to zero during the second, zero otherwise.
+fn supplement_amount(
+  now: i64,
+  start: i64,
+  flat_end: i64,
+  taper_end: i64,
+  flat_rate: u64,
+  taper_initial: u64,
+) -> u64 {
+  if now >= start && now < flat_end {
+    flat_rate
+  } else if now >= flat_end && now < taper_end {
+    let remaining = taper_end.saturating_sub(now) as u128;
+    let total = (taper_end - flat_end) as u128;
+    (taper_initial as u128)
+      .saturating_mul(remaining)
+      .checked_div(total)
+      .unwrap_or(0) as u64
+  } else {
+    0
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // Explicit windows so the test doesn't depend on the TESTING-gated consts.
+  const START: i64 = 1_000_000;
+  const FLAT_END: i64 = START + 360 * EPOCH_LENGTH;
+  const TAPER_END: i64 = FLAT_END + 720 * EPOCH_LENGTH;
+  const FLAT: u64 = 98_000 * 100_000_000;
+
+  fn amt(now: i64) -> u64 {
+    supplement_amount(now, START, FLAT_END, TAPER_END, FLAT, FLAT)
+  }
+
+  #[test]
+  fn zero_before_start() {
+    assert_eq!(amt(START - 1), 0);
+  }
+
+  #[test]
+  fn flat_rate_during_first_window() {
+    assert_eq!(amt(START), FLAT);
+    assert_eq!(amt(START + 100 * EPOCH_LENGTH), FLAT);
+    assert_eq!(amt(FLAT_END - 1), FLAT);
+  }
+
+  #[test]
+  fn taper_decays_linearly_to_zero() {
+    // Start of taper ~ full rate.
+    assert_eq!(amt(FLAT_END), FLAT);
+    // Midpoint ~ half rate.
+    let mid = FLAT_END + (TAPER_END - FLAT_END) / 2;
+    let m = amt(mid);
+    assert!(
+      (m as i128 - (FLAT as i128 / 2)).abs() < (FLAT as i128 / 1000),
+      "taper midpoint {m} should be ~half of {FLAT}"
+    );
+    // Just before the end ~ near zero, and monotonic decreasing.
+    assert!(amt(TAPER_END - EPOCH_LENGTH) < FLAT / 100);
+    assert!(amt(FLAT_END + 10 * EPOCH_LENGTH) > amt(FLAT_END + 11 * EPOCH_LENGTH));
+  }
+
+  #[test]
+  fn zero_at_and_after_taper_end() {
+    assert_eq!(amt(TAPER_END), 0);
+    assert_eq!(amt(TAPER_END + 1_000_000), 0);
+  }
+
+  #[test]
+  fn council_cut_is_125_bps_and_splits_cleanly() {
+    // Flat per-sub-DAO amount: 1.25% carve-out, remainder to the vault, summing exactly.
+    let council = council_cut(FLAT);
+    assert_eq!(council, FLAT * 125 / 10_000);
+    assert_eq!(council + (FLAT - council), FLAT);
+    // A tiny tapered amount can round the carve-out to zero without underflowing.
+    assert_eq!(council_cut(0), 0);
+    assert_eq!(council_cut(79), 0); // 79 * 125 / 10000 == 0
+    assert_eq!(council_cut(80), 1); // 80 * 125 / 10000 == 1
+  }
+}

--- a/programs/helium-sub-daos/src/supplement.rs
+++ b/programs/helium-sub-daos/src/supplement.rs
@@ -41,10 +41,13 @@ pub const INFLATION_FLAT_PER_EPOCH_PER_SUBDAO: u64 = 98_000 * 100_000_000;
 /// then decaying linearly to zero across the taper window.
 pub const INFLATION_TAPER_INITIAL_PER_EPOCH_PER_SUBDAO: u64 = INFLATION_FLAT_PER_EPOCH_PER_SUBDAO;
 
-// PATCH-TIME: the Receiving Entity's Squads vault that receives the supplement. Placeholder
-// (the system program id); set to the real vault before deploy. issue_rewards_v0 checks the
-// supplied supplement token account is owned by this key (relaxed under TESTING).
-pub const SUPPLEMENT_VAULT_OWNER: Pubkey = pubkey!("11111111111111111111111111111111");
+// PATCH-TIME: the Receiving Entity's Squads vault HNT token account that receives the
+// supplement. Placeholder (the system program id); set to the real token account before
+// deploy. issue_rewards_v0 requires the supplied supplement token account to equal this key
+// (relaxed under TESTING), pinned to the exact account — like COUNCIL_FANOUT_TOKEN_ACCOUNT —
+// rather than only checking the token-account authority, so a caller cannot route the
+// supplement to a different account under the same authority (I-03).
+pub const SUPPLEMENT_VAULT_TOKEN_ACCOUNT: Pubkey = pubkey!("11111111111111111111111111111111");
 
 // ── HIP 149 Decision 4: Advisory Council compensation carve-out ─────────────────────────
 /// The community-nominated Council seats share 1.25% of the supplement (HIP 149 Decision 4).

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -5,7 +5,7 @@ use helium_sub_daos::{
   accounts::CalculateUtilityScoreV0, instruction::IssueRewardsV0, CalculateUtilityScoreArgsV0,
   DaoV0, IssueRewardsArgsV0, SubDaoV0,
 };
-use spl_token::solana_program::instruction::Instruction;
+use spl_token::solana_program::instruction::{AccountMeta, Instruction};
 use tuktuk_program::{
   compile_transaction,
   write_return_tasks::{write_return_tasks, AccountWithSeeds, PayerInfo, WriteReturnTasksArgs},
@@ -33,6 +33,10 @@ pub struct QueueEndEpoch<'info> {
   pub dao: Box<Account<'info, DaoV0>>,
   pub iot_sub_dao: Box<Account<'info, SubDaoV0>>,
   pub mobile_sub_dao: Box<Account<'info, SubDaoV0>>,
+  /// CHECK: The HNT/USD Pyth price account, forwarded into each
+  /// calculate_utility_score_v0 for the HIP 149 backstop. Its feed id and
+  /// verification level are validated by that instruction's constraints.
+  pub hnt_price_oracle: UncheckedAccount<'info>,
   /// CHECK: We init this when writing
   #[account(
     mut,
@@ -44,6 +48,18 @@ pub struct QueueEndEpoch<'info> {
   #[account(constraint = *task_queue.owner == tuktuk_program::tuktuk::ID)]
   pub task_queue: UncheckedAccount<'info>,
   pub system_program: Program<'info, System>,
+}
+
+fn sub_dao_epoch_info_pda(sub_dao: &Pubkey, epoch: u64) -> Pubkey {
+  Pubkey::find_program_address(
+    &[
+      b"sub_dao_epoch_info",
+      sub_dao.as_ref(),
+      &epoch.to_le_bytes(),
+    ],
+    &helium_sub_daos::ID,
+  )
+  .0
 }
 
 pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
@@ -96,25 +112,8 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     .iter()
     .map(|sub_dao| {
       let sub_dao_key = sub_dao.key();
-      let prev_sub_dao_epoch_info = Pubkey::find_program_address(
-        &[
-          b"sub_dao_epoch_info",
-          sub_dao_key.as_ref(),
-          &prev_epoch.to_le_bytes(),
-        ],
-        &helium_sub_daos::ID,
-      )
-      .0;
-
-      let sub_dao_epoch_info = Pubkey::find_program_address(
-        &[
-          b"sub_dao_epoch_info",
-          sub_dao_key.as_ref(),
-          &curr_epoch.to_le_bytes(),
-        ],
-        &helium_sub_daos::ID,
-      )
-      .0;
+      let prev_sub_dao_epoch_info = sub_dao_epoch_info_pda(&sub_dao_key, prev_epoch);
+      let sub_dao_epoch_info = sub_dao_epoch_info_pda(&sub_dao_key, curr_epoch);
 
       (
         sub_dao,
@@ -125,31 +124,43 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     })
     .collect();
 
+  // HIP 149 backstop: every calculate_utility_score_v0 (both the IoT and Mobile pass)
+  // reads the Mobile sub-DAO's current- and previous-epoch info to size the deployer
+  // top-up, so total_rewards is independent of sub-DAO ordering. These are passed as
+  // read-only remaining accounts and located on-chain by PDA.
+  let mobile_sub_dao_key = ctx.accounts.mobile_sub_dao.key();
+  let mobile_curr_epoch_info = sub_dao_epoch_info_pda(&mobile_sub_dao_key, curr_epoch);
+  let mobile_prev_epoch_info = sub_dao_epoch_info_pda(&mobile_sub_dao_key, prev_epoch);
+
   // Add all calculate instructions
   for (_, sub_dao_key, prev_sub_dao_epoch_info, sub_dao_epoch_info) in sub_dao_infos.iter() {
+    let mut accounts = CalculateUtilityScoreV0 {
+      payer: ctx.accounts.payer.key(),
+      registrar: ctx.accounts.dao.registrar,
+      dao: dao_key,
+      hnt_mint,
+      sub_dao: *sub_dao_key,
+      prev_dao_epoch_info,
+      dao_epoch_info,
+      sub_dao_epoch_info: *sub_dao_epoch_info,
+      system_program: system_program::ID,
+      token_program: spl_token::ID,
+      circuit_breaker_program: CIRCUIT_BREAKER_PROGRAM,
+      prev_sub_dao_epoch_info: *prev_sub_dao_epoch_info,
+      not_emitted_counter: Pubkey::find_program_address(
+        &[b"not_emitted_counter", hnt_mint.as_ref()],
+        &no_emit::ID,
+      )
+      .0,
+      no_emit_program: no_emit::ID,
+      hnt_price_oracle: Some(ctx.accounts.hnt_price_oracle.key()),
+    }
+    .to_account_metas(None);
+    accounts.push(AccountMeta::new_readonly(mobile_curr_epoch_info, false));
+    accounts.push(AccountMeta::new_readonly(mobile_prev_epoch_info, false));
     ixs.push(Instruction {
       program_id: helium_sub_daos::ID,
-      accounts: CalculateUtilityScoreV0 {
-        payer: ctx.accounts.payer.key(),
-        registrar: ctx.accounts.dao.registrar,
-        dao: dao_key,
-        hnt_mint,
-        sub_dao: *sub_dao_key,
-        prev_dao_epoch_info,
-        dao_epoch_info,
-        sub_dao_epoch_info: *sub_dao_epoch_info,
-        system_program: system_program::ID,
-        token_program: spl_token::ID,
-        circuit_breaker_program: CIRCUIT_BREAKER_PROGRAM,
-        prev_sub_dao_epoch_info: *prev_sub_dao_epoch_info,
-        not_emitted_counter: Pubkey::find_program_address(
-          &[b"not_emitted_counter", hnt_mint.as_ref()],
-          &no_emit::ID,
-        )
-        .0,
-        no_emit_program: no_emit::ID,
-      }
-      .to_account_metas(None),
+      accounts,
       data: calc_args.data(),
     });
   }
@@ -173,6 +184,12 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
         treasury: sub_dao.treasury,
         rewards_escrow: ctx.accounts.dao.rewards_escrow,
         delegator_pool: ctx.accounts.dao.delegator_pool,
+        // HIP 149 Decision 2 supplement vault + Decision 4 Council fanout. None while the
+        // supplement window is inactive (the default). At patch-time activation, set these to
+        // the Receiving Entity vault's HNT ATA and the Council fanout's HNT token account
+        // before rescheduling the cron.
+        supplement_vault: None,
+        council_vault: None,
       }
       .to_account_metas(None),
       data: reward_args.data(),
@@ -215,6 +232,7 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
       dao: ctx.accounts.dao.to_account_info(),
       iot_sub_dao: ctx.accounts.iot_sub_dao.to_account_info(),
       mobile_sub_dao: ctx.accounts.mobile_sub_dao.to_account_info(),
+      hnt_price_oracle: ctx.accounts.hnt_price_oracle.to_account_info(),
       task_return_account: ctx.accounts.task_return_account.to_account_info(),
       task_queue: ctx.accounts.task_queue.to_account_info(),
       epoch_tracker: ctx.accounts.epoch_tracker.to_account_info(),

--- a/tests/dc-auto-topoff.ts
+++ b/tests/dc-auto-topoff.ts
@@ -56,6 +56,7 @@ import {
 import {
   createDcaServer,
   runAllTasks as runAllTasksUtil,
+  calculateExpectedOutput,
 } from "./utils/dca-test-server";
 import { Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { customSignerKey } from "@helium/tuktuk-sdk";
@@ -671,7 +672,19 @@ describe("dc-auto-topoff", () => {
         provider.connection,
         getAssociatedTokenAddressSync(hntMint, autoTopOff, true)
       );
-      const expectedAfterFirstSwap = startingHnt.add(hntPerSwap);
+      // The swap output is derived forward from dcaSwapAmount (the same way the
+      // DCA server computes it), not the idealized hntPerSwap target. Because
+      // dcaSwapAmount is rounded (truncate + `+1`) with a *100 decimal scaling,
+      // the roundtrip overshoots hntPerSwap by up to ~inputPrice/outputPrice*100
+      // bones, which varies with the live (cloned) oracle price ratio. Assert
+      // against the actual server output so the test is price-independent.
+      const expectedAfterFirstSwap = startingHnt.add(
+        calculateExpectedOutput(
+          dcaSwapAmount,
+          inputPriceUpdate,
+          outputPriceUpdate
+        )
+      );
       // Allow for 1 bone tolerance due to rounding in DCA calculations
       const actualAmount = new anchor.BN(
         hntAccountAfterFirstSwap.amount.toString()

--- a/tests/helium-sub-daos.ts
+++ b/tests/helium-sub-daos.ts
@@ -1,5 +1,6 @@
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
+import { PythSolanaReceiver } from "@pythnetwork/pyth-solana-receiver";
 import { init as cbInit } from "@helium/circuit-breaker-sdk";
 import { Keypair as HeliumKeypair } from "@helium/crypto";
 import {
@@ -1073,9 +1074,23 @@ describe("helium-sub-daos", () => {
               // Delivered Mobile data deployer HNT = total_rewards x mobile_share x 0.70.
               const alpha = (mobileShare / 0xffffffff) * 0.7;
               const delivered = di.totalRewards.toNumber() * alpha;
-              // Price-derived target: deployer_cap_hnt is 3x carrier-paid USD in HNT, the
-              // floor target is 0.5x => target == cap / 6. The floor should deliver it.
-              const target = di.deployerCapHnt.toNumber() / 6;
+              // deployer_cap_hnt is 3x carrier-paid USD converted at the EMA point price;
+              // the floor target is 0.5x converted at the lower-bound price (ema - 2*conf).
+              // So target == (cap / 6) x (ema / price_lower), not simply cap / 6 (the two
+              // coincide only at zero confidence). Read the cloned mainnet price to
+              // reconstruct the ratio.
+              const pythReceiver = new PythSolanaReceiver({
+                connection: provider.connection,
+                wallet: provider.wallet as any,
+              });
+              const priceAcc = await pythReceiver.fetchPriceUpdateAccount(
+                HNT_PYTH_PRICE_FEED
+              );
+              const emaPrice = priceAcc!.priceMessage.emaPrice.toNumber();
+              const emaConf = priceAcc!.priceMessage.emaConf.toNumber();
+              const priceLower = emaPrice - 2 * emaConf;
+              const target =
+                (di.deployerCapHnt.toNumber() / 6) * (emaPrice / priceLower);
 
               expect(mobileShare).to.be.greaterThan(0);
               expect(delivered).to.be.closeTo(target, target * 0.02);

--- a/tests/helium-sub-daos.ts
+++ b/tests/helium-sub-daos.ts
@@ -14,6 +14,7 @@ import { Proposal } from "@helium/modular-governance-idls/lib/types/proposal";
 import { init as initProposal } from "@helium/proposal-sdk";
 import { init as initProxy } from "@helium/nft-proxy-sdk";
 import {
+  HNT_PYTH_PRICE_FEED,
   createAtaAndMint,
   createAtaAndTransfer,
   createMint,
@@ -375,7 +376,7 @@ describe("helium-sub-daos", () => {
 
         const method = program.methods
           .calculateUtilityScoreV0({ epoch })
-          .accountsPartial({ subDao, dao });
+          .accountsPartial({ subDao, dao, hntPriceOracle: null });
 
         const { daoEpochInfo } = await method.pubkeys();
         await method.rpc({ skipPreflight: true });
@@ -408,6 +409,65 @@ describe("helium-sub-daos", () => {
       expect(firstEpoch.daoEpochInfoAcc.currentHntSupply.toString()).to.eq(
         new BN(supply.toString()).add(new BN(expectedRewards)).toString()
       );
+    });
+
+    describe("HIP 149 backstop", () => {
+      it("computes the deployer cap when an oracle is supplied", async () => {
+        await vsrProgram.methods
+          .setTimeOffsetV0(new BN(1 * 60 * 60 * 24))
+          .accountsPartial({ registrar })
+          .rpc({ skipPreflight: true });
+
+        // Carrier-paid DC burn for the epoch; drives the 3x earnings-cap ceiling.
+        const { subDaoEpochInfo } = await burnDc(50000);
+        const epoch = (
+          await program.account.subDaoEpochInfoV0.fetch(subDaoEpochInfo)
+        ).epoch;
+
+        const method = program.methods
+          .calculateUtilityScoreV0({ epoch })
+          .preInstructions([
+            ComputeBudgetProgram.setComputeUnitLimit({ units: 400000 }),
+          ])
+          .accountsPartial({
+            subDao,
+            dao,
+            // HNT/USD Pyth push account, cloned from mainnet by the test validator.
+            hntPriceOracle: HNT_PYTH_PRICE_FEED,
+          });
+        const { daoEpochInfo } = await method.pubkeys();
+        await method.rpc({ skipPreflight: true });
+
+        const acc = await program.account.daoEpochInfoV0.fetch(daoEpochInfo!);
+        // 3x-carrier-paid earnings ceiling computed from dc_burned + price.
+        expect(acc.deployerCapHnt.toNumber()).to.be.greaterThan(0);
+      });
+
+      it("stays dormant (no cap) when no oracle is supplied", async () => {
+        await vsrProgram.methods
+          .setTimeOffsetV0(new BN(1 * 60 * 60 * 24))
+          .accountsPartial({ registrar })
+          .rpc({ skipPreflight: true });
+
+        const { subDaoEpochInfo } = await burnDc(50000);
+        const epoch = (
+          await program.account.subDaoEpochInfoV0.fetch(subDaoEpochInfo)
+        ).epoch;
+
+        const method = program.methods
+          .calculateUtilityScoreV0({ epoch })
+          .preInstructions([
+            ComputeBudgetProgram.setComputeUnitLimit({ units: 400000 }),
+          ])
+          .accountsPartial({ subDao, dao, hntPriceOracle: null });
+        const { daoEpochInfo } = await method.pubkeys();
+        await method.rpc({ skipPreflight: true });
+
+        const acc = await program.account.daoEpochInfoV0.fetch(daoEpochInfo!);
+        // No oracle => backstop dormant: no ceiling.
+        expect(acc.deployerCapHnt.toNumber()).to.eq(0);
+      });
+
     });
 
     describe("with position", () => {
@@ -445,6 +505,7 @@ describe("helium-sub-daos", () => {
           .accountsPartial({
             subDao,
             dao,
+            hntPriceOracle: null,
           })
           .rpc({ skipPreflight: true });
 
@@ -670,6 +731,7 @@ describe("helium-sub-daos", () => {
             .accountsPartial({
               subDao,
               dao,
+              hntPriceOracle: null,
             });
 
           const pubkeys = await instr.pubkeys();
@@ -889,6 +951,137 @@ describe("helium-sub-daos", () => {
             );
           });
 
+          describe("HIP 149 cap redirect", () => {
+            it("redirects data-bucket overflow above the cap to the delegator pool", async () => {
+              await vsrProgram.methods
+                .setTimeOffsetV0(new BN(1 * 60 * 60 * 24))
+                .accountsPartial({ registrar })
+                .rpc({ skipPreflight: true });
+
+              // Tiny carrier burn => a very low 3x earnings ceiling, so almost the
+              // entire Mobile data bucket sits above the cap and must overflow to
+              // stakers (escrow -> delegator pool) in issue_rewards_v0.
+              const { subDaoEpochInfo } = await burnDc(10);
+              const epoch = (
+                await program.account.subDaoEpochInfoV0.fetch(subDaoEpochInfo)
+              ).epoch;
+
+              await program.methods
+                .calculateUtilityScoreV0({ epoch })
+                .preInstructions([
+                  ComputeBudgetProgram.setComputeUnitLimit({ units: 400000 }),
+                ])
+                .accountsPartial({
+                  subDao,
+                  dao,
+                  hntPriceOracle: HNT_PYTH_PRICE_FEED,
+                })
+                .rpc({ skipPreflight: true });
+
+              await program.methods
+                .issueRewardsV0({ epoch })
+                .accountsPartial({ subDao, supplementVault: null, councilVault: null })
+                .rpc({ skipPreflight: true });
+
+              const acc = await program.account.subDaoEpochInfoV0.fetch(
+                subDaoEpochInfo
+              );
+              // Cap binding hard: the redirected overflow makes the delegator-pool
+              // mint exceed the trimmed rewards escrow (normally escrow >> the 6%
+              // delegator slice), proving the escrow->delegator redirect fired.
+              expect(acc.delegationRewardsIssued.toNumber()).to.be.greaterThan(
+                acc.hntRewardsIssued.toNumber()
+              );
+              expect(acc.hntRewardsIssued.toNumber()).to.be.greaterThan(0);
+            });
+          });
+
+          describe("HIP 149 floor delivery", () => {
+            it("tops deployers up to the price-derived 0.5x-carrier target", async () => {
+              // Set net_emissions_cap = 0 so the top-up's burn budget is just
+              // smoothed_hnt_burned; then a real HNT burn (below) makes that budget far
+              // exceed demand, so the top-up is the full price-derived amount (unclamped).
+              await program.methods
+                .updateDaoV0({
+                  authority: null,
+                  emissionSchedule: null,
+                  hstEmissionSchedule: null,
+                  hstPool: null,
+                  netEmissionsCap: new BN(0),
+                  proposalNamespace: null,
+                  delegatorRewardsPercent: null,
+                  rewardsEscrow: null,
+                })
+                .accountsPartial({ dao })
+                .rpc({ skipPreflight: true });
+
+              // Epoch 1: calculate to record supply and give the sub-DAO a utility score
+              // (so epoch 2's bootstrap sets a non-zero Mobile percent share).
+              await vsrProgram.methods
+                .setTimeOffsetV0(new BN(1 * 60 * 60 * 24))
+                .accountsPartial({ registrar })
+                .rpc({ skipPreflight: true });
+              const epoch1 = (
+                await burnDc(1)
+              ).subDaoEpochInfo;
+              const e1 = (
+                await program.account.subDaoEpochInfoV0.fetch(epoch1)
+              ).epoch;
+              await program.methods
+                .calculateUtilityScoreV0({ epoch: e1 })
+                .preInstructions([
+                  ComputeBudgetProgram.setComputeUnitLimit({ units: 400000 }),
+                ])
+                .accountsPartial({ subDao, dao, hntPriceOracle: HNT_PYTH_PRICE_FEED })
+                .rpc({ skipPreflight: true });
+
+              // Epoch 2: a large carrier burn drives a 0.5x-carrier target well above the
+              // deployer baseline, and burns ~100k HNT so smoothed_hnt_burned (the budget)
+              // dwarfs demand. The same Mobile sub-DAO epoch-info account is its prev next.
+              await vsrProgram.methods
+                .setTimeOffsetV0(new BN(2 * 60 * 60 * 24))
+                .accountsPartial({ registrar })
+                .rpc({ skipPreflight: true });
+              const { subDaoEpochInfo } = await burnDc(100000);
+              const epoch = (
+                await program.account.subDaoEpochInfoV0.fetch(subDaoEpochInfo)
+              ).epoch;
+
+              const calc = () =>
+                program.methods
+                  .calculateUtilityScoreV0({ epoch })
+                  .preInstructions([
+                    ComputeBudgetProgram.setComputeUnitLimit({ units: 400000 }),
+                  ])
+                  .accountsPartial({
+                    subDao,
+                    dao,
+                    hntPriceOracle: HNT_PYTH_PRICE_FEED,
+                  });
+              const { daoEpochInfo, prevSubDaoEpochInfo } =
+                await calc().pubkeys();
+              // First pass bootstraps the prev-epoch Mobile share to non-zero; recalc
+              // (TESTING) then sizes the top-up against it.
+              await calc().rpc({ skipPreflight: true });
+              await calc().rpc({ skipPreflight: true });
+
+              const di = await program.account.daoEpochInfoV0.fetch(daoEpochInfo!);
+              const mobileShare = (
+                await program.account.subDaoEpochInfoV0.fetch(prevSubDaoEpochInfo)
+              ).previousPercentage;
+
+              // Delivered Mobile data deployer HNT = total_rewards x mobile_share x 0.70.
+              const alpha = (mobileShare / 0xffffffff) * 0.7;
+              const delivered = di.totalRewards.toNumber() * alpha;
+              // Price-derived target: deployer_cap_hnt is 3x carrier-paid USD in HNT, the
+              // floor target is 0.5x => target == cap / 6. The floor should deliver it.
+              const target = di.deployerCapHnt.toNumber() / 6;
+
+              expect(mobileShare).to.be.greaterThan(0);
+              expect(delivered).to.be.closeTo(target, target * 0.02);
+            });
+          });
+
           describe("with multiple delegated vehnt", () => {
             let basePosition: PublicKey;
             let basePositionOptions = {
@@ -945,13 +1138,7 @@ describe("helium-sub-daos", () => {
                 })
                 .signers([positionAuthorityKp]);
 
-              const { delegatedPosition, subDaoEpochInfo } =
-                await method.pubkeys();
-              // const sed = await program.account.subDaoEpochInfoV0.fetch(
-              //   subDaoEpochInfo!
-              // );
-              // console.log(sed.fallRatesFromClosingPositions.toString());
-              // console.log(sed.vehntInClosingPositions.toString());
+              const { delegatedPosition } = await method.pubkeys();
               await method.rpc({ skipPreflight: true });
 
               const sdAcc = await program.account.subDaoV0.fetch(subDao);
@@ -1015,6 +1202,7 @@ describe("helium-sub-daos", () => {
                 .accountsPartial({
                   subDao,
                   dao,
+                  hntPriceOracle: null,
                 })
                 .rpc({ skipPreflight: true });
             });
@@ -1029,31 +1217,16 @@ describe("helium-sub-daos", () => {
               const preHntBalance = AccountLayout.decode(
                 (await provider.connection.getAccountInfo(rewardsEscrow))?.data!
               ).amount;
-              const {
-                pubkeys: { prevSubDaoEpochInfo, daoEpochInfo },
-              } = await program.methods
+              await program.methods
                 .issueRewardsV0({
                   epoch,
                 })
                 .accountsPartial({
                   subDao,
+                  supplementVault: null,
+                  councilVault: null,
                 })
-                .rpcAndKeys({ skipPreflight: true });
-
-              console.log(
-                "subDaoEpochInfo",
-                await program.account.subDaoEpochInfoV0.fetch(subDaoEpochInfo!)
-              );
-              console.log(
-                "prevSubDaoEpochInfo",
-                await program.account.subDaoEpochInfoV0.fetch(
-                  prevSubDaoEpochInfo!
-                )
-              );
-              console.log(
-                "daoEpochInfo",
-                await program.account.daoEpochInfoV0.fetch(daoEpochInfo!)
-              );
+                .rpc({ skipPreflight: true });
 
               const postTreasuryBalance = AccountLayout.decode(
                 (await provider.connection.getAccountInfo(treasury))?.data!
@@ -1160,6 +1333,8 @@ describe("helium-sub-daos", () => {
                   })
                   .accountsPartial({
                     subDao,
+                    supplementVault: null,
+                    councilVault: null,
                   })
                   .instruction(),
               ]);

--- a/tests/utils/daos.ts
+++ b/tests/utils/daos.ts
@@ -146,7 +146,11 @@ export async function initTestSubdao(
       activeDeviceAuthority: activeDeviceAuthority || authority,
     })
     .preInstructions([
-      ComputeBudgetProgram.setComputeUnitLimit({ units: 350000 }),
+      // Generous headroom: this tx creates the sub-DAO's rewardable-entity
+      // collection via a Metaplex master edition, and Metaplex is cloned live from
+      // mainnet in tests, so its CU cost drifts. 350k sat right at the ceiling and
+      // tripped intermittently; unused CU isn't charged, so set the max.
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
     ])
     .accountsPartial({
       dao,


### PR DESCRIPTION
Implements the complete on-chain (`helium-program-library`) surface of HIP 149: the
Decision 1 deployer earnings backstop, the Decision 2 operations and growth
supplement, and the Decision 4 Council compensation carve-out. Decision 3 (PoC
retirement) is verifier-oracle work and lands separately; the Decision 4 curtailment
and vacancy provisions are governance/program-upgrade actions with no on-chain code.

## Decision 1 — deployer earnings backstop

- **Floor (top-up):** when the Mobile data deployer baseline falls below half the
  carrier-paid USD for the epoch, mint a top-up so deployers reach that target.
  Bounded by `max(0, smoothed_hnt_burned - net_emissions_cap)` so the top-up and the
  existing HIP 20 net-emissions re-emit share one burn budget and never re-mint the
  same destroyed HNT twice.
- **Cap (overflow to stakers):** when the data bucket would pay deployers more than
  3x the carrier-paid USD, redirect the excess from the rewards escrow to the
  delegator pool. `total_rewards` unchanged; net-supply-neutral.
- HNT/USD from the maintained on-chain Pyth push account (`HNT_PYTH_PRICE_FEED`), the
  same feed the price oracle already uses to price rewards.
- **Fail-safe:** a missing, stale, malformed, or wrong-feed price — or absent Mobile
  epoch-info accounts — makes the backstop dormant for that epoch (baseline emission
  + existing re-emit, no top-up/cap) rather than failing the instruction.

## Decision 2 — operations and growth supplement

- A per-epoch HNT mint bounded by two hardcoded timestamps: a flat first window then
  a linear taper to zero, both self-terminating (no vote or manual halt needed to end
  them). `issue_rewards_v0` mints the per-sub-DAO slice while the window is active.
- `calculate_utility_score_v0` records the same total in `current_hnt_supply` so the
  mint is not misread as burned HNT. Applied there only; adding it to
  `total_hnt_burned` as well would double-count. Verified on a live validator: the
  supply correction equals the minted total exactly, so `smoothed_hnt_burned` reflects
  only carrier burns.
- Ships **INACTIVE by default** (far-future start) so the program is safe to deploy
  and review before the patch-time constants are finalized.

## Decision 4 — Council compensation

- The supplement mint is split: 1.25% to a Council fanout (a `mini_fanout` that
  distributes pro-rata among the seated community members) and the remainder to the
  Receiving Entity vault. The two destinations sum to the per-sub-DAO supplement, so
  total minted and the supply correction are unchanged.
- The Council destination is pinned to a patch-time constant
  (`COUNCIL_FANOUT_TOKEN_ACCOUNT`); the fanout's owner is the governance multisig,
  never the Receiving Entity. `create-council-fanout` (admin-CLI) creates it.

## Commits (organized for security review)

- **Contract** — all Solana program changes (`helium-sub-daos` + `hpl-crons`) in a
  single commit; each program file shows its complete final diff.
- **Tooling** — admin-CLI + spl-utils (price/account wiring, council fanout creation).
- **Tests** — backstop floor/cap/dormant integration tests, the optional-account call
  sites, and a CU-limit bump that stabilizes the world-setup Metaplex CPI. Full
  `helium-sub-daos` suite passes 89/89.

## Deploy-time steps (not code)

- Set the three patch-time constants: `INFLATION_START`, `SUPPLEMENT_VAULT_OWNER`,
  `COUNCIL_FANOUT_TOKEN_ACCOUNT`.
- Run `create-council-fanout` at council-seating, then hardcode its printed token
  account into `COUNCIL_FANOUT_TOKEN_ACCOUNT`.
- Bump the HNT circuit breaker (multisig `update_mint_windowed_breaker_v0`) to cover
  the supplement, and point the cron's `supplement_vault` / `council_vault` at the
  real accounts.

## Not in this PR (tracked separately)

- The `mobile_verifier` change to size the Mobile data pool from the actual escrow so
  the Decision 1 cap's redirect is reflected off-chain, and the Decision 3 PoC
  retirement (Mobile + IoT verifier oracles) — both in the `oracles` repo. The floor
  needs no oracle change; the cap is dormant-correct until that ships.
