### PR TITLE
ci: free runner disk before Docker image builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -153,6 +153,15 @@ jobs:
       - name: Build idls package
         if: startsWith(matrix.test, 'packages/')
         run: pnpm turbo run build --filter=@helium/idls
+      - name: Free disk space
+        # Hosted runners ship ~14GB free but waste tens of GB on toolchains the
+        # Docker build never uses; the heavier images (e.g. blockchain-api) hit
+        # "No space left on device". Reclaim it before building.
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+                      /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h
       - name: Build Docker image
         run: |
           # JS services with turbo prune build from repo root


### PR DESCRIPTION
## Problem

`test-docker-builds` runs `docker build` on `ubuntu-latest` with no disk cleanup. Hosted runners ship ~14GB free but waste tens of GB on preinstalled toolchains the build never uses, so the heavier images — notably `blockchain-api`, a full-monorepo `turbo prune` build — intermittently fail mid-build with:

```
System.IO.IOException: No space left on device
```

(The failure also wipes the job's own logs, since the runner can't write its diagnostics — `gh ... /logs` returns `BlobNotFound`; the cause is only visible in the job's check-run annotations.)

### Observed occurrences

Intermittent — the same job passes on a re-run with no code change — but recurring across runs:

- `blockchain-api` — https://github.com/helium/helium-program-library/actions/runs/28470886187/job/84383200852
- `blockchain-api` — https://github.com/helium/helium-program-library/actions/runs/28455700901/job/84330043557

## Fix

Add a `Free disk space` step before `Build Docker image` that removes the unused toolchains (.NET, GHC, Android SDK, CodeQL — ~30–40GB) and prunes preloaded Docker images. `df -h` is left in the log as a breadcrumb if usage creeps back up.

Inline `rm` rather than a third-party action — same effect, nothing new to trust/pin in CI. No untrusted input, so no workflow-injection surface.