### PR TITLE
feat(blockchain-api): build wallet transactions server-side (tokens, DC, claims, automation, squads, data-only)

### DIFF
--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -22,6 +22,8 @@ jobs:
             file: hotspot-transfer.test.ts
           - name: token-transfer
             file: token-transfer.test.ts
+          - name: data-credits-burn
+            file: data-credits-burn.test.ts
           - name: token-burn-memo
             file: token-burn-memo.test.ts
           - name: update-rewards

--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -30,6 +30,8 @@ jobs:
             file: claim-hotspot-rewards.test.ts
           - name: hotspot-burn
             file: hotspot-burn.test.ts
+          - name: squads-lifecycle
+            file: squads-lifecycle.test.ts
           - name: update-rewards
             file: update-rewards-destination.test.ts
           - name: welcome-pack

--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -32,6 +32,8 @@ jobs:
             file: hotspot-burn.test.ts
           - name: squads-lifecycle
             file: squads-lifecycle.test.ts
+          - name: squads-propose
+            file: squads-propose.test.ts
           - name: update-rewards
             file: update-rewards-destination.test.ts
           - name: welcome-pack

--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -22,6 +22,8 @@ jobs:
             file: hotspot-transfer.test.ts
           - name: token-transfer
             file: token-transfer.test.ts
+          - name: token-burn-memo
+            file: token-burn-memo.test.ts
           - name: update-rewards
             file: update-rewards-destination.test.ts
           - name: welcome-pack

--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -26,6 +26,10 @@ jobs:
             file: data-credits-burn.test.ts
           - name: token-burn-memo
             file: token-burn-memo.test.ts
+          - name: claim-hotspot-rewards
+            file: claim-hotspot-rewards.test.ts
+          - name: hotspot-burn
+            file: hotspot-burn.test.ts
           - name: update-rewards
             file: update-rewards-destination.test.ts
           - name: welcome-pack

--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
+    # Backstop so a hung test (e.g. a stalled RPC) fails fast instead of running
+    # until GitHub's default 6h job timeout and holding a runner.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/packages/blockchain-api-client/src/contracts/data-credits.ts
+++ b/packages/blockchain-api-client/src/contracts/data-credits.ts
@@ -2,6 +2,7 @@ import { oc } from "@orpc/contract";
 import {
   MintDataCreditsInputSchema,
   DelegateDataCreditsInputSchema,
+  BurnDataCreditsInputSchema,
 } from "../schemas/data-credits";
 import { TransactionDataSchema } from "../schemas/common";
 import { BAD_REQUEST } from "../errors/common";
@@ -27,6 +28,18 @@ export const dataCreditsContract = oc.tag("Data Credits").router({
       summary: "Delegate data credits to a router key",
     })
     .input(DelegateDataCreditsInputSchema)
+    .output(TransactionDataSchema)
+    .errors({
+      BAD_REQUEST,
+      INSUFFICIENT_FUNDS,
+    }),
+  burn: oc
+    .route({
+      method: "POST",
+      path: "/data-credits/burn",
+      summary: "Burn data credits",
+    })
+    .input(BurnDataCreditsInputSchema)
     .output(TransactionDataSchema)
     .errors({
       BAD_REQUEST,

--- a/packages/blockchain-api-client/src/contracts/data-credits.ts
+++ b/packages/blockchain-api-client/src/contracts/data-credits.ts
@@ -5,7 +5,7 @@ import {
   BurnDataCreditsInputSchema,
 } from "../schemas/data-credits";
 import { TransactionDataSchema } from "../schemas/common";
-import { BAD_REQUEST } from "../errors/common";
+import { BAD_REQUEST, NOT_FOUND } from "../errors/common";
 import { INSUFFICIENT_FUNDS } from "../errors/solana";
 
 export const dataCreditsContract = oc.tag("Data Credits").router({
@@ -44,5 +44,6 @@ export const dataCreditsContract = oc.tag("Data Credits").router({
     .errors({
       BAD_REQUEST,
       INSUFFICIENT_FUNDS,
+      NOT_FOUND,
     }),
 });

--- a/packages/blockchain-api-client/src/contracts/data-credits.ts
+++ b/packages/blockchain-api-client/src/contracts/data-credits.ts
@@ -32,6 +32,7 @@ export const dataCreditsContract = oc.tag("Data Credits").router({
     .errors({
       BAD_REQUEST,
       INSUFFICIENT_FUNDS,
+      NOT_FOUND,
     }),
   burn: oc
     .route({

--- a/packages/blockchain-api-client/src/contracts/hotspots.ts
+++ b/packages/blockchain-api-client/src/contracts/hotspots.ts
@@ -46,6 +46,10 @@ import {
   RemoveEntityFromAutomationOutputSchema,
   TopUpAutomationInputSchema,
   TopUpAutomationOutputSchema,
+  IssueDataOnlyHotspotInputSchema,
+  IssueDataOnlyHotspotOutputSchema,
+  OnboardDataOnlyHotspotInputSchema,
+  OnboardDataOnlyHotspotOutputSchema,
   UpdateHotspotInfoInputSchema,
   UpdateHotspotInfoOutputSchema,
 } from "../schemas/hotspots";
@@ -306,6 +310,32 @@ export const hotspotsContract = oc
       })
       .input(RemoveEntityFromAutomationInputSchema)
       .output(RemoveEntityFromAutomationOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+    /** Protected: Issue a data-only hotspot (relays the onboarding server) */
+    issueDataOnlyHotspot: oc
+      .route({
+        method: "POST",
+        path: "/data-only/issue",
+        summary: "Issue a data-only hotspot",
+      })
+      .input(IssueDataOnlyHotspotInputSchema)
+      .output(IssueDataOnlyHotspotOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+    /** Protected: Onboard a data-only hotspot (relays the onboarding server) */
+    onboardDataOnlyHotspot: oc
+      .route({
+        method: "POST",
+        path: "/data-only/onboard",
+        summary: "Onboard a data-only hotspot",
+      })
+      .input(OnboardDataOnlyHotspotInputSchema)
+      .output(OnboardDataOnlyHotspotOutputSchema)
       .errors({
         NOT_FOUND,
         INSUFFICIENT_FUNDS,

--- a/packages/blockchain-api-client/src/contracts/hotspots.ts
+++ b/packages/blockchain-api-client/src/contracts/hotspots.ts
@@ -314,7 +314,7 @@ export const hotspotsContract = oc
         NOT_FOUND,
         INSUFFICIENT_FUNDS,
       }),
-    /** Protected: Issue a data-only hotspot (relays the onboarding server) */
+    /** Protected: Issue a data-only hotspot */
     issueDataOnlyHotspot: oc
       .route({
         method: "POST",
@@ -326,8 +326,12 @@ export const hotspotsContract = oc
       .errors({
         NOT_FOUND,
         INSUFFICIENT_FUNDS,
+        BAD_REQUEST: {
+          message: "Invalid add-gateway transaction",
+          status: 400,
+        },
       }),
-    /** Protected: Onboard a data-only hotspot (relays the onboarding server) */
+    /** Protected: Onboard a data-only hotspot */
     onboardDataOnlyHotspot: oc
       .route({
         method: "POST",
@@ -339,6 +343,7 @@ export const hotspotsContract = oc
       .errors({
         NOT_FOUND,
         INSUFFICIENT_FUNDS,
+        BAD_REQUEST: { message: "Invalid onboard parameters", status: 400 },
       }),
     /** Protected: Operator floor top-up for a batch of automations */
     topUpAutomation: oc

--- a/packages/blockchain-api-client/src/contracts/hotspots.ts
+++ b/packages/blockchain-api-client/src/contracts/hotspots.ts
@@ -1,177 +1,267 @@
-import { CONFLICT, INVALID_WALLET_ADDRESS, NOT_FOUND, UNAUTHORIZED } from "../errors/common";
+import {
+  CONFLICT,
+  INVALID_WALLET_ADDRESS,
+  NOT_FOUND,
+  UNAUTHORIZED,
+} from "../errors/common";
 import { INSUFFICIENT_FUNDS } from "../errors/solana";
 import {
-      GetHotspotsInputSchema,
-      HotspotsDataSchema,
-      ClaimRewardsInputSchema,
-      ClaimRewardsOutputSchema,
-      GetPendingRewardsInputSchema,
-      GetPendingRewardsOutputSchema,
-      TransferHotspotInputSchema,
-      TransferHotspotOutputSchema,
-      UpdateRewardsDestinationInputSchema,
-      UpdateRewardsDestinationOutputSchema,
-      GetSplitInputSchema,
-      SplitResponseSchema,
-      CreateSplitInputSchema,
-      CreateSplitOutputSchema,
-      DeleteSplitInputSchema,
-      DeleteSplitOutputSchema,
-      CloseAutomationOutputSchema,
-      CloseAutomationInputSchema,
-      AutomationStatusOutputSchema,
-      GetAutomationStatusInputSchema,
-      FundAutomationOutputSchema,
-      FundAutomationInputSchema,
-      SetupAutomationOutputSchema,
-      SetupAutomationInputSchema,
-      FundingEstimateOutputSchema,
-      GetFundingEstimateInputSchema,
-      UpdateHotspotInfoInputSchema,
-      UpdateHotspotInfoOutputSchema,
+  GetHotspotsInputSchema,
+  HotspotsDataSchema,
+  ClaimRewardsInputSchema,
+  ClaimRewardsOutputSchema,
+  ClaimHotspotRewardsInputSchema,
+  ClaimHotspotRewardsOutputSchema,
+  HotspotBurnInputSchema,
+  HotspotBurnOutputSchema,
+  GetPendingRewardsInputSchema,
+  GetPendingRewardsOutputSchema,
+  TransferHotspotInputSchema,
+  TransferHotspotOutputSchema,
+  UpdateRewardsDestinationInputSchema,
+  UpdateRewardsDestinationOutputSchema,
+  GetSplitInputSchema,
+  SplitResponseSchema,
+  CreateSplitInputSchema,
+  CreateSplitOutputSchema,
+  DeleteSplitInputSchema,
+  DeleteSplitOutputSchema,
+  CloseAutomationOutputSchema,
+  CloseAutomationInputSchema,
+  AutomationStatusOutputSchema,
+  GetAutomationStatusInputSchema,
+  FundAutomationOutputSchema,
+  FundAutomationInputSchema,
+  SetupAutomationOutputSchema,
+  SetupAutomationInputSchema,
+  FundingEstimateOutputSchema,
+  GetFundingEstimateInputSchema,
+  UpdateHotspotInfoInputSchema,
+  UpdateHotspotInfoOutputSchema,
 } from "../schemas/hotspots";
 import { oc } from "@orpc/contract";
 
 export const hotspotsContract = oc
-      .tag("Hotspot")
-      .prefix("/hotspots")
-      .router({
-            /** Public: Get hotspots for a wallet */
-            getHotspots: oc
-                  .route({ method: "GET", path: "/wallet/{walletAddress}", summary: "Get hotspots for a wallet" })
-                  .input(GetHotspotsInputSchema)
-                  .output(HotspotsDataSchema)
-                  .errors({
-                        INVALID_WALLET_ADDRESS
-                  }),
+  .tag("Hotspot")
+  .prefix("/hotspots")
+  .router({
+    /** Public: Get hotspots for a wallet */
+    getHotspots: oc
+      .route({
+        method: "GET",
+        path: "/wallet/{walletAddress}",
+        summary: "Get hotspots for a wallet",
+      })
+      .input(GetHotspotsInputSchema)
+      .output(HotspotsDataSchema)
+      .errors({
+        INVALID_WALLET_ADDRESS,
+      }),
 
-            /** Protected: Claim rewards for hotspots */
-            claimRewards: oc
-                  .route({ method: "POST", path: "/claim-rewards", summary: "Claim all hotspot rewards" })
-                  .input(ClaimRewardsInputSchema)
-                  .output(ClaimRewardsOutputSchema)
-                  .errors({
-                        INSUFFICIENT_FUNDS
-                  }),
+    /** Protected: Claim rewards for hotspots */
+    claimRewards: oc
+      .route({
+        method: "POST",
+        path: "/claim-rewards",
+        summary: "Claim all hotspot rewards",
+      })
+      .input(ClaimRewardsInputSchema)
+      .output(ClaimRewardsOutputSchema)
+      .errors({
+        INSUFFICIENT_FUNDS,
+      }),
 
-            /** Public: Get pending rewards for a wallet */
-            getPendingRewards: oc
-                  .route({ method: "GET", path: "/pending-rewards/{walletAddress}", summary: "Get pending rewards" })
-                  .input(GetPendingRewardsInputSchema)
-                  .output(GetPendingRewardsOutputSchema)
-                  .errors({
-                        BAD_REQUEST: { message: "Invalid wallet address", status: 400 },
-                        INVALID_WALLET_ADDRESS
-                  }),
+    /** Protected: Claim rewards for a single hotspot */
+    claimHotspotRewards: oc
+      .route({
+        method: "POST",
+        path: "/{entityPubKey}/claim-rewards",
+        summary: "Claim rewards for one hotspot",
+      })
+      .input(ClaimHotspotRewardsInputSchema)
+      .output(ClaimHotspotRewardsOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
 
-            /** Protected: Transfer hotspot ownership */
-            transferHotspot: oc
-                  .route({ method: "POST", path: "/transfer", summary: "Transfer ownership" })
-                  .input(TransferHotspotInputSchema)
-                  .output(TransferHotspotOutputSchema)
-                  .errors({
-                        UNAUTHORIZED,
-                        NOT_FOUND,
-                        BAD_REQUEST: { message: "Invalid transfer parameters", status: 400 },
-                        INSUFFICIENT_FUNDS,
-                        CONFLICT,
-                  }),
+    /** Protected: Burn (permanently destroy) a hotspot */
+    burnHotspot: oc
+      .route({ method: "POST", path: "/burn", summary: "Burn a hotspot" })
+      .input(HotspotBurnInputSchema)
+      .output(HotspotBurnOutputSchema)
+      .errors({
+        NOT_FOUND,
+        UNAUTHORIZED,
+        BAD_REQUEST: { message: "Invalid parameters", status: 400 },
+        INSUFFICIENT_FUNDS,
+        CONFLICT,
+      }),
 
-            /** Protected: Update rewards destination */
-            updateRewardsDestination: oc
-                  .route({ method: "POST", path: "/update-rewards-destination", summary: "Update rewards destination" })
-                  .input(UpdateRewardsDestinationInputSchema)
-                  .output(UpdateRewardsDestinationOutputSchema)
-                  .errors({
-                        BAD_REQUEST: { message: "Invalid parameters", status: 400 },
-                        NOT_FOUND,
-                        INSUFFICIENT_FUNDS,
-                  }),
+    /** Public: Get pending rewards for a wallet */
+    getPendingRewards: oc
+      .route({
+        method: "GET",
+        path: "/pending-rewards/{walletAddress}",
+        summary: "Get pending rewards",
+      })
+      .input(GetPendingRewardsInputSchema)
+      .output(GetPendingRewardsOutputSchema)
+      .errors({
+        BAD_REQUEST: { message: "Invalid wallet address", status: 400 },
+        INVALID_WALLET_ADDRESS,
+      }),
 
-            /** Public: Get split configuration for a hotspot */
-            getSplit: oc
-                  .route({ method: "GET", path: "/split/{walletAddress}/{hotspotPubkey}", summary: "Get reward split" })
-                  .input(GetSplitInputSchema)
-                  .output(SplitResponseSchema)
-                  .errors({
-                        NOT_FOUND: { message: "Split not found", status: 404 },
-                        INVALID_WALLET_ADDRESS
-                  }),
+    /** Protected: Transfer hotspot ownership */
+    transferHotspot: oc
+      .route({
+        method: "POST",
+        path: "/transfer",
+        summary: "Transfer ownership",
+      })
+      .input(TransferHotspotInputSchema)
+      .output(TransferHotspotOutputSchema)
+      .errors({
+        UNAUTHORIZED,
+        NOT_FOUND,
+        BAD_REQUEST: { message: "Invalid transfer parameters", status: 400 },
+        INSUFFICIENT_FUNDS,
+        CONFLICT,
+      }),
 
-            /** Protected: Create a split configuration */
-            createSplit: oc
-                  .route({ method: "POST", path: "/split", summary: "Create a reward split" })
-                  .input(CreateSplitInputSchema)
-                  .output(CreateSplitOutputSchema)
-                  .errors({
-                        NOT_FOUND,
-                        BAD_REQUEST: { message: "Invalid split configuration", status: 400 },
-                        INSUFFICIENT_FUNDS
-                  }),
+    /** Protected: Update rewards destination */
+    updateRewardsDestination: oc
+      .route({
+        method: "POST",
+        path: "/update-rewards-destination",
+        summary: "Update rewards destination",
+      })
+      .input(UpdateRewardsDestinationInputSchema)
+      .output(UpdateRewardsDestinationOutputSchema)
+      .errors({
+        BAD_REQUEST: { message: "Invalid parameters", status: 400 },
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
 
-            /** Protected: Delete a split configuration */
-            deleteSplit: oc
-                  .route({ method: "DELETE", path: "/split", summary: "Delete a reward split" })
-                  .input(DeleteSplitInputSchema)
-                  .output(DeleteSplitOutputSchema)
-                  .errors({
-                        NOT_FOUND,
-                        INSUFFICIENT_FUNDS,
-                  }),
-            /** Protected: Close automation */
-            closeAutomation: oc
-                  .route({ method: "POST", path: "/wallet/{walletAddress}/automation/close", summary: "Close automation" })
-                  .input(CloseAutomationInputSchema)
-                  .output(CloseAutomationOutputSchema)
-                  .errors({
-                        NOT_FOUND,
-                        INSUFFICIENT_FUNDS,
-                  }),
-            /** Protected: Get automation status */
-            getAutomationStatus: oc
-                  .route({ method: "GET", path: "/wallet/{walletAddress}/automation/status", summary: "Get automation status" })
-                  .input(GetAutomationStatusInputSchema)
-                  .output(AutomationStatusOutputSchema)
-                  .errors({
-                        NOT_FOUND,
-                  }),
-            /** Protected: Create automation */
-            createAutomation: oc
-                  .route({
-                        method: "POST",
-                        path: "/wallet/{walletAddress}/automation",
-                        summary: "Setup automation"
-                  })
-                  .input(SetupAutomationInputSchema)
-                  .output(SetupAutomationOutputSchema)
-                  .errors({
-                        NOT_FOUND,
-                        INSUFFICIENT_FUNDS,
-                  }),
-            /** Protected: Fund automation */
-            fundAutomation: oc
-                  .route({ method: "POST", path: "/wallet/{walletAddress}/automation/fund", summary: "Fund automation" })
-                  .input(FundAutomationInputSchema)
-                  .output(FundAutomationOutputSchema)
-                  .errors({
-                        NOT_FOUND,
-                        INSUFFICIENT_FUNDS,
-                  }),
+    /** Public: Get split configuration for a hotspot */
+    getSplit: oc
+      .route({
+        method: "GET",
+        path: "/split/{walletAddress}/{hotspotPubkey}",
+        summary: "Get reward split",
+      })
+      .input(GetSplitInputSchema)
+      .output(SplitResponseSchema)
+      .errors({
+        NOT_FOUND: { message: "Split not found", status: 404 },
+        INVALID_WALLET_ADDRESS,
+      }),
 
-            /** Protected: Get funding estimate */
-            getFundingEstimate: oc
-                  .route({ method: "GET", path: "/wallet/{walletAddress}/automation/funding-estimate", summary: "Get funding estimate" })
-                  .input(GetFundingEstimateInputSchema)
-                  .output(FundingEstimateOutputSchema)
-                  .errors({}),
-updateHotspotInfo: oc
-                  .route({ method: "POST", path: "/update-info", summary: "Update hotspot info", description: "Creates an unsigned transaction to update hotspot configuration. Requires deviceType discriminant (iot or mobile) to select the correct update path and validate against on-chain network." })
-                  .input(UpdateHotspotInfoInputSchema)
-                  .output(UpdateHotspotInfoOutputSchema)
-                  .errors({
-                        NOT_FOUND,
-                        UNAUTHORIZED,
-                        BAD_REQUEST: { message: "Device type mismatch", status: 400 },
-                        INSUFFICIENT_FUNDS,
-                  }),
-      });
+    /** Protected: Create a split configuration */
+    createSplit: oc
+      .route({
+        method: "POST",
+        path: "/split",
+        summary: "Create a reward split",
+      })
+      .input(CreateSplitInputSchema)
+      .output(CreateSplitOutputSchema)
+      .errors({
+        NOT_FOUND,
+        BAD_REQUEST: { message: "Invalid split configuration", status: 400 },
+        INSUFFICIENT_FUNDS,
+      }),
+
+    /** Protected: Delete a split configuration */
+    deleteSplit: oc
+      .route({
+        method: "DELETE",
+        path: "/split",
+        summary: "Delete a reward split",
+      })
+      .input(DeleteSplitInputSchema)
+      .output(DeleteSplitOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+    /** Protected: Close automation */
+    closeAutomation: oc
+      .route({
+        method: "POST",
+        path: "/wallet/{walletAddress}/automation/close",
+        summary: "Close automation",
+      })
+      .input(CloseAutomationInputSchema)
+      .output(CloseAutomationOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+    /** Protected: Get automation status */
+    getAutomationStatus: oc
+      .route({
+        method: "GET",
+        path: "/wallet/{walletAddress}/automation/status",
+        summary: "Get automation status",
+      })
+      .input(GetAutomationStatusInputSchema)
+      .output(AutomationStatusOutputSchema)
+      .errors({
+        NOT_FOUND,
+      }),
+    /** Protected: Create automation */
+    createAutomation: oc
+      .route({
+        method: "POST",
+        path: "/wallet/{walletAddress}/automation",
+        summary: "Setup automation",
+      })
+      .input(SetupAutomationInputSchema)
+      .output(SetupAutomationOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+    /** Protected: Fund automation */
+    fundAutomation: oc
+      .route({
+        method: "POST",
+        path: "/wallet/{walletAddress}/automation/fund",
+        summary: "Fund automation",
+      })
+      .input(FundAutomationInputSchema)
+      .output(FundAutomationOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+
+    /** Protected: Get funding estimate */
+    getFundingEstimate: oc
+      .route({
+        method: "GET",
+        path: "/wallet/{walletAddress}/automation/funding-estimate",
+        summary: "Get funding estimate",
+      })
+      .input(GetFundingEstimateInputSchema)
+      .output(FundingEstimateOutputSchema)
+      .errors({}),
+    updateHotspotInfo: oc
+      .route({
+        method: "POST",
+        path: "/update-info",
+        summary: "Update hotspot info",
+        description:
+          "Creates an unsigned transaction to update hotspot configuration. Requires deviceType discriminant (iot or mobile) to select the correct update path and validate against on-chain network.",
+      })
+      .input(UpdateHotspotInfoInputSchema)
+      .output(UpdateHotspotInfoOutputSchema)
+      .errors({
+        NOT_FOUND,
+        UNAUTHORIZED,
+        BAD_REQUEST: { message: "Device type mismatch", status: 400 },
+        INSUFFICIENT_FUNDS,
+      }),
+  });

--- a/packages/blockchain-api-client/src/contracts/hotspots.ts
+++ b/packages/blockchain-api-client/src/contracts/hotspots.ts
@@ -36,6 +36,16 @@ import {
   SetupAutomationInputSchema,
   FundingEstimateOutputSchema,
   GetFundingEstimateInputSchema,
+  RequeueAutomationInputSchema,
+  RequeueAutomationOutputSchema,
+  AddWalletToAutomationInputSchema,
+  AddWalletToAutomationOutputSchema,
+  AddEntityToAutomationInputSchema,
+  AddEntityToAutomationOutputSchema,
+  RemoveEntityFromAutomationInputSchema,
+  RemoveEntityFromAutomationOutputSchema,
+  TopUpAutomationInputSchema,
+  TopUpAutomationOutputSchema,
   UpdateHotspotInfoInputSchema,
   UpdateHotspotInfoOutputSchema,
 } from "../schemas/hotspots";
@@ -248,6 +258,71 @@ export const hotspotsContract = oc
       .input(GetFundingEstimateInputSchema)
       .output(FundingEstimateOutputSchema)
       .errors({}),
+    /** Protected: Requeue an automation that ran out of SOL */
+    requeueAutomation: oc
+      .route({
+        method: "POST",
+        path: "/wallet/{walletAddress}/automation/requeue",
+        summary: "Requeue automation",
+      })
+      .input(RequeueAutomationInputSchema)
+      .output(RequeueAutomationOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+    /** Protected: Add a whole-wallet claim to an automation */
+    addWalletToAutomation: oc
+      .route({
+        method: "POST",
+        path: "/wallet/{walletAddress}/automation/add-wallet",
+        summary: "Add wallet claim to automation",
+      })
+      .input(AddWalletToAutomationInputSchema)
+      .output(AddWalletToAutomationOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+    /** Protected: Add a single hotspot claim to an automation */
+    addEntityToAutomation: oc
+      .route({
+        method: "POST",
+        path: "/wallet/{walletAddress}/automation/add-entity",
+        summary: "Add hotspot claim to automation",
+      })
+      .input(AddEntityToAutomationInputSchema)
+      .output(AddEntityToAutomationOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+    /** Protected: Remove a claim entry from an automation */
+    removeEntityFromAutomation: oc
+      .route({
+        method: "POST",
+        path: "/wallet/{walletAddress}/automation/remove-entity",
+        summary: "Remove claim from automation",
+      })
+      .input(RemoveEntityFromAutomationInputSchema)
+      .output(RemoveEntityFromAutomationOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
+    /** Protected: Operator floor top-up for a batch of automations */
+    topUpAutomation: oc
+      .route({
+        method: "POST",
+        path: "/automation/top-up",
+        summary: "Operator floor top-up of automation funding",
+      })
+      .input(TopUpAutomationInputSchema)
+      .output(TopUpAutomationOutputSchema)
+      .errors({
+        NOT_FOUND,
+        INSUFFICIENT_FUNDS,
+      }),
     updateHotspotInfo: oc
       .route({
         method: "POST",

--- a/packages/blockchain-api-client/src/contracts/index.ts
+++ b/packages/blockchain-api-client/src/contracts/index.ts
@@ -10,6 +10,7 @@ import { fiatContract } from "./fiat";
 import { webhooksContract } from "./webhooks";
 import { migrationContract } from "./migration";
 import { dataCreditsContract } from "./data-credits";
+import { squadsContract } from "./squads";
 import { oc } from "@orpc/contract";
 
 export * from "./governance";
@@ -24,6 +25,7 @@ export * from "./fiat";
 export * from "./webhooks";
 export * from "./migration";
 export * from "./data-credits";
+export * from "./squads";
 
 /**
  * Public API contract definition (for external consumers).
@@ -40,6 +42,7 @@ export const apiContract = oc.router({
   welcomePacks: welcomePacksContract,
   migration: migrationContract,
   dataCredits: dataCreditsContract,
+  squads: squadsContract,
 });
 
 /**

--- a/packages/blockchain-api-client/src/contracts/squads.ts
+++ b/packages/blockchain-api-client/src/contracts/squads.ts
@@ -1,0 +1,64 @@
+import { oc } from "@orpc/contract";
+import {
+  SquadsProposalVoteInputSchema,
+  SquadsExecuteProposalInputSchema,
+  SquadsProposeConfigChangeInputSchema,
+} from "../schemas/squads";
+import { TransactionDataSchema } from "../schemas/common";
+import { BAD_REQUEST, NOT_FOUND } from "../errors/common";
+import { INSUFFICIENT_FUNDS } from "../errors/solana";
+
+/**
+ * Squads v4 multisig proposal lifecycle. Every endpoint builds a single
+ * unsigned transaction to be signed by the acting member and submitted via
+ * the transactions router. Reads (list/inspect proposals) live in the client
+ * SDK, not here.
+ */
+export const squadsContract = oc.tag("Squads").router({
+  approveProposal: oc
+    .route({
+      method: "POST",
+      path: "/squads/proposals/approve",
+      summary: "Approve a Squads v4 proposal",
+    })
+    .input(SquadsProposalVoteInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+  rejectProposal: oc
+    .route({
+      method: "POST",
+      path: "/squads/proposals/reject",
+      summary: "Reject a Squads v4 proposal",
+    })
+    .input(SquadsProposalVoteInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+  cancelProposal: oc
+    .route({
+      method: "POST",
+      path: "/squads/proposals/cancel",
+      summary: "Cancel an approved Squads v4 proposal",
+    })
+    .input(SquadsProposalVoteInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+  executeProposal: oc
+    .route({
+      method: "POST",
+      path: "/squads/proposals/execute",
+      summary: "Execute an approved Squads v4 proposal (vault or config)",
+    })
+    .input(SquadsExecuteProposalInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+  proposeConfigChange: oc
+    .route({
+      method: "POST",
+      path: "/squads/proposals/config",
+      summary:
+        "Propose a Squads v4 config change (add/remove member, change threshold)",
+    })
+    .input(SquadsProposeConfigChangeInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+});

--- a/packages/blockchain-api-client/src/contracts/tokens.ts
+++ b/packages/blockchain-api-client/src/contracts/tokens.ts
@@ -71,6 +71,7 @@ export const tokensContract = oc.tag("Tokens").router({
     .errors({
       BAD_REQUEST,
       INSUFFICIENT_FUNDS,
+      NOT_FOUND,
     }),
 
   /** Protected: Emit a memo transaction */

--- a/packages/blockchain-api-client/src/contracts/tokens.ts
+++ b/packages/blockchain-api-client/src/contracts/tokens.ts
@@ -1,4 +1,8 @@
-import { BAD_REQUEST, INVALID_WALLET_ADDRESS } from "../errors/common";
+import {
+  BAD_REQUEST,
+  INVALID_WALLET_ADDRESS,
+  NOT_FOUND,
+} from "../errors/common";
 import { INSUFFICIENT_FUNDS } from "../errors/solana";
 import {
   GetBalancesInputSchema,
@@ -42,6 +46,7 @@ export const tokensContract = oc.tag("Tokens").router({
     .errors({
       BAD_REQUEST,
       INSUFFICIENT_FUNDS,
+      NOT_FOUND,
     }),
 
   /** Protected: Transfer the same token mint to multiple recipients, packed into as few txs as possible */

--- a/packages/blockchain-api-client/src/contracts/tokens.ts
+++ b/packages/blockchain-api-client/src/contracts/tokens.ts
@@ -7,54 +7,92 @@ import {
   TransferOutputSchema,
   MultiTransferInputSchema,
   MultiTransferOutputSchema,
+  BurnInputSchema,
+  BurnOutputSchema,
+  MemoInputSchema,
+  MemoOutputSchema,
   CreateHntAccountInputSchema,
   CreateHntAccountOutputSchema,
 } from "../schemas/tokens";
 import { oc } from "@orpc/contract";
 
-export const tokensContract = oc
-  .tag("Tokens")
-  .router({
-    /** Public: Get token balances for a wallet */
-    getBalances: oc
-      .route({ method: "GET", path: "/tokens/{walletAddress}", summary: "Get token balances for a wallet" })
-      .input(GetBalancesInputSchema)
-      .output(TokenBalanceDataSchema)
-      .errors({
-        INVALID_WALLET_ADDRESS
-      }),
+export const tokensContract = oc.tag("Tokens").router({
+  /** Public: Get token balances for a wallet */
+  getBalances: oc
+    .route({
+      method: "GET",
+      path: "/tokens/{walletAddress}",
+      summary: "Get token balances for a wallet",
+    })
+    .input(GetBalancesInputSchema)
+    .output(TokenBalanceDataSchema)
+    .errors({
+      INVALID_WALLET_ADDRESS,
+    }),
 
-    /** Protected: Transfer tokens */
-    transfer: oc
-      .route({ method: "POST", path: "/tokens/transfer", summary: "Transfer tokens" })
-      .input(TransferInputSchema)
-      .output(TransferOutputSchema)
-      .errors({
-        BAD_REQUEST,
-        INSUFFICIENT_FUNDS,
-      }),
+  /** Protected: Transfer tokens */
+  transfer: oc
+    .route({
+      method: "POST",
+      path: "/tokens/transfer",
+      summary: "Transfer tokens",
+    })
+    .input(TransferInputSchema)
+    .output(TransferOutputSchema)
+    .errors({
+      BAD_REQUEST,
+      INSUFFICIENT_FUNDS,
+    }),
 
-    /** Protected: Transfer the same token mint to multiple recipients, packed into as few txs as possible */
-    multiTransfer: oc
-      .route({
-        method: "POST",
-        path: "/tokens/multi-transfer",
-        summary: "Transfer the same token to multiple recipients",
-      })
-      .input(MultiTransferInputSchema)
-      .output(MultiTransferOutputSchema)
-      .errors({
-        BAD_REQUEST,
-        INSUFFICIENT_FUNDS,
-      }),
+  /** Protected: Transfer the same token mint to multiple recipients, packed into as few txs as possible */
+  multiTransfer: oc
+    .route({
+      method: "POST",
+      path: "/tokens/multi-transfer",
+      summary: "Transfer the same token to multiple recipients",
+    })
+    .input(MultiTransferInputSchema)
+    .output(MultiTransferOutputSchema)
+    .errors({
+      BAD_REQUEST,
+      INSUFFICIENT_FUNDS,
+    }),
 
-    /** Protected: Create HNT account */
-    createHntAccount: oc
-      .route({ method: "POST", path: "/tokens/hnt-account", summary: "Create HNT account" })
-      .input(CreateHntAccountInputSchema)
-      .output(CreateHntAccountOutputSchema)
-      .errors({
-        INVALID_WALLET_ADDRESS,
-        INSUFFICIENT_FUNDS,
-      }),
-  });
+  /** Protected: Burn tokens */
+  burn: oc
+    .route({ method: "POST", path: "/tokens/burn", summary: "Burn tokens" })
+    .input(BurnInputSchema)
+    .output(BurnOutputSchema)
+    .errors({
+      BAD_REQUEST,
+      INSUFFICIENT_FUNDS,
+    }),
+
+  /** Protected: Emit a memo transaction */
+  memo: oc
+    .route({
+      method: "POST",
+      path: "/tokens/memo",
+      summary: "Emit a memo transaction",
+    })
+    .input(MemoInputSchema)
+    .output(MemoOutputSchema)
+    .errors({
+      BAD_REQUEST,
+      INSUFFICIENT_FUNDS,
+    }),
+
+  /** Protected: Create HNT account */
+  createHntAccount: oc
+    .route({
+      method: "POST",
+      path: "/tokens/hnt-account",
+      summary: "Create HNT account",
+    })
+    .input(CreateHntAccountInputSchema)
+    .output(CreateHntAccountOutputSchema)
+    .errors({
+      INVALID_WALLET_ADDRESS,
+      INSUFFICIENT_FUNDS,
+    }),
+});

--- a/packages/blockchain-api-client/src/schemas/common.ts
+++ b/packages/blockchain-api-client/src/schemas/common.ts
@@ -75,6 +75,22 @@ export const PublicKeySchema = z
 export const HeliumPublicKeySchema = z.string().min(32).max(400);
 
 /**
+ * Optional Squads v4 propose-mode fields shared by the action schemas. When
+ * `multisig` is set the action is built from that multisig's vault and wrapped
+ * as a proposal; the action's signer is the proposing member and outer fee
+ * payer.
+ */
+export const squadsProposeFields = {
+  multisig: PublicKeySchema.optional().describe(
+    "If set, build the action as a Squads v4 proposal from this multisig's vault instead of a direct transaction. The action's signer is the proposing member and outer fee payer."
+  ),
+  memo: z
+    .string()
+    .optional()
+    .describe("Optional memo recorded on the Squads proposal (multisig mode)"),
+};
+
+/**
  * Standard pagination input schema.
  */
 export const PaginationInputSchema = z.object({
@@ -115,7 +131,7 @@ export const TokenAmountInputSchema = z.object({
     .string()
     .regex(/^\d+$/, "Amount must be a whole number in smallest unit")
     .describe(
-      'Raw token amount in smallest unit (bones). e.g. for a mint with 8 decimals, 1 full token = "100000000"',
+      'Raw token amount in smallest unit (bones). e.g. for a mint with 8 decimals, 1 full token = "100000000"'
     ),
   mint: PublicKeySchema.describe("Mint address of the token"),
 });
@@ -124,7 +140,7 @@ export const TokenAmountOutputSchema = z.object({
   amount: z
     .string()
     .describe(
-      'Raw token amount in smallest unit (bones). e.g. for a mint with 8 decimals, 1 full token = "100000000"',
+      'Raw token amount in smallest unit (bones). e.g. for a mint with 8 decimals, 1 full token = "100000000"'
     ),
   decimals: z.number().describe("Number of decimals for the mint"),
   uiAmount: z
@@ -158,14 +174,14 @@ export type RewardSplitInput = z.infer<typeof RewardSplitInputSchema>;
 // ---------------------------------------------------------------------------
 
 export function typedTransactionData<T extends z.ZodTypeAny>(
-  metadataSchema: T,
+  metadataSchema: T
 ) {
   return z.object({
     transactions: z.array(
       z.object({
         serializedTransaction: z.string(),
         metadata: metadataSchema.optional(),
-      }),
+      })
     ),
     parallel: z.boolean(),
     tag: z.string().optional(),
@@ -177,18 +193,18 @@ export function createTransactionResponse() {
   return z.object({
     transactionData: TransactionDataSchema,
     estimatedSolFee: TokenAmountOutputSchema.describe(
-      "Estimated total SOL fee including rent, priority fees, and automation costs",
+      "Estimated total SOL fee including rent, priority fees, and automation costs"
     ),
   });
 }
 
 export function createTypedTransactionResponse<T extends z.ZodTypeAny>(
-  metadataSchema: T,
+  metadataSchema: T
 ) {
   return z.object({
     transactionData: typedTransactionData(metadataSchema),
     estimatedSolFee: TokenAmountOutputSchema.describe(
-      "Estimated total SOL fee including rent, priority fees, and automation costs",
+      "Estimated total SOL fee including rent, priority fees, and automation costs"
     ),
   });
 }
@@ -198,19 +214,19 @@ export function createPaginatedTransactionResponse() {
     hasMore: z
       .boolean()
       .describe(
-        "True if more work remains — call again with the same arguments to continue.",
+        "True if more work remains — call again with the same arguments to continue."
       ),
   });
 }
 
 export function createTypedPaginatedTransactionResponse<T extends z.ZodTypeAny>(
-  metadataSchema: T,
+  metadataSchema: T
 ) {
   return createTypedTransactionResponse(metadataSchema).extend({
     hasMore: z
       .boolean()
       .describe(
-        "True if more work remains — call again with the same arguments to continue.",
+        "True if more work remains — call again with the same arguments to continue."
       ),
   });
 }

--- a/packages/blockchain-api-client/src/schemas/data-credits.ts
+++ b/packages/blockchain-api-client/src/schemas/data-credits.ts
@@ -9,7 +9,9 @@ export const MintDataCreditsInputSchema = z.object({
     .string()
     .regex(/^\d+$/, "Amount must be a whole number")
     .optional()
-    .describe("Amount of DC to mint (in smallest unit). Provide either dcAmount or hntAmount."),
+    .describe(
+      "Amount of DC to mint (in smallest unit). Provide either dcAmount or hntAmount."
+    ),
   hntAmount: z
     .string()
     .regex(/^\d+$/, "Amount must be a whole number in bones")
@@ -39,7 +41,24 @@ export const DelegateDataCreditsInputSchema = z.object({
   mint: PublicKeySchema.describe(
     "SubDAO token mint (e.g. MOBILE or IOT mint) to determine which subDAO to delegate to"
   ),
-  memo: z.string().optional().describe("Optional memo to include in the transaction"),
+  memo: z
+    .string()
+    .optional()
+    .describe("Optional memo to include in the transaction"),
 });
 
-export type DelegateDataCreditsInput = z.infer<typeof DelegateDataCreditsInputSchema>;
+export type DelegateDataCreditsInput = z.infer<
+  typeof DelegateDataCreditsInputSchema
+>;
+
+export const BurnDataCreditsInputSchema = z.object({
+  owner: PublicKeySchema.describe(
+    "Wallet address burning the data credits (signer and fee payer)"
+  ),
+  amount: z
+    .string()
+    .regex(/^\d+$/, "Amount must be a whole number")
+    .describe("Amount of DC to burn (smallest unit, DC has 0 decimals)"),
+});
+
+export type BurnDataCreditsInput = z.infer<typeof BurnDataCreditsInputSchema>;

--- a/packages/blockchain-api-client/src/schemas/data-credits.ts
+++ b/packages/blockchain-api-client/src/schemas/data-credits.ts
@@ -59,6 +59,13 @@ export const BurnDataCreditsInputSchema = z.object({
     .string()
     .regex(/^\d+$/, "Amount must be a whole number")
     .describe("Amount of DC to burn (smallest unit, DC has 0 decimals)"),
+  multisig: PublicKeySchema.optional().describe(
+    "If set, burn from this multisig's vault as a Squads v4 proposal. `owner` is the proposing member and outer fee payer."
+  ),
+  memo: z
+    .string()
+    .optional()
+    .describe("Optional memo recorded on the Squads proposal (multisig mode)"),
 });
 
 export type BurnDataCreditsInput = z.infer<typeof BurnDataCreditsInputSchema>;

--- a/packages/blockchain-api-client/src/schemas/data-credits.ts
+++ b/packages/blockchain-api-client/src/schemas/data-credits.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { PublicKeySchema } from "./common";
+import { PublicKeySchema, squadsProposeFields } from "./common";
 
 export const MintDataCreditsInputSchema = z.object({
   owner: PublicKeySchema.describe(
@@ -44,15 +44,7 @@ export const DelegateDataCreditsInputSchema = z.object({
   mint: PublicKeySchema.describe(
     "SubDAO token mint (e.g. MOBILE or IOT mint) to determine which subDAO to delegate to"
   ),
-  memo: z
-    .string()
-    .optional()
-    .describe(
-      "In direct mode, a memo instruction included in the transaction. In multisig mode, the memo recorded on the Squads proposal."
-    ),
-  multisig: PublicKeySchema.optional().describe(
-    "If set, delegate from this multisig's vault as a Squads v4 proposal. `owner` is the proposing member and outer fee payer."
-  ),
+  ...squadsProposeFields,
 });
 
 export type DelegateDataCreditsInput = z.infer<
@@ -67,13 +59,7 @@ export const BurnDataCreditsInputSchema = z.object({
     .string()
     .regex(/^\d+$/, "Amount must be a whole number")
     .describe("Amount of DC to burn (smallest unit, DC has 0 decimals)"),
-  multisig: PublicKeySchema.optional().describe(
-    "If set, burn from this multisig's vault as a Squads v4 proposal. `owner` is the proposing member and outer fee payer."
-  ),
-  memo: z
-    .string()
-    .optional()
-    .describe("Optional memo recorded on the Squads proposal (multisig mode)"),
+  ...squadsProposeFields,
 });
 
 export type BurnDataCreditsInput = z.infer<typeof BurnDataCreditsInputSchema>;

--- a/packages/blockchain-api-client/src/schemas/data-credits.ts
+++ b/packages/blockchain-api-client/src/schemas/data-credits.ts
@@ -22,6 +22,9 @@ export const MintDataCreditsInputSchema = z.object({
   recipient: PublicKeySchema.optional().describe(
     "Recipient wallet for the minted DC. Defaults to the owner."
   ),
+  // No Squads propose mode: minting requires a fresh Pyth price in the same
+  // transaction, which a deferred proposal can't satisfy (see the mint
+  // procedure). Delegation and burns are proposable.
 });
 
 export type MintDataCreditsInput = z.infer<typeof MintDataCreditsInputSchema>;
@@ -44,7 +47,12 @@ export const DelegateDataCreditsInputSchema = z.object({
   memo: z
     .string()
     .optional()
-    .describe("Optional memo to include in the transaction"),
+    .describe(
+      "In direct mode, a memo instruction included in the transaction. In multisig mode, the memo recorded on the Squads proposal."
+    ),
+  multisig: PublicKeySchema.optional().describe(
+    "If set, delegate from this multisig's vault as a Squads v4 proposal. `owner` is the proposing member and outer fee payer."
+  ),
 });
 
 export type DelegateDataCreditsInput = z.infer<

--- a/packages/blockchain-api-client/src/schemas/hotspots.ts
+++ b/packages/blockchain-api-client/src/schemas/hotspots.ts
@@ -127,7 +127,6 @@ export const SetupAutomationInputSchema = z.object({
   // Raw crontab string (clockwork format) the cron fires on.
   cronSchedule: z.string().min(1),
   duration: z.number().int().min(1), // Number of claims to pre-fund
-  totalHotspots: z.number().int().min(1),
 });
 
 export const FundAutomationInputSchema = z.object({

--- a/packages/blockchain-api-client/src/schemas/hotspots.ts
+++ b/packages/blockchain-api-client/src/schemas/hotspots.ts
@@ -165,6 +165,26 @@ export const RemoveEntityFromAutomationInputSchema = z.object({
   index: z.number().int().min(0),
 });
 
+// ---- Data-only hotspot onboarding ----
+// The onboarding server builds the issue (via the ECC verifier) and onboard
+// transactions; these endpoints relay them for local signing.
+
+export const IssueDataOnlyHotspotInputSchema = z.object({
+  walletAddress: WalletAddressSchema,
+  // Base64 add-gateway token (BlockchainTxnAddGatewayV1 envelope) from the hotspot.
+  addGatewayTxn: z.string().min(1),
+});
+
+export const OnboardDataOnlyHotspotInputSchema = z.object({
+  walletAddress: WalletAddressSchema,
+  network: z.enum(["iot", "mobile"]),
+  hotspotAddress: HeliumPublicKeySchema,
+  lat: z.number().min(-90).max(90).optional(),
+  lng: z.number().min(-180).max(180).optional(),
+  elevation: z.number().optional(), // IoT only
+  gain: z.number().optional(), // IoT only
+});
+
 // Operator-run floor top-up: for each target wallet whose pool balance is at or
 // below `floorLamports`, the operator funds it with `fundLamports`. The operator
 // is the fee payer and funding source (mirrors the off-chain funder pattern).
@@ -260,6 +280,8 @@ export const SetupAutomationOutputSchema = createTransactionResponse();
 export const FundAutomationOutputSchema = createTransactionResponse();
 export const CloseAutomationOutputSchema = createTransactionResponse();
 export const RequeueAutomationOutputSchema = createTransactionResponse();
+export const IssueDataOnlyHotspotOutputSchema = createTransactionResponse();
+export const OnboardDataOnlyHotspotOutputSchema = createTransactionResponse();
 export const AddWalletToAutomationOutputSchema = createTransactionResponse();
 export const AddEntityToAutomationOutputSchema = createTransactionResponse();
 export const RemoveEntityFromAutomationOutputSchema =
@@ -429,3 +451,9 @@ export type RemoveEntityFromAutomationInput = z.infer<
   typeof RemoveEntityFromAutomationInputSchema
 >;
 export type TopUpAutomationInput = z.infer<typeof TopUpAutomationInputSchema>;
+export type IssueDataOnlyHotspotInput = z.infer<
+  typeof IssueDataOnlyHotspotInputSchema
+>;
+export type OnboardDataOnlyHotspotInput = z.infer<
+  typeof OnboardDataOnlyHotspotInputSchema
+>;

--- a/packages/blockchain-api-client/src/schemas/hotspots.ts
+++ b/packages/blockchain-api-client/src/schemas/hotspots.ts
@@ -118,12 +118,15 @@ export const GetAutomationStatusInputSchema = z.object({
   walletAddress: WalletAddressSchema,
 });
 
+// Best-effort classification of a raw cron string, surfaced on the status
+// output for display only. Funding math is per-firing and never depends on it.
 export const AutomationScheduleSchema = z.enum(["daily", "weekly", "monthly"]);
 
 export const SetupAutomationInputSchema = z.object({
   walletAddress: WalletAddressSchema,
-  schedule: AutomationScheduleSchema,
-  duration: z.number().int().min(1), // Number of claims
+  // Raw crontab string (clockwork format) the cron fires on.
+  cronSchedule: z.string().min(1),
+  duration: z.number().int().min(1), // Number of claims to pre-fund
   totalHotspots: z.number().int().min(1),
 });
 
@@ -139,6 +142,37 @@ export const GetFundingEstimateInputSchema = z.object({
 
 export const CloseAutomationInputSchema = z.object({
   walletAddress: WalletAddressSchema,
+});
+
+export const RequeueAutomationInputSchema = z.object({
+  walletAddress: WalletAddressSchema,
+});
+
+// Add a whole-wallet claim (claims every hotspot the wallet owns) to the cron.
+export const AddWalletToAutomationInputSchema = z.object({
+  walletAddress: WalletAddressSchema,
+});
+
+// Add a single hotspot/entity claim to the cron.
+export const AddEntityToAutomationInputSchema = z.object({
+  walletAddress: WalletAddressSchema,
+  entityKey: HeliumPublicKeySchema,
+});
+
+// Remove a single claim entry (by its cron transaction index) from the cron.
+export const RemoveEntityFromAutomationInputSchema = z.object({
+  walletAddress: WalletAddressSchema,
+  index: z.number().int().min(0),
+});
+
+// Operator-run floor top-up: for each target wallet whose pool balance is at or
+// below `floorLamports`, the operator funds it with `fundLamports`. The operator
+// is the fee payer and funding source (mirrors the off-chain funder pattern).
+export const TopUpAutomationInputSchema = z.object({
+  operatorAddress: WalletAddressSchema,
+  floorLamports: z.coerce.number().int().min(0),
+  fundLamports: z.coerce.number().int().min(1),
+  targets: z.array(WalletAddressSchema).min(1).max(50),
 });
 
 // ============================================================================
@@ -225,6 +259,12 @@ export const DeleteSplitOutputSchema = createTransactionResponse();
 export const SetupAutomationOutputSchema = createTransactionResponse();
 export const FundAutomationOutputSchema = createTransactionResponse();
 export const CloseAutomationOutputSchema = createTransactionResponse();
+export const RequeueAutomationOutputSchema = createTransactionResponse();
+export const AddWalletToAutomationOutputSchema = createTransactionResponse();
+export const AddEntityToAutomationOutputSchema = createTransactionResponse();
+export const RemoveEntityFromAutomationOutputSchema =
+  createTransactionResponse();
+export const TopUpAutomationOutputSchema = createTransactionResponse();
 
 export const SplitShareSchema = z.object({
   wallet: z.string(),
@@ -245,7 +285,8 @@ export const AutomationStatusOutputSchema = z.object({
   isOutOfSol: z.boolean(),
   currentSchedule: z
     .object({
-      schedule: AutomationScheduleSchema,
+      cron: z.string(), // raw crontab string the cron fires on
+      schedule: AutomationScheduleSchema, // best-effort classification (display only)
       time: z.string(),
       nextRun: z.string(), // ISO date string
     })
@@ -375,3 +416,16 @@ export type GetFundingEstimateInput = z.infer<
   typeof GetFundingEstimateInputSchema
 >;
 export type FundingEstimate = z.infer<typeof FundingEstimateOutputSchema>;
+export type RequeueAutomationInput = z.infer<
+  typeof RequeueAutomationInputSchema
+>;
+export type AddWalletToAutomationInput = z.infer<
+  typeof AddWalletToAutomationInputSchema
+>;
+export type AddEntityToAutomationInput = z.infer<
+  typeof AddEntityToAutomationInputSchema
+>;
+export type RemoveEntityFromAutomationInput = z.infer<
+  typeof RemoveEntityFromAutomationInputSchema
+>;
+export type TopUpAutomationInput = z.infer<typeof TopUpAutomationInputSchema>;

--- a/packages/blockchain-api-client/src/schemas/hotspots.ts
+++ b/packages/blockchain-api-client/src/schemas/hotspots.ts
@@ -29,6 +29,14 @@ export const ClaimRewardsInputSchema = z.object({
   estimatedPendingRewards: TokenAmountOutputSchema.optional(),
 });
 
+export const ClaimHotspotRewardsInputSchema = z.object({
+  entityPubKey: HeliumPublicKeySchema.describe(
+    "The hotspot to claim rewards for."
+  ),
+  walletAddress: WalletAddressSchema,
+  network: RewardNetworkSchema,
+});
+
 export const GetPendingRewardsInputSchema = z.object({
   walletAddress: WalletAddressSchema,
   network: RewardNetworkSchema,
@@ -181,6 +189,16 @@ export const ClaimRewardsOutputSchema =
         actionMetadata: ClaimRewardsActionMetadataSchema.optional(),
       }),
   });
+
+// A single-hotspot claim is one action with no pagination, so it uses the
+// standard (non-paginated) transaction response.
+export const ClaimHotspotRewardsOutputSchema = createTransactionResponse();
+
+export const HotspotBurnInputSchema = z.object({
+  walletAddress: WalletAddressSchema,
+  hotspotPubkey: HeliumPublicKeySchema,
+});
+export const HotspotBurnOutputSchema = createTransactionResponse();
 export const TransferHotspotOutputSchema = createTransactionResponse();
 export const UpdateRewardsDestinationOutputSchema = createTransactionResponse();
 export const CreateSplitOutputSchema = createTransactionResponse();

--- a/packages/blockchain-api-client/src/schemas/hotspots.ts
+++ b/packages/blockchain-api-client/src/schemas/hotspots.ts
@@ -3,28 +3,12 @@ import {
   createPaginatedTransactionResponse,
   createTransactionResponse,
   HeliumPublicKeySchema,
-  PublicKeySchema,
   RewardSplitInputSchema,
   ScheduleInputSchema,
+  squadsProposeFields,
   TokenAmountOutputSchema,
   WalletAddressSchema,
 } from "./common";
-
-/**
- * Optional Squads v4 propose-mode fields shared by the hotspot action schemas.
- * When `multisig` is set the action is built from that multisig's vault (which
- * must own the hotspot) and wrapped as a proposal; `walletAddress` is the
- * proposing member and outer fee payer.
- */
-const squadsProposeFields = {
-  multisig: PublicKeySchema.optional().describe(
-    "If set, build the action as a Squads v4 proposal from this multisig's vault (which must own the hotspot)."
-  ),
-  memo: z
-    .string()
-    .optional()
-    .describe("Optional memo recorded on the Squads proposal (multisig mode)"),
-};
 
 export const RewardNetworkSchema = z
   .enum(["hnt", "iot", "mobile"])

--- a/packages/blockchain-api-client/src/schemas/hotspots.ts
+++ b/packages/blockchain-api-client/src/schemas/hotspots.ts
@@ -3,11 +3,28 @@ import {
   createPaginatedTransactionResponse,
   createTransactionResponse,
   HeliumPublicKeySchema,
+  PublicKeySchema,
   RewardSplitInputSchema,
   ScheduleInputSchema,
   TokenAmountOutputSchema,
   WalletAddressSchema,
 } from "./common";
+
+/**
+ * Optional Squads v4 propose-mode fields shared by the hotspot action schemas.
+ * When `multisig` is set the action is built from that multisig's vault (which
+ * must own the hotspot) and wrapped as a proposal; `walletAddress` is the
+ * proposing member and outer fee payer.
+ */
+const squadsProposeFields = {
+  multisig: PublicKeySchema.optional().describe(
+    "If set, build the action as a Squads v4 proposal from this multisig's vault (which must own the hotspot)."
+  ),
+  memo: z
+    .string()
+    .optional()
+    .describe("Optional memo recorded on the Squads proposal (multisig mode)"),
+};
 
 export const RewardNetworkSchema = z
   .enum(["hnt", "iot", "mobile"])
@@ -69,6 +86,7 @@ export const TransferHotspotInputSchema = z.object({
   walletAddress: WalletAddressSchema,
   hotspotPubkey: HeliumPublicKeySchema,
   recipient: WalletAddressSchema,
+  ...squadsProposeFields,
 });
 
 export const UpdateRewardsDestinationInputSchema = z.object({
@@ -197,6 +215,7 @@ export const ClaimHotspotRewardsOutputSchema = createTransactionResponse();
 export const HotspotBurnInputSchema = z.object({
   walletAddress: WalletAddressSchema,
   hotspotPubkey: HeliumPublicKeySchema,
+  ...squadsProposeFields,
 });
 export const HotspotBurnOutputSchema = createTransactionResponse();
 export const TransferHotspotOutputSchema = createTransactionResponse();

--- a/packages/blockchain-api-client/src/schemas/hotspots.ts
+++ b/packages/blockchain-api-client/src/schemas/hotspots.ts
@@ -124,8 +124,13 @@ export const AutomationScheduleSchema = z.enum(["daily", "weekly", "monthly"]);
 
 export const SetupAutomationInputSchema = z.object({
   walletAddress: WalletAddressSchema,
-  // Raw crontab string (clockwork format) the cron fires on.
-  cronSchedule: z.string().min(1),
+  // How often the cron fires: a preset cadence (daily/weekly/monthly) or a raw
+  // clockwork crontab string. Presets are resolved to a crontab server-side.
+  schedule: z
+    .union([AutomationScheduleSchema, z.string().min(1)])
+    .describe(
+      "A preset cadence (daily/weekly/monthly) or a raw clockwork crontab string."
+    ),
   duration: z.number().int().min(1), // Number of claims to pre-fund
 });
 

--- a/packages/blockchain-api-client/src/schemas/squads.ts
+++ b/packages/blockchain-api-client/src/schemas/squads.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import { PublicKeySchema } from "./common";
+
+/**
+ * A transaction index within a Squads v4 multisig, encoded as a decimal
+ * string because on-chain indices are u64 and can exceed Number.MAX_SAFE_INTEGER.
+ */
+const TransactionIndexSchema = z
+  .string()
+  .regex(/^\d+$/, "transactionIndex must be a whole number")
+  .describe("Squads transaction index of the target proposal (u64 as string)");
+
+/**
+ * Shared inputs for a proposal vote (approve / reject / cancel). The member
+ * casting the vote is also the fee payer for the returned transaction.
+ */
+export const SquadsProposalVoteInputSchema = z.object({
+  member: PublicKeySchema.describe(
+    "Wallet address of the multisig member casting the vote (signer and fee payer)"
+  ),
+  multisig: PublicKeySchema.describe("Multisig account PDA"),
+  transactionIndex: TransactionIndexSchema,
+  memo: z.string().optional().describe("Optional memo recorded on the vote"),
+});
+
+export type SquadsProposalVoteInput = z.infer<
+  typeof SquadsProposalVoteInputSchema
+>;
+
+/**
+ * Input for executing an approved proposal. Handles both vault and config
+ * transactions; the server detects which kind the target index holds.
+ */
+export const SquadsExecuteProposalInputSchema = z.object({
+  member: PublicKeySchema.describe(
+    "Wallet address of the multisig member executing the proposal (signer and fee payer)"
+  ),
+  multisig: PublicKeySchema.describe("Multisig account PDA"),
+  transactionIndex: TransactionIndexSchema,
+});
+
+export type SquadsExecuteProposalInput = z.infer<
+  typeof SquadsExecuteProposalInputSchema
+>;
+
+/**
+ * Member permissions for an AddMember config action. Mirrors the Squads v4
+ * permission bits: initiate (propose), vote, execute.
+ */
+export const SquadsPermissionSchema = z.enum(["initiate", "vote", "execute"]);
+
+/**
+ * A single config change to include in a config-transaction proposal.
+ */
+export const SquadsConfigActionSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("addMember"),
+    newMember: PublicKeySchema.describe("Pubkey of the member to add"),
+    permissions: z
+      .array(SquadsPermissionSchema)
+      .nonempty()
+      .optional()
+      .describe(
+        "Permissions granted to the new member. Defaults to all three (initiate, vote, execute)."
+      ),
+  }),
+  z.object({
+    type: z.literal("removeMember"),
+    oldMember: PublicKeySchema.describe("Pubkey of the member to remove"),
+  }),
+  z.object({
+    type: z.literal("changeThreshold"),
+    newThreshold: z
+      .number()
+      .int()
+      .min(1)
+      .describe("New approval threshold for the multisig"),
+  }),
+]);
+
+export type SquadsConfigAction = z.infer<typeof SquadsConfigActionSchema>;
+
+/**
+ * Input for proposing a config change (add/remove member, change threshold).
+ * The server creates a config transaction plus its proposal at the multisig's
+ * next transaction index, returned in actionMetadata.
+ */
+export const SquadsProposeConfigChangeInputSchema = z.object({
+  member: PublicKeySchema.describe(
+    "Wallet address of the multisig member creating the proposal (signer and fee payer)"
+  ),
+  multisig: PublicKeySchema.describe("Multisig account PDA"),
+  actions: z
+    .array(SquadsConfigActionSchema)
+    .nonempty()
+    .describe("One or more config changes to apply when the proposal executes"),
+  memo: z
+    .string()
+    .optional()
+    .describe("Optional memo recorded on the proposal"),
+});
+
+export type SquadsProposeConfigChangeInput = z.infer<
+  typeof SquadsProposeConfigChangeInputSchema
+>;

--- a/packages/blockchain-api-client/src/schemas/tokens.ts
+++ b/packages/blockchain-api-client/src/schemas/tokens.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   createTransactionResponse,
   PublicKeySchema,
+  squadsProposeFields,
   TokenAmountInputSchema,
   WalletAddressSchema,
 } from "./common";
@@ -14,13 +15,7 @@ export const TransferInputSchema = z.object({
   walletAddress: WalletAddressSchema,
   destination: z.string().min(32),
   tokenAmount: TokenAmountInputSchema,
-  multisig: PublicKeySchema.optional().describe(
-    "If set, build the transfer as a Squads v4 proposal from this multisig's vault instead of a direct transfer. walletAddress is the proposing member and outer fee payer."
-  ),
-  memo: z
-    .string()
-    .optional()
-    .describe("Optional memo recorded on the Squads proposal (multisig mode)"),
+  ...squadsProposeFields,
 });
 
 export const MultiTransferRecipientSchema = z.object({
@@ -49,13 +44,7 @@ export const MultiTransferInputSchema = z.object({
 export const BurnInputSchema = z.object({
   walletAddress: WalletAddressSchema,
   tokenAmount: TokenAmountInputSchema,
-  multisig: PublicKeySchema.optional().describe(
-    "If set, build the burn as a Squads v4 proposal from this multisig's vault. walletAddress is the proposing member and outer fee payer."
-  ),
-  memo: z
-    .string()
-    .optional()
-    .describe("Optional memo recorded on the Squads proposal (multisig mode)"),
+  ...squadsProposeFields,
 });
 
 export const MemoInputSchema = z.object({

--- a/packages/blockchain-api-client/src/schemas/tokens.ts
+++ b/packages/blockchain-api-client/src/schemas/tokens.ts
@@ -4,7 +4,7 @@ import {
   PublicKeySchema,
   TokenAmountInputSchema,
   WalletAddressSchema,
-} from "./common"
+} from "./common";
 
 export const GetBalancesInputSchema = z.object({
   walletAddress: WalletAddressSchema,
@@ -22,19 +22,31 @@ export const MultiTransferRecipientSchema = z.object({
     .string()
     .regex(/^\d+$/, "Amount must be a whole number in smallest unit")
     .describe(
-      'Raw token amount in smallest unit (bones). e.g. for a mint with 8 decimals, 1 full token = "100000000"',
+      'Raw token amount in smallest unit (bones). e.g. for a mint with 8 decimals, 1 full token = "100000000"'
     ),
 });
 
 export const MultiTransferInputSchema = z.object({
   walletAddress: WalletAddressSchema,
   mint: PublicKeySchema.describe(
-    "Mint address of the token to transfer to all recipients",
+    "Mint address of the token to transfer to all recipients"
   ),
   recipients: z
     .array(MultiTransferRecipientSchema)
     .min(1)
-    .describe("Recipients receiving the same mint, packed into as few txs as possible"),
+    .describe(
+      "Recipients receiving the same mint, packed into as few txs as possible"
+    ),
+});
+
+export const BurnInputSchema = z.object({
+  walletAddress: WalletAddressSchema,
+  tokenAmount: TokenAmountInputSchema,
+});
+
+export const MemoInputSchema = z.object({
+  walletAddress: WalletAddressSchema,
+  memo: z.string().min(1).max(500).describe("UTF-8 memo text"),
 });
 
 export const CreateHntAccountInputSchema = z.object({
@@ -63,15 +75,23 @@ export const TokenBalanceDataSchema = z.object({
 
 export const TransferOutputSchema = createTransactionResponse();
 export const MultiTransferOutputSchema = createTransactionResponse();
+export const BurnOutputSchema = createTransactionResponse();
+export const MemoOutputSchema = createTransactionResponse();
 export const CreateHntAccountOutputSchema = createTransactionResponse();
 
 export type GetBalancesInput = z.infer<typeof GetBalancesInputSchema>;
 export type TransferInput = z.infer<typeof TransferInputSchema>;
-export type MultiTransferRecipient = z.infer<typeof MultiTransferRecipientSchema>;
+export type MultiTransferRecipient = z.infer<
+  typeof MultiTransferRecipientSchema
+>;
 export type MultiTransferInput = z.infer<typeof MultiTransferInputSchema>;
 export type CreateHntAccountInput = z.infer<typeof CreateHntAccountInputSchema>;
 export type TokenAccount = z.infer<typeof TokenAccountSchema>;
 export type TokenBalanceData = z.infer<typeof TokenBalanceDataSchema>;
 export type TransferOutput = z.infer<typeof TransferOutputSchema>;
 export type MultiTransferOutput = z.infer<typeof MultiTransferOutputSchema>;
-export type CreateHntAccountOutput = z.infer<typeof CreateHntAccountOutputSchema>;
+export type BurnInput = z.infer<typeof BurnInputSchema>;
+export type MemoInput = z.infer<typeof MemoInputSchema>;
+export type CreateHntAccountOutput = z.infer<
+  typeof CreateHntAccountOutputSchema
+>;

--- a/packages/blockchain-api-client/src/schemas/tokens.ts
+++ b/packages/blockchain-api-client/src/schemas/tokens.ts
@@ -49,6 +49,13 @@ export const MultiTransferInputSchema = z.object({
 export const BurnInputSchema = z.object({
   walletAddress: WalletAddressSchema,
   tokenAmount: TokenAmountInputSchema,
+  multisig: PublicKeySchema.optional().describe(
+    "If set, build the burn as a Squads v4 proposal from this multisig's vault. walletAddress is the proposing member and outer fee payer."
+  ),
+  memo: z
+    .string()
+    .optional()
+    .describe("Optional memo recorded on the Squads proposal (multisig mode)"),
 });
 
 export const MemoInputSchema = z.object({

--- a/packages/blockchain-api-client/src/schemas/tokens.ts
+++ b/packages/blockchain-api-client/src/schemas/tokens.ts
@@ -14,6 +14,13 @@ export const TransferInputSchema = z.object({
   walletAddress: WalletAddressSchema,
   destination: z.string().min(32),
   tokenAmount: TokenAmountInputSchema,
+  multisig: PublicKeySchema.optional().describe(
+    "If set, build the transfer as a Squads v4 proposal from this multisig's vault instead of a direct transfer. walletAddress is the proposing member and outer fee payer."
+  ),
+  memo: z
+    .string()
+    .optional()
+    .describe("Optional memo recorded on the Squads proposal (multisig mode)"),
 });
 
 export const MultiTransferRecipientSchema = z.object({

--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -66,6 +66,7 @@
     "@sentry/nextjs": "^10",
     "@solana/spl-token": "^0.4.13",
     "@solana/web3.js": "^1.98.2",
+    "@sqds/multisig": "^2.1.4",
     "@t3-oss/env-nextjs": "^0.13.8",
     "@tanstack/react-query": "^5.80.10",
     "@types/bn.js": "^5.2.0",

--- a/packages/blockchain-api/src/lib/env.ts
+++ b/packages/blockchain-api/src/lib/env.ts
@@ -49,6 +49,13 @@ export const env = createEnv({
       .string()
       .url()
       .default("https://onboarding.dewi.org/api/v3"),
+    // ECC verifier service that co-signs data-only hotspot issue transactions
+    // after verifying the gateway's ECC key signature. Base URL; the issue
+    // procedure POSTs to `${ECC_VERIFIER_URL}/verify`.
+    ECC_VERIFIER_URL: z
+      .string()
+      .url()
+      .default("https://ecc-verifier.web.helium.io"),
     FEE_PAYER_WALLET_PATH: z.string().optional(),
     MIGRATION_PASSWORD: z.string().optional(),
   },
@@ -98,6 +105,7 @@ export const env = createEnv({
     JUPITER_API_KEY: process.env.JUPITER_API_KEY,
     SENTRY_DSN: process.env.SENTRY_DSN,
     ONBOARDING_ENDPOINT: process.env.ONBOARDING_ENDPOINT,
+    ECC_VERIFIER_URL: process.env.ECC_VERIFIER_URL,
     FEE_PAYER_WALLET_PATH: process.env.FEE_PAYER_WALLET_PATH,
     MIGRATION_PASSWORD: process.env.MIGRATION_PASSWORD,
     NEXT_PUBLIC_WORLD_HELIUM_URL: process.env.NEXT_PUBLIC_WORLD_HELIUM_URL,

--- a/packages/blockchain-api/src/lib/env.ts
+++ b/packages/blockchain-api/src/lib/env.ts
@@ -51,10 +51,12 @@ export const env = createEnv({
       .default("https://onboarding.dewi.org/api/v3"),
     // ECC verifier service that co-signs data-only hotspot issue transactions
     // after verifying the gateway's ECC key signature. Base URL; the issue
-    // procedure POSTs to `${ECC_VERIFIER_URL}/verify`.
+    // procedure POSTs to `${ECC_VERIFIER_URL}/verify`. Require https so the
+    // transaction to be co-signed is never sent over a cleartext channel.
     ECC_VERIFIER_URL: z
       .string()
       .url()
+      .refine((u) => u.startsWith("https://"), "ECC_VERIFIER_URL must be https")
       .default("https://ecc-verifier.web.helium.io"),
     FEE_PAYER_WALLET_PATH: z.string().optional(),
     MIGRATION_PASSWORD: z.string().optional(),

--- a/packages/blockchain-api/src/lib/solana.ts
+++ b/packages/blockchain-api/src/lib/solana.ts
@@ -1,6 +1,5 @@
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import { AnchorProvider } from "@coral-xyz/anchor";
-import { HELIUM_COMMON_LUT, HELIUM_COMMON_LUT_DEVNET } from "@helium/spl-utils";
 import { env } from "./env";
 import fs from "fs";
 
@@ -18,15 +17,9 @@ export function getCluster(): string {
   return process.env.NEXT_PUBLIC_SOLANA_CLUSTER || "mainnet";
 }
 
-/** The Helium common address-lookup table for the active cluster. */
-export const getCommonLut = (): PublicKey =>
-  process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
-    ? HELIUM_COMMON_LUT_DEVNET
-    : HELIUM_COMMON_LUT;
-
 export function loadKeypair(keypair: string): Keypair {
   return Keypair.fromSecretKey(
-    new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString())),
+    new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString()))
   );
 }
 
@@ -40,7 +33,7 @@ function getConnection(): Connection {
 }
 
 export function createSolanaConnection(
-  walletAddress: string,
+  walletAddress: string
 ): SolanaConnection {
   const connection = getConnection();
   const wallet = {
@@ -55,7 +48,7 @@ export function createSolanaConnection(
   const provider = new AnchorProvider(
     connection,
     wallet,
-    AnchorProvider.defaultOptions(),
+    AnchorProvider.defaultOptions()
   );
 
   return {

--- a/packages/blockchain-api/src/lib/solana.ts
+++ b/packages/blockchain-api/src/lib/solana.ts
@@ -1,5 +1,6 @@
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import { AnchorProvider } from "@coral-xyz/anchor";
+import { HELIUM_COMMON_LUT, HELIUM_COMMON_LUT_DEVNET } from "@helium/spl-utils";
 import { env } from "./env";
 import fs from "fs";
 
@@ -16,6 +17,12 @@ export interface SolanaConnection {
 export function getCluster(): string {
   return process.env.NEXT_PUBLIC_SOLANA_CLUSTER || "mainnet";
 }
+
+/** The Helium common address-lookup table for the active cluster. */
+export const getCommonLut = (): PublicKey =>
+  process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
+    ? HELIUM_COMMON_LUT_DEVNET
+    : HELIUM_COMMON_LUT;
 
 export function loadKeypair(keypair: string): Keypair {
   return Keypair.fromSecretKey(

--- a/packages/blockchain-api/src/lib/utils/automation-helpers.ts
+++ b/packages/blockchain-api/src/lib/utils/automation-helpers.ts
@@ -52,6 +52,20 @@ export function getScheduleCronString(schedule: Schedule): string {
   }
 }
 
+const SCHEDULE_PRESETS: readonly Schedule[] = ["daily", "weekly", "monthly"];
+
+/**
+ * Resolve a setup input into a raw crontab string. The preset cadences
+ * (daily/weekly/monthly) map through getScheduleCronString; any other value is
+ * treated as an already-raw clockwork crontab and returned unchanged. Lets
+ * callers pass either a convenient preset or a full crontab.
+ */
+export function resolveScheduleToCron(scheduleOrCron: string): string {
+  return (SCHEDULE_PRESETS as readonly string[]).includes(scheduleOrCron)
+    ? getScheduleCronString(scheduleOrCron as Schedule)
+    : scheduleOrCron;
+}
+
 export interface CronScheduleInfo {
   schedule: Schedule;
   time: string;

--- a/packages/blockchain-api/src/lib/utils/automation-helpers.ts
+++ b/packages/blockchain-api/src/lib/utils/automation-helpers.ts
@@ -88,8 +88,8 @@ export function interpretCronString(cronString: string): CronScheduleInfo {
       now.getUTCDate(),
       parseInt(hours, 10),
       parseInt(minutes, 10),
-      parseInt(seconds, 10)
-    )
+      parseInt(seconds, 10),
+    ),
   );
 
   // Convert UTC to local time for display
@@ -119,7 +119,7 @@ export function interpretCronString(cronString: string): CronScheduleInfo {
     const targetDay = parseInt(dayOfWeek, 10);
     const daysUntil = targetDay - currentDay;
     nextRunUTC.setUTCDate(
-      now.getUTCDate() + (daysUntil >= 0 ? daysUntil : 7 + daysUntil)
+      now.getUTCDate() + (daysUntil >= 0 ? daysUntil : 7 + daysUntil),
     );
     nextRun.setTime(nextRunUTC.getTime());
   } else {
@@ -144,7 +144,7 @@ export function interpretCronString(cronString: string): CronScheduleInfo {
  */
 export function calculateCronJobCostPerClaim(
   minCrankReward: number,
-  numCronTransactions: number
+  numCronTransactions: number,
 ): number {
   return (1 + numCronTransactions) * minCrankReward;
 }
@@ -164,7 +164,7 @@ export function calculatePdaWalletCostPerClaim(totalHotspots: number): number {
  */
 export function calculatePoolPeriods(
   balanceLamports: number,
-  costPerClaimLamports: number
+  costPerClaimLamports: number,
 ): number {
   return Math.max(0, Math.floor(balanceLamports / costPerClaimLamports));
 }
@@ -191,7 +191,7 @@ export interface CalculatePeriodsRemainingParams {
  * - Recipient rent: already committed rent for recipients
  */
 export function calculatePeriodsRemaining(
-  params: CalculatePeriodsRemainingParams
+  params: CalculatePeriodsRemainingParams,
 ): {
   periodLength: Schedule;
   periodsRemaining: number; // Minimum of both pools
@@ -214,7 +214,9 @@ export function calculatePeriodsRemaining(
   // Cron job must maintain rent for the account and task return account
   const availableCronJobBalance = Math.max(
     0,
-    cronJobBalanceLamports - cronJobRentLamports - taskReturnAccountRentLamports
+    cronJobBalanceLamports -
+      cronJobRentLamports -
+      taskReturnAccountRentLamports,
   );
 
   // PDA wallet must maintain minimum rent, plus any recipient rent and ATA rent
@@ -223,24 +225,24 @@ export function calculatePeriodsRemaining(
     pdaWalletBalanceLamports -
       PDA_WALLET_RENT_LAMPORTS -
       recipientRentLamports -
-      ataRentLamports
+      ataRentLamports,
   );
 
   // Calculate periods remaining for each pool independently
   const cronJobPeriodsRemaining = calculatePoolPeriods(
     availableCronJobBalance,
-    cronJobCostPerClaimLamports
+    cronJobCostPerClaimLamports,
   );
   const pdaWalletPeriodsRemaining = calculatePoolPeriods(
     availablePdaWalletBalance,
-    pdaWalletCostPerClaimLamports
+    pdaWalletCostPerClaimLamports,
   );
 
   // The effective periods remaining is the minimum of both pools
   // since both are required for each claim
   const periodsRemaining = Math.min(
     cronJobPeriodsRemaining,
-    pdaWalletPeriodsRemaining
+    pdaWalletPeriodsRemaining,
   );
 
   return {
@@ -265,7 +267,7 @@ export interface CalculateFundingNeededParams {
  * Returns funding needed in lamports for each pool.
  */
 export function calculateFundingNeededForTargetPeriods(
-  params: CalculateFundingNeededParams
+  params: CalculateFundingNeededParams,
 ): {
   cronJobFundingLamports: number;
   pdaWalletFundingLamports: number;
@@ -280,11 +282,11 @@ export function calculateFundingNeededForTargetPeriods(
 
   const cronJobPeriods = calculatePoolPeriods(
     availableCronJobBalanceLamports,
-    cronJobCostPerClaimLamports
+    cronJobCostPerClaimLamports,
   );
   const pdaWalletPeriods = calculatePoolPeriods(
     availablePdaWalletBalanceLamports,
-    pdaWalletCostPerClaimLamports
+    pdaWalletCostPerClaimLamports,
   );
 
   // Calculate funding needed for each pool independently to reach target periods
@@ -319,7 +321,7 @@ export interface CalculateFundingForAdditionalDurationParams {
  * Handles all the logic for calculating available balances, current periods, and target periods.
  */
 export function calculateFundingForAdditionalDuration(
-  params: CalculateFundingForAdditionalDurationParams
+  params: CalculateFundingForAdditionalDurationParams,
 ): {
   cronJobFundingLamports: number;
   pdaWalletFundingLamports: number;
@@ -357,7 +359,7 @@ export function calculateFundingForAdditionalDuration(
   const pdaWalletRentShortfall = Math.max(0, -pdaWalletBalanceAfterRent);
   const availablePdaWalletBalanceLamports = Math.max(
     0,
-    pdaWalletBalanceAfterRent
+    pdaWalletBalanceAfterRent,
   );
 
   // Calculate how much of the shortfall covers recipient rent
@@ -367,17 +369,17 @@ export function calculateFundingForAdditionalDuration(
     pdaWalletBalanceLamports - PDA_WALLET_RENT_LAMPORTS;
   const pdaWalletRentShortfallOnly = Math.max(
     0,
-    -pdaWalletBalanceAfterPdaRentOnly
+    -pdaWalletBalanceAfterPdaRentOnly,
   );
   // The remaining shortfall (after covering PDA wallet rent) goes to recipient rent and ATA rent
   // Recipient rent covered = min(remaining shortfall, recipientRentLamports)
   const shortfallAfterPdaRent = Math.max(
     0,
-    pdaWalletRentShortfall - pdaWalletRentShortfallOnly
+    pdaWalletRentShortfall - pdaWalletRentShortfallOnly,
   );
   const recipientRentCoveredByShortfall = Math.min(
     shortfallAfterPdaRent,
-    recipientRentLamports
+    recipientRentLamports,
   );
 
   // If there's no shortfall, the balance covers all rent including recipient rent,
@@ -387,11 +389,11 @@ export function calculateFundingForAdditionalDuration(
   // Calculate current periods for each pool
   const cronJobPeriods = calculatePoolPeriods(
     availableCronJobBalanceLamports,
-    cronJobCostPerClaimLamports
+    cronJobCostPerClaimLamports,
   );
   const pdaWalletPeriods = calculatePoolPeriods(
     availablePdaWalletBalanceLamports,
-    pdaWalletCostPerClaimLamports
+    pdaWalletCostPerClaimLamports,
   );
   const currentMinPeriods = Math.min(cronJobPeriods, pdaWalletPeriods);
 

--- a/packages/blockchain-api/src/lib/utils/automation-helpers.ts
+++ b/packages/blockchain-api/src/lib/utils/automation-helpers.ts
@@ -2,6 +2,14 @@ import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 
 export type Schedule = "daily" | "weekly" | "monthly";
 
+/**
+ * Cron-job name-mapping alias. hpl_crons hardcodes this in
+ * init_entity_claim_cron_v0, and the name-mapping PDA is keyed by
+ * (authority, name) — so a wallet has exactly one entity-claim cron. close and
+ * requeue must pass this same name mapping.
+ */
+export const ENTITY_CLAIM_CRON_NAME = "entity_claim";
+
 // Constants from useAutomateHotspotClaims hook
 export const BASE_AUTOMATION_RENT = 0.02098095;
 export const TASK_RETURN_ACCOUNT_SIZE = 0.01;
@@ -66,8 +74,8 @@ export function interpretCronString(cronString: string): CronScheduleInfo {
       now.getUTCDate(),
       parseInt(hours, 10),
       parseInt(minutes, 10),
-      parseInt(seconds, 10),
-    ),
+      parseInt(seconds, 10)
+    )
   );
 
   // Convert UTC to local time for display
@@ -97,7 +105,7 @@ export function interpretCronString(cronString: string): CronScheduleInfo {
     const targetDay = parseInt(dayOfWeek, 10);
     const daysUntil = targetDay - currentDay;
     nextRunUTC.setUTCDate(
-      now.getUTCDate() + (daysUntil >= 0 ? daysUntil : 7 + daysUntil),
+      now.getUTCDate() + (daysUntil >= 0 ? daysUntil : 7 + daysUntil)
     );
     nextRun.setTime(nextRunUTC.getTime());
   } else {
@@ -122,7 +130,7 @@ export function interpretCronString(cronString: string): CronScheduleInfo {
  */
 export function calculateCronJobCostPerClaim(
   minCrankReward: number,
-  numCronTransactions: number,
+  numCronTransactions: number
 ): number {
   return (1 + numCronTransactions) * minCrankReward;
 }
@@ -142,7 +150,7 @@ export function calculatePdaWalletCostPerClaim(totalHotspots: number): number {
  */
 export function calculatePoolPeriods(
   balanceLamports: number,
-  costPerClaimLamports: number,
+  costPerClaimLamports: number
 ): number {
   return Math.max(0, Math.floor(balanceLamports / costPerClaimLamports));
 }
@@ -169,7 +177,7 @@ export interface CalculatePeriodsRemainingParams {
  * - Recipient rent: already committed rent for recipients
  */
 export function calculatePeriodsRemaining(
-  params: CalculatePeriodsRemainingParams,
+  params: CalculatePeriodsRemainingParams
 ): {
   periodLength: Schedule;
   periodsRemaining: number; // Minimum of both pools
@@ -192,9 +200,7 @@ export function calculatePeriodsRemaining(
   // Cron job must maintain rent for the account and task return account
   const availableCronJobBalance = Math.max(
     0,
-    cronJobBalanceLamports -
-      cronJobRentLamports -
-      taskReturnAccountRentLamports,
+    cronJobBalanceLamports - cronJobRentLamports - taskReturnAccountRentLamports
   );
 
   // PDA wallet must maintain minimum rent, plus any recipient rent and ATA rent
@@ -203,24 +209,24 @@ export function calculatePeriodsRemaining(
     pdaWalletBalanceLamports -
       PDA_WALLET_RENT_LAMPORTS -
       recipientRentLamports -
-      ataRentLamports,
+      ataRentLamports
   );
 
   // Calculate periods remaining for each pool independently
   const cronJobPeriodsRemaining = calculatePoolPeriods(
     availableCronJobBalance,
-    cronJobCostPerClaimLamports,
+    cronJobCostPerClaimLamports
   );
   const pdaWalletPeriodsRemaining = calculatePoolPeriods(
     availablePdaWalletBalance,
-    pdaWalletCostPerClaimLamports,
+    pdaWalletCostPerClaimLamports
   );
 
   // The effective periods remaining is the minimum of both pools
   // since both are required for each claim
   const periodsRemaining = Math.min(
     cronJobPeriodsRemaining,
-    pdaWalletPeriodsRemaining,
+    pdaWalletPeriodsRemaining
   );
 
   return {
@@ -245,7 +251,7 @@ export interface CalculateFundingNeededParams {
  * Returns funding needed in lamports for each pool.
  */
 export function calculateFundingNeededForTargetPeriods(
-  params: CalculateFundingNeededParams,
+  params: CalculateFundingNeededParams
 ): {
   cronJobFundingLamports: number;
   pdaWalletFundingLamports: number;
@@ -260,11 +266,11 @@ export function calculateFundingNeededForTargetPeriods(
 
   const cronJobPeriods = calculatePoolPeriods(
     availableCronJobBalanceLamports,
-    cronJobCostPerClaimLamports,
+    cronJobCostPerClaimLamports
   );
   const pdaWalletPeriods = calculatePoolPeriods(
     availablePdaWalletBalanceLamports,
-    pdaWalletCostPerClaimLamports,
+    pdaWalletCostPerClaimLamports
   );
 
   // Calculate funding needed for each pool independently to reach target periods
@@ -299,7 +305,7 @@ export interface CalculateFundingForAdditionalDurationParams {
  * Handles all the logic for calculating available balances, current periods, and target periods.
  */
 export function calculateFundingForAdditionalDuration(
-  params: CalculateFundingForAdditionalDurationParams,
+  params: CalculateFundingForAdditionalDurationParams
 ): {
   cronJobFundingLamports: number;
   pdaWalletFundingLamports: number;
@@ -337,7 +343,7 @@ export function calculateFundingForAdditionalDuration(
   const pdaWalletRentShortfall = Math.max(0, -pdaWalletBalanceAfterRent);
   const availablePdaWalletBalanceLamports = Math.max(
     0,
-    pdaWalletBalanceAfterRent,
+    pdaWalletBalanceAfterRent
   );
 
   // Calculate how much of the shortfall covers recipient rent
@@ -347,17 +353,17 @@ export function calculateFundingForAdditionalDuration(
     pdaWalletBalanceLamports - PDA_WALLET_RENT_LAMPORTS;
   const pdaWalletRentShortfallOnly = Math.max(
     0,
-    -pdaWalletBalanceAfterPdaRentOnly,
+    -pdaWalletBalanceAfterPdaRentOnly
   );
   // The remaining shortfall (after covering PDA wallet rent) goes to recipient rent and ATA rent
   // Recipient rent covered = min(remaining shortfall, recipientRentLamports)
   const shortfallAfterPdaRent = Math.max(
     0,
-    pdaWalletRentShortfall - pdaWalletRentShortfallOnly,
+    pdaWalletRentShortfall - pdaWalletRentShortfallOnly
   );
   const recipientRentCoveredByShortfall = Math.min(
     shortfallAfterPdaRent,
-    recipientRentLamports,
+    recipientRentLamports
   );
 
   // If there's no shortfall, the balance covers all rent including recipient rent,
@@ -367,11 +373,11 @@ export function calculateFundingForAdditionalDuration(
   // Calculate current periods for each pool
   const cronJobPeriods = calculatePoolPeriods(
     availableCronJobBalanceLamports,
-    cronJobCostPerClaimLamports,
+    cronJobCostPerClaimLamports
   );
   const pdaWalletPeriods = calculatePoolPeriods(
     availablePdaWalletBalanceLamports,
-    pdaWalletCostPerClaimLamports,
+    pdaWalletCostPerClaimLamports
   );
   const currentMinPeriods = Math.min(cronJobPeriods, pdaWalletPeriods);
 

--- a/packages/blockchain-api/src/lib/utils/build-transaction.ts
+++ b/packages/blockchain-api/src/lib/utils/build-transaction.ts
@@ -5,6 +5,7 @@ import {
   TransactionInstruction,
   VersionedTransaction,
 } from "@solana/web3.js";
+import { NATIVE_MINT } from "@solana/spl-token";
 import {
   HELIUM_COMMON_LUT,
   HELIUM_COMMON_LUT_DEVNET,
@@ -12,7 +13,13 @@ import {
   toVersionedTx,
   withPriorityFees,
 } from "@helium/spl-utils";
+import BN from "bn.js";
 import { env } from "@/lib/env";
+import {
+  calculateRequiredBalance,
+  getTransactionFee,
+} from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
 
 export function getHeliumLookupTable(): PublicKey {
   return env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
@@ -53,7 +60,7 @@ export async function buildVersionedTransaction({
   } catch (error) {
     console.warn(
       "[buildVersionedTransaction] Priority fee estimation failed, using default instructions:",
-      error,
+      error
     );
     instructionsWithFees = draftWithLuts.instructions;
   }
@@ -64,14 +71,14 @@ export async function buildVersionedTransaction({
       await populateMissingDraftInfo(
         connection,
         { ...draftWithLuts, instructions: instructionsWithFees },
-        "finalized",
-      ),
+        "finalized"
+      )
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (message.includes("encoding overruns")) {
       throw new Error(
-        `Transaction too large to serialize (${instructionsWithFees.length} instructions). Split into smaller batches.`,
+        `Transaction too large to serialize (${instructionsWithFees.length} instructions). Split into smaller batches.`
       );
     }
     throw error;
@@ -86,4 +93,83 @@ export async function buildVersionedTransaction({
 
 export function serializeTransaction(tx: VersionedTransaction): string {
   return Buffer.from(tx.serialize()).toString("base64");
+}
+
+/**
+ * Shared tail for the direct (non-Squads) single-transaction endpoints: build
+ * the unsigned tx, verify the fee payer can cover the fee plus rent and the
+ * min-wallet buffer, and return the standard `{ transactionData, estimatedSolFee }`
+ * envelope. Mirrors `buildAutomationTransactionResponse` for the single-tx case.
+ *
+ * Only for endpoints whose required balance is exactly
+ * `calculateRequiredBalance(fee, rentLamports)` and whose reported fee is that
+ * same amount; endpoints that add a transfer amount or report a different fee
+ * build their response inline.
+ */
+export async function buildSingleTransactionResponse({
+  connection,
+  instructions,
+  feePayer,
+  addressLookupTableAddresses,
+  rentLamports = 0,
+  insufficientFundsMessage,
+  errors,
+  tag,
+  transactionMetadata,
+  actionMetadata,
+}: {
+  connection: Connection;
+  instructions: TransactionInstruction[];
+  feePayer: PublicKey;
+  addressLookupTableAddresses?: PublicKey[];
+  rentLamports?: number;
+  insufficientFundsMessage: string;
+  errors: {
+    INSUFFICIENT_FUNDS: (opts: {
+      message: string;
+      data: { required: number; available: number };
+    }) => Error;
+  };
+  tag: string;
+  transactionMetadata: {
+    type: string;
+    description: string;
+    [key: string]: unknown;
+  };
+  actionMetadata: Record<string, unknown>;
+}) {
+  const tx = await buildVersionedTransaction({
+    connection,
+    draft: { instructions, feePayer, addressLookupTableAddresses },
+  });
+
+  const required = calculateRequiredBalance(
+    getTransactionFee(tx),
+    rentLamports
+  );
+  const available = await connection.getBalance(feePayer);
+  if (available < required) {
+    throw errors.INSUFFICIENT_FUNDS({
+      message: insufficientFundsMessage,
+      data: { required, available },
+    });
+  }
+
+  return {
+    transactionData: {
+      transactions: [
+        {
+          serializedTransaction: serializeTransaction(tx),
+          metadata: transactionMetadata,
+        },
+      ],
+      parallel: false,
+      tag,
+      actionMetadata,
+    },
+    estimatedSolFee: await toTokenAmountOutput(
+      new BN(required),
+      NATIVE_MINT.toBase58()
+    ),
+  };
 }

--- a/packages/blockchain-api/src/lib/utils/hotspot-helpers.ts
+++ b/packages/blockchain-api/src/lib/utils/hotspot-helpers.ts
@@ -1,12 +1,45 @@
 import KeyToAsset from "@/lib/models/key-to-asset";
-import { init, keyToAssetKey } from "@helium/helium-entity-manager-sdk";
+import {
+  entityCreatorKey,
+  init,
+  keyToAssetKey,
+} from "@helium/helium-entity-manager-sdk";
 import { daoKey } from "@helium/helium-sub-daos-sdk";
-import { HNT_MINT } from "@helium/spl-utils";
+import { HNT_MINT, type Asset } from "@helium/spl-utils";
+import { PROGRAM_ID as BUBBLEGUM_PROGRAM_ID } from "@metaplex-foundation/mpl-bubblegum";
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import bs58 from "bs58";
 import { env } from "../env";
 import { connectToDb } from "./db";
 import * as anchor from "@coral-xyz/anchor";
+
+const DAO_KEY = daoKey(HNT_MINT)[0];
+
+/** Derive the bubblegum tree authority PDA for a cNFT's Merkle tree. */
+export const getBubblegumAuthorityPDA = async (
+  merkleRollPubKey: PublicKey,
+): Promise<PublicKey> => {
+  const [bubblegumAuthorityPDAKey] = await PublicKey.findProgramAddress(
+    [merkleRollPubKey.toBuffer()],
+    BUBBLEGUM_PROGRAM_ID,
+  );
+  return bubblegumAuthorityPDAKey;
+};
+
+/** Whether a cNFT was verified-minted by the Helium entity creator. */
+export const validateHeliumHotspot = (asset: Asset): boolean => {
+  const heliumEntityCreator = entityCreatorKey(DAO_KEY)[0].toBase58();
+
+  return (
+    asset.creators?.some((creator) => {
+      const address =
+        typeof creator.address === "string"
+          ? creator.address
+          : creator.address.toBase58();
+      return address === heliumEntityCreator && creator.verified;
+    }) || false
+  );
+};
 
 type HemProgram = Awaited<ReturnType<typeof init>>;
 type HemIdl = HemProgram extends anchor.Program<infer T> ? T : never;
@@ -14,13 +47,13 @@ type HemIdl = HemProgram extends anchor.Program<infer T> ? T : never;
 let hemProgram: HemProgram | null = null;
 
 export const initHemLocal = async (
-  provider: anchor.AnchorProvider
+  provider: anchor.AnchorProvider,
 ): Promise<HemProgram> => {
   if (hemProgram) {
     return hemProgram;
   }
   const HEM_PROGRAM_ID = new PublicKey(
-    "hemjuPXBpNvggtaUnN1MwT3wrdhttKEfosTcc2P9Pg8"
+    "hemjuPXBpNvggtaUnN1MwT3wrdhttKEfosTcc2P9Pg8",
   );
   const idl = await anchor.Program.fetchIdl(HEM_PROGRAM_ID, provider);
   hemProgram = new anchor.Program(idl as HemIdl, provider);
@@ -57,7 +90,7 @@ const decodeEntityKey = (encodedEntityKey: string): Buffer | null => {
 };
 
 export const getAssetIdFromPubkey = async (
-  encodedEntityKey: string
+  encodedEntityKey: string,
 ): Promise<string | null> => {
   if (env.NO_PG === "true") {
     // Use ASSET_ENDPOINT when available — surfpool may not have KeyToAsset PDAs
@@ -75,13 +108,12 @@ export const getAssetIdFromPubkey = async (
     const provider = new anchor.AnchorProvider(
       connection,
       wallet,
-      anchor.AnchorProvider.defaultOptions()
+      anchor.AnchorProvider.defaultOptions(),
     );
     const [keyToAssetK] = keyToAssetKey(daoKey(HNT_MINT)[0], encodedEntityKey);
     const program = await initHemLocal(provider);
-    const keyToAsset = await program.account.keyToAssetV0.fetchNullable(
-      keyToAssetK
-    );
+    const keyToAsset =
+      await program.account.keyToAssetV0.fetchNullable(keyToAssetK);
     return keyToAsset?.asset.toBase58() || null;
   } else {
     await connectToDb();

--- a/packages/blockchain-api/src/lib/utils/hotspot-helpers.ts
+++ b/packages/blockchain-api/src/lib/utils/hotspot-helpers.ts
@@ -14,29 +14,28 @@ import { connectToDb } from "./db";
 import * as anchor from "@coral-xyz/anchor";
 
 const DAO_KEY = daoKey(HNT_MINT)[0];
+const HELIUM_ENTITY_CREATOR = entityCreatorKey(DAO_KEY)[0].toBase58();
 
 /** Derive the bubblegum tree authority PDA for a cNFT's Merkle tree. */
 export const getBubblegumAuthorityPDA = async (
-  merkleRollPubKey: PublicKey,
+  merkleRollPubKey: PublicKey
 ): Promise<PublicKey> => {
   const [bubblegumAuthorityPDAKey] = await PublicKey.findProgramAddress(
     [merkleRollPubKey.toBuffer()],
-    BUBBLEGUM_PROGRAM_ID,
+    BUBBLEGUM_PROGRAM_ID
   );
   return bubblegumAuthorityPDAKey;
 };
 
 /** Whether a cNFT was verified-minted by the Helium entity creator. */
 export const validateHeliumHotspot = (asset: Asset): boolean => {
-  const heliumEntityCreator = entityCreatorKey(DAO_KEY)[0].toBase58();
-
   return (
     asset.creators?.some((creator) => {
       const address =
         typeof creator.address === "string"
           ? creator.address
           : creator.address.toBase58();
-      return address === heliumEntityCreator && creator.verified;
+      return address === HELIUM_ENTITY_CREATOR && creator.verified;
     }) || false
   );
 };
@@ -47,13 +46,13 @@ type HemIdl = HemProgram extends anchor.Program<infer T> ? T : never;
 let hemProgram: HemProgram | null = null;
 
 export const initHemLocal = async (
-  provider: anchor.AnchorProvider,
+  provider: anchor.AnchorProvider
 ): Promise<HemProgram> => {
   if (hemProgram) {
     return hemProgram;
   }
   const HEM_PROGRAM_ID = new PublicKey(
-    "hemjuPXBpNvggtaUnN1MwT3wrdhttKEfosTcc2P9Pg8",
+    "hemjuPXBpNvggtaUnN1MwT3wrdhttKEfosTcc2P9Pg8"
   );
   const idl = await anchor.Program.fetchIdl(HEM_PROGRAM_ID, provider);
   hemProgram = new anchor.Program(idl as HemIdl, provider);
@@ -90,7 +89,7 @@ const decodeEntityKey = (encodedEntityKey: string): Buffer | null => {
 };
 
 export const getAssetIdFromPubkey = async (
-  encodedEntityKey: string,
+  encodedEntityKey: string
 ): Promise<string | null> => {
   if (env.NO_PG === "true") {
     // Use ASSET_ENDPOINT when available — surfpool may not have KeyToAsset PDAs
@@ -108,12 +107,13 @@ export const getAssetIdFromPubkey = async (
     const provider = new anchor.AnchorProvider(
       connection,
       wallet,
-      anchor.AnchorProvider.defaultOptions(),
+      anchor.AnchorProvider.defaultOptions()
     );
     const [keyToAssetK] = keyToAssetKey(daoKey(HNT_MINT)[0], encodedEntityKey);
     const program = await initHemLocal(provider);
-    const keyToAsset =
-      await program.account.keyToAssetV0.fetchNullable(keyToAssetK);
+    const keyToAsset = await program.account.keyToAssetV0.fetchNullable(
+      keyToAssetK
+    );
     return keyToAsset?.asset.toBase58() || null;
   } else {
     await connectToDb();

--- a/packages/blockchain-api/src/lib/utils/pending-rewards.ts
+++ b/packages/blockchain-api/src/lib/utils/pending-rewards.ts
@@ -1,0 +1,24 @@
+import type { BulkRewards } from "@helium/distributor-oracle";
+import BN from "bn.js";
+
+/**
+ * Pending oracle rewards for a single entity: the median of the oracles'
+ * reported `currentRewards` minus what the recipient has already been
+ * distributed. Sorts with `BN.cmp` (subtracting and calling `.toNumber()`
+ * overflows for large reward amounts). The result may be negative when the
+ * recipient is ahead of the current median; callers clamp or compare as needed.
+ */
+export const pendingOracleRewards = (
+  rewards: BulkRewards[],
+  entityKey: string,
+  recipientAcc: { totalRewards?: BN } | null | undefined
+): BN => {
+  const sortedOracleRewards = rewards
+    .map((rew) => new BN(rew.currentRewards[entityKey] || 0))
+    .sort((a, b) => a.cmp(b));
+  const oracleMedian =
+    sortedOracleRewards[Math.floor(sortedOracleRewards.length / 2)] ??
+    new BN(0);
+  const alreadyDistributed = recipientAcc?.totalRewards ?? new BN(0);
+  return oracleMedian.sub(alreadyDistributed);
+};

--- a/packages/blockchain-api/src/lib/utils/transaction-tags.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-tags.ts
@@ -57,6 +57,14 @@ export const TRANSACTION_TYPES = {
   SQUADS_PROPOSAL_EXECUTE: "squads_proposal_execute",
   SQUADS_CONFIG_CHANGE: "squads_config_change",
 
+  // Squads propose mode of the action endpoints
+  TOKEN_TRANSFER_PROPOSAL: "token_transfer_proposal",
+  TOKEN_BURN_PROPOSAL: "token_burn_proposal",
+  BURN_DATA_CREDITS_PROPOSAL: "burn_data_credits_proposal",
+  DELEGATE_DATA_CREDITS_PROPOSAL: "delegate_data_credits_proposal",
+  HOTSPOT_BURN_PROPOSAL: "hotspot_burn_proposal",
+  HOTSPOT_TRANSFER_PROPOSAL: "hotspot_transfer_proposal",
+
   // Governance - Position Management
   POSITION_CREATE: "position_create",
   POSITION_CLOSE: "position_close",

--- a/packages/blockchain-api/src/lib/utils/transaction-tags.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-tags.ts
@@ -8,13 +8,10 @@ export function generateTransactionTag(params: {
 
   const sortedParams = Object.keys(otherParams)
     .sort()
-    .reduce(
-      (acc, key) => {
-        acc[key] = otherParams[key];
-        return acc;
-      },
-      {} as Record<string, any>,
-    );
+    .reduce((acc, key) => {
+      acc[key] = otherParams[key];
+      return acc;
+    }, {} as Record<string, any>);
 
   const paramString = JSON.stringify({ type, ...sortedParams });
 
@@ -33,6 +30,8 @@ export const TRANSACTION_TYPES = {
   REMOVE_SPLIT: "remove_split",
   ADD_SPLIT: "add_split",
   TOKEN_TRANSFER: "token_transfer",
+  TOKEN_BURN: "token_burn",
+  MEMO: "memo",
   HOTSPOT_TRANSFER: "hotspot_transfer",
   HOTSPOT_REASSERT: "hotspot_reassert",
   HOTSPOT_UPDATE: "hotspot_update",

--- a/packages/blockchain-api/src/lib/utils/transaction-tags.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-tags.ts
@@ -47,6 +47,13 @@ export const TRANSACTION_TYPES = {
   DELEGATE_DATA_CREDITS: "delegate_data_credits",
   BURN_DATA_CREDITS: "burn_data_credits",
 
+  // Squads v4 multisig
+  SQUADS_PROPOSAL_APPROVE: "squads_proposal_approve",
+  SQUADS_PROPOSAL_REJECT: "squads_proposal_reject",
+  SQUADS_PROPOSAL_CANCEL: "squads_proposal_cancel",
+  SQUADS_PROPOSAL_EXECUTE: "squads_proposal_execute",
+  SQUADS_CONFIG_CHANGE: "squads_config_change",
+
   // Governance - Position Management
   POSITION_CREATE: "position_create",
   POSITION_CLOSE: "position_close",

--- a/packages/blockchain-api/src/lib/utils/transaction-tags.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-tags.ts
@@ -8,10 +8,13 @@ export function generateTransactionTag(params: {
 
   const sortedParams = Object.keys(otherParams)
     .sort()
-    .reduce((acc, key) => {
-      acc[key] = otherParams[key];
-      return acc;
-    }, {} as Record<string, any>);
+    .reduce(
+      (acc, key) => {
+        acc[key] = otherParams[key];
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
 
   const paramString = JSON.stringify({ type, ...sortedParams });
 

--- a/packages/blockchain-api/src/lib/utils/transaction-tags.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-tags.ts
@@ -33,6 +33,7 @@ export const TRANSACTION_TYPES = {
   TOKEN_BURN: "token_burn",
   MEMO: "memo",
   HOTSPOT_TRANSFER: "hotspot_transfer",
+  HOTSPOT_BURN: "hotspot_burn",
   HOTSPOT_REASSERT: "hotspot_reassert",
   HOTSPOT_UPDATE: "hotspot_update",
   BANK_SEND: "bank_send",

--- a/packages/blockchain-api/src/lib/utils/transaction-tags.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-tags.ts
@@ -44,6 +44,7 @@ export const TRANSACTION_TYPES = {
   MIGRATION: "migration",
   MINT_DATA_CREDITS: "mint_data_credits",
   DELEGATE_DATA_CREDITS: "delegate_data_credits",
+  BURN_DATA_CREDITS: "burn_data_credits",
 
   // Governance - Position Management
   POSITION_CREATE: "position_create",

--- a/packages/blockchain-api/src/server/api/index.ts
+++ b/packages/blockchain-api/src/server/api/index.ts
@@ -11,6 +11,7 @@ import { fiatRouter } from "./routers/fiat/router";
 import { webhooksRouter } from "./routers/webhooks/router";
 import { migrationRouter } from "./routers/migration/router";
 import { dataCreditsRouter } from "./routers/data-credits/router";
+import { squadsRouter } from "./routers/squads/router";
 import { implement } from "@orpc/server";
 import { fullApiContract, apiContract } from "@helium/blockchain-api";
 
@@ -25,6 +26,7 @@ const sharedRouters = {
   welcomePacks: welcomePacksRouter,
   migration: migrationRouter,
   dataCredits: dataCreditsRouter,
+  squads: squadsRouter,
 };
 
 export const publicRouter = implement(apiContract).router(sharedRouters);

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/burn.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/burn.ts
@@ -13,14 +13,17 @@ import {
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
 import { getTransactionFee } from "@/lib/utils/balance-validation";
-import { buildActionProposal } from "../../squads/procedures/helpers";
+import {
+  buildActionProposal,
+  proposalTransactionData,
+} from "../../squads/procedures/helpers";
 import BN from "bn.js";
 
 /** Burn `amount` DC (burnWithoutTrackingV0) from `authority`'s DC account. */
 async function buildBurnDcInstruction(
   program: Awaited<ReturnType<typeof initDc>>,
   authority: PublicKey,
-  amount: string
+  amount: string,
 ): Promise<TransactionInstruction> {
   return program.methods
     .burnWithoutTrackingV0({ amount: new BN(amount) })
@@ -74,30 +77,20 @@ export const burn = publicProcedure.dataCredits.burn.handler(
             }),
         });
 
-      return {
-        transactions: [
-          {
-            serializedTransaction,
-            metadata: {
-              type: "burn_data_credits_proposal",
-              description: `Propose burn of ${amount} DC`,
-            },
-          },
-        ],
-        parallel: false,
+      return proposalTransactionData({
+        serializedTransaction,
+        type: TRANSACTION_TYPES.BURN_DATA_CREDITS_PROPOSAL,
+        description: `Propose burn of ${amount} DC`,
         tag: generateTransactionTag({
           type: TRANSACTION_TYPES.BURN_DATA_CREDITS,
           userAddress: owner,
           amount,
           multisig: input.multisig,
         }),
-        actionMetadata: {
-          type: "burn_data_credits_proposal",
-          multisig: input.multisig,
-          transactionIndex,
-          amount,
-        },
-      };
+        multisig: input.multisig,
+        transactionIndex,
+        actionMetadata: { amount },
+      });
     }
 
     // ---- Direct burn from the owner ----
@@ -137,5 +130,5 @@ export const burn = publicProcedure.dataCredits.burn.handler(
       tag,
       actionMetadata: { type: "burn_data_credits", amount },
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/burn.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/burn.ts
@@ -1,0 +1,80 @@
+import { publicProcedure } from "../../../procedures";
+import { PublicKey } from "@solana/web3.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { createSolanaConnection } from "@/lib/solana";
+import { init as initDc, dataCreditsKey } from "@helium/data-credits-sdk";
+import { DC_MINT } from "@helium/spl-utils";
+import {
+  buildVersionedTransaction,
+  serializeTransaction,
+} from "@/lib/utils/build-transaction";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "@/lib/utils/transaction-tags";
+import { getTransactionFee } from "@/lib/utils/balance-validation";
+import BN from "bn.js";
+
+/**
+ * Burn data credits directly from the owner's DC account
+ * (burnWithoutTrackingV0). Delegated-DC burns are a separate, heavier flow and
+ * are not handled here.
+ */
+export const burn = publicProcedure.dataCredits.burn.handler(
+  async ({ input, errors }) => {
+    const { owner, amount } = input;
+
+    const { provider, connection } = createSolanaConnection(owner);
+    const feePayer = new PublicKey(owner);
+    const program = await initDc(provider);
+
+    const ix = await program.methods
+      .burnWithoutTrackingV0({ amount: new BN(amount) })
+      .accountsPartial({
+        // `burnAccounts` is a composite account struct on the instruction;
+        // its members must be nested, not flattened.
+        burnAccounts: {
+          burner: getAssociatedTokenAddressSync(DC_MINT, feePayer, true),
+          dcMint: DC_MINT,
+          dataCredits: dataCreditsKey(DC_MINT)[0],
+          owner: feePayer,
+        },
+      })
+      .instruction();
+
+    const tx = await buildVersionedTransaction({
+      connection,
+      draft: { instructions: [ix], feePayer },
+    });
+
+    const txFee = getTransactionFee(tx);
+    const walletBalance = await connection.getBalance(feePayer);
+    if (walletBalance < txFee) {
+      throw errors.INSUFFICIENT_FUNDS({
+        message: "Insufficient SOL balance to burn data credits",
+        data: { required: txFee, available: walletBalance },
+      });
+    }
+
+    const tag = generateTransactionTag({
+      type: TRANSACTION_TYPES.BURN_DATA_CREDITS,
+      userAddress: owner,
+      amount,
+    });
+
+    return {
+      transactions: [
+        {
+          serializedTransaction: serializeTransaction(tx),
+          metadata: {
+            type: "burn_data_credits",
+            description: `Burn ${amount} DC`,
+          },
+        },
+      ],
+      parallel: false,
+      tag,
+      actionMetadata: { type: "burn_data_credits", amount },
+    };
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/burn.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/burn.ts
@@ -23,7 +23,7 @@ import BN from "bn.js";
 async function buildBurnDcInstruction(
   program: Awaited<ReturnType<typeof initDc>>,
   authority: PublicKey,
-  amount: string,
+  amount: string
 ): Promise<TransactionInstruction> {
   return program.methods
     .burnWithoutTrackingV0({ amount: new BN(amount) })
@@ -65,16 +65,8 @@ export const burn = publicProcedure.dataCredits.burn.handler(
           buildInstructions: async (vault) => [
             await buildBurnDcInstruction(program, vault, amount),
           ],
-          insufficientFunds: ({ required, available }) =>
-            errors.INSUFFICIENT_FUNDS({
-              message:
-                "Insufficient SOL balance to create the DC burn proposal",
-              data: { required, available },
-            }),
-          notFound: () =>
-            errors.NOT_FOUND({
-              message: `Multisig ${input.multisig} not found`,
-            }),
+          errors,
+          action: "DC burn",
         });
 
       return proposalTransactionData({
@@ -130,5 +122,5 @@ export const burn = publicProcedure.dataCredits.burn.handler(
       tag,
       actionMetadata: { type: "burn_data_credits", amount },
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/burn.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/burn.ts
@@ -1,5 +1,5 @@
 import { publicProcedure } from "../../../procedures";
-import { PublicKey } from "@solana/web3.js";
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { createSolanaConnection } from "@/lib/solana";
 import { init as initDc, dataCreditsKey } from "@helium/data-credits-sdk";
@@ -13,7 +13,29 @@ import {
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
 import { getTransactionFee } from "@/lib/utils/balance-validation";
+import { buildActionProposal } from "../../squads/procedures/helpers";
 import BN from "bn.js";
+
+/** Burn `amount` DC (burnWithoutTrackingV0) from `authority`'s DC account. */
+async function buildBurnDcInstruction(
+  program: Awaited<ReturnType<typeof initDc>>,
+  authority: PublicKey,
+  amount: string
+): Promise<TransactionInstruction> {
+  return program.methods
+    .burnWithoutTrackingV0({ amount: new BN(amount) })
+    .accountsPartial({
+      // `burnAccounts` is a composite account struct on the instruction;
+      // its members must be nested, not flattened.
+      burnAccounts: {
+        burner: getAssociatedTokenAddressSync(DC_MINT, authority, true),
+        dcMint: DC_MINT,
+        dataCredits: dataCreditsKey(DC_MINT)[0],
+        owner: authority,
+      },
+    })
+    .instruction();
+}
 
 /**
  * Burn data credits directly from the owner's DC account
@@ -28,19 +50,58 @@ export const burn = publicProcedure.dataCredits.burn.handler(
     const feePayer = new PublicKey(owner);
     const program = await initDc(provider);
 
-    const ix = await program.methods
-      .burnWithoutTrackingV0({ amount: new BN(amount) })
-      .accountsPartial({
-        // `burnAccounts` is a composite account struct on the instruction;
-        // its members must be nested, not flattened.
-        burnAccounts: {
-          burner: getAssociatedTokenAddressSync(DC_MINT, feePayer, true),
-          dcMint: DC_MINT,
-          dataCredits: dataCreditsKey(DC_MINT)[0],
-          owner: feePayer,
+    // ---- Squads propose mode: burn from the vault's DC account ----
+    if (input.multisig) {
+      const multisigPda = new PublicKey(input.multisig);
+      const { serializedTransaction, transactionIndex } =
+        await buildActionProposal({
+          connection,
+          multisigPda,
+          member: feePayer,
+          memo: input.memo,
+          buildInstructions: async (vault) => [
+            await buildBurnDcInstruction(program, vault, amount),
+          ],
+          insufficientFunds: ({ required, available }) =>
+            errors.INSUFFICIENT_FUNDS({
+              message:
+                "Insufficient SOL balance to create the DC burn proposal",
+              data: { required, available },
+            }),
+          notFound: () =>
+            errors.NOT_FOUND({
+              message: `Multisig ${input.multisig} not found`,
+            }),
+        });
+
+      return {
+        transactions: [
+          {
+            serializedTransaction,
+            metadata: {
+              type: "burn_data_credits_proposal",
+              description: `Propose burn of ${amount} DC`,
+            },
+          },
+        ],
+        parallel: false,
+        tag: generateTransactionTag({
+          type: TRANSACTION_TYPES.BURN_DATA_CREDITS,
+          userAddress: owner,
+          amount,
+          multisig: input.multisig,
+        }),
+        actionMetadata: {
+          type: "burn_data_credits_proposal",
+          multisig: input.multisig,
+          transactionIndex,
+          amount,
         },
-      })
-      .instruction();
+      };
+    }
+
+    // ---- Direct burn from the owner ----
+    const ix = await buildBurnDcInstruction(program, feePayer, amount);
 
     const tx = await buildVersionedTransaction({
       connection,

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/delegate.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/delegate.ts
@@ -19,7 +19,7 @@ import {
 import BN from "bn.js";
 
 const MEMO_PROGRAM_ID = new PublicKey(
-  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
 );
 
 export const delegate = publicProcedure.dataCredits.delegate.handler(
@@ -32,9 +32,9 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
     const subDao = subDaoKey(new PublicKey(mint))[0];
 
     // ---- Squads propose mode: delegate the vault's DC, wrapped as a proposal.
-    // The delegate authority (owner) is resolved by anchor from the provider
-    // wallet, so build the instruction with a vault-scoped provider. `memo` is
-    // recorded on the proposal rather than as an in-tx memo here.
+    // The vault is both the DC owner (authority) and the payer for the escrow
+    // init, passed explicitly so anchor resolves `fromAccount` to the vault's DC
+    // ATA. `memo` is recorded on the proposal rather than as an in-tx memo here.
     if (input.multisig) {
       const multisigPda = new PublicKey(input.multisig);
       const { serializedTransaction, transactionIndex } =
@@ -43,28 +43,14 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
           multisigPda,
           member: feePayer,
           memo,
-          buildInstructions: async (vault) => {
-            const { provider: vaultProvider } = createSolanaConnection(
-              vault.toBase58(),
-            );
-            const vaultProgram = await initDc(vaultProvider);
-            return [
-              await vaultProgram.methods
-                .delegateDataCreditsV0({ amount: new BN(amount), routerKey })
-                .accountsPartial({ subDao })
-                .instruction(),
-            ];
-          },
-          insufficientFunds: ({ required, available }) =>
-            errors.INSUFFICIENT_FUNDS({
-              message:
-                "Insufficient SOL balance to create the delegate proposal",
-              data: { required, available },
-            }),
-          notFound: () =>
-            errors.NOT_FOUND({
-              message: `Multisig ${input.multisig} not found`,
-            }),
+          buildInstructions: async (vault) => [
+            await program.methods
+              .delegateDataCreditsV0({ amount: new BN(amount), routerKey })
+              .accountsPartial({ subDao, owner: vault, payer: vault })
+              .instruction(),
+          ],
+          errors,
+          action: "delegate",
         });
 
       return proposalTransactionData({
@@ -72,7 +58,7 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
         type: TRANSACTION_TYPES.DELEGATE_DATA_CREDITS_PROPOSAL,
         description: `Propose delegation of ${amount} DC to router ${routerKey.substring(
           0,
-          8,
+          8
         )}...`,
         tag: generateTransactionTag({
           type: TRANSACTION_TYPES.DELEGATE_DATA_CREDITS,
@@ -96,7 +82,7 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
           keys: [{ pubkey: feePayer, isSigner: true, isWritable: false }],
           programId: MEMO_PROGRAM_ID,
           data: Buffer.from(memo, "utf-8"),
-        }),
+        })
       );
     }
 
@@ -109,7 +95,7 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
         .accountsPartial({
           subDao,
         })
-        .instruction(),
+        .instruction()
     );
 
     const tx = await buildVersionedTransaction({
@@ -145,7 +131,7 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
             type: "delegate_data_credits",
             description: `Delegate ${amount} DC to router ${routerKey.substring(
               0,
-              8,
+              8
             )}...`,
           },
         },
@@ -159,5 +145,5 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
         mint,
       },
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/delegate.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/delegate.ts
@@ -12,6 +12,7 @@ import {
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
 import { getTransactionFee } from "@/lib/utils/balance-validation";
+import { buildActionProposal } from "../../squads/procedures/helpers";
 import BN from "bn.js";
 
 const MEMO_PROGRAM_ID = new PublicKey(
@@ -26,6 +27,75 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
     const feePayer = new PublicKey(owner);
     const program = await initDc(provider);
     const subDao = subDaoKey(new PublicKey(mint))[0];
+
+    // ---- Squads propose mode: delegate the vault's DC, wrapped as a proposal.
+    // The delegate authority (owner) is resolved by anchor from the provider
+    // wallet, so build the instruction with a vault-scoped provider. `memo` is
+    // recorded on the proposal rather than as an in-tx memo here.
+    if (input.multisig) {
+      const multisigPda = new PublicKey(input.multisig);
+      const { serializedTransaction, transactionIndex } =
+        await buildActionProposal({
+          connection,
+          multisigPda,
+          member: feePayer,
+          memo,
+          buildInstructions: async (vault) => {
+            const { provider: vaultProvider } = createSolanaConnection(
+              vault.toBase58()
+            );
+            const vaultProgram = await initDc(vaultProvider);
+            return [
+              await vaultProgram.methods
+                .delegateDataCreditsV0({ amount: new BN(amount), routerKey })
+                .accountsPartial({ subDao })
+                .instruction(),
+            ];
+          },
+          insufficientFunds: ({ required, available }) =>
+            errors.INSUFFICIENT_FUNDS({
+              message:
+                "Insufficient SOL balance to create the delegate proposal",
+              data: { required, available },
+            }),
+          notFound: () =>
+            errors.NOT_FOUND({
+              message: `Multisig ${input.multisig} not found`,
+            }),
+        });
+
+      return {
+        transactions: [
+          {
+            serializedTransaction,
+            metadata: {
+              type: "delegate_data_credits_proposal",
+              description: `Propose delegation of ${amount} DC to router ${routerKey.substring(
+                0,
+                8
+              )}...`,
+            },
+          },
+        ],
+        parallel: false,
+        tag: generateTransactionTag({
+          type: TRANSACTION_TYPES.DELEGATE_DATA_CREDITS,
+          userAddress: owner,
+          routerKey,
+          amount,
+          mint,
+          multisig: input.multisig,
+        }),
+        actionMetadata: {
+          type: "delegate_data_credits_proposal",
+          multisig: input.multisig,
+          transactionIndex,
+          routerKey,
+          amount,
+          mint,
+        },
+      };
+    }
 
     const instructions: TransactionInstruction[] = [];
 
@@ -82,13 +152,21 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
           serializedTransaction: serializeTransaction(tx),
           metadata: {
             type: "delegate_data_credits",
-            description: `Delegate ${amount} DC to router ${routerKey.substring(0, 8)}...`,
+            description: `Delegate ${amount} DC to router ${routerKey.substring(
+              0,
+              8
+            )}...`,
           },
         },
       ],
       parallel: false,
       tag,
-      actionMetadata: { type: "delegate_data_credits", routerKey, amount, mint },
+      actionMetadata: {
+        type: "delegate_data_credits",
+        routerKey,
+        amount,
+        mint,
+      },
     };
   }
 );

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/delegate.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/delegate.ts
@@ -12,11 +12,14 @@ import {
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
 import { getTransactionFee } from "@/lib/utils/balance-validation";
-import { buildActionProposal } from "../../squads/procedures/helpers";
+import {
+  buildActionProposal,
+  proposalTransactionData,
+} from "../../squads/procedures/helpers";
 import BN from "bn.js";
 
 const MEMO_PROGRAM_ID = new PublicKey(
-  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
 );
 
 export const delegate = publicProcedure.dataCredits.delegate.handler(
@@ -42,7 +45,7 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
           memo,
           buildInstructions: async (vault) => {
             const { provider: vaultProvider } = createSolanaConnection(
-              vault.toBase58()
+              vault.toBase58(),
             );
             const vaultProgram = await initDc(vaultProvider);
             return [
@@ -64,20 +67,13 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
             }),
         });
 
-      return {
-        transactions: [
-          {
-            serializedTransaction,
-            metadata: {
-              type: "delegate_data_credits_proposal",
-              description: `Propose delegation of ${amount} DC to router ${routerKey.substring(
-                0,
-                8
-              )}...`,
-            },
-          },
-        ],
-        parallel: false,
+      return proposalTransactionData({
+        serializedTransaction,
+        type: TRANSACTION_TYPES.DELEGATE_DATA_CREDITS_PROPOSAL,
+        description: `Propose delegation of ${amount} DC to router ${routerKey.substring(
+          0,
+          8,
+        )}...`,
         tag: generateTransactionTag({
           type: TRANSACTION_TYPES.DELEGATE_DATA_CREDITS,
           userAddress: owner,
@@ -86,15 +82,10 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
           mint,
           multisig: input.multisig,
         }),
-        actionMetadata: {
-          type: "delegate_data_credits_proposal",
-          multisig: input.multisig,
-          transactionIndex,
-          routerKey,
-          amount,
-          mint,
-        },
-      };
+        multisig: input.multisig,
+        transactionIndex,
+        actionMetadata: { routerKey, amount, mint },
+      });
     }
 
     const instructions: TransactionInstruction[] = [];
@@ -105,7 +96,7 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
           keys: [{ pubkey: feePayer, isSigner: true, isWritable: false }],
           programId: MEMO_PROGRAM_ID,
           data: Buffer.from(memo, "utf-8"),
-        })
+        }),
       );
     }
 
@@ -118,7 +109,7 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
         .accountsPartial({
           subDao,
         })
-        .instruction()
+        .instruction(),
     );
 
     const tx = await buildVersionedTransaction({
@@ -154,7 +145,7 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
             type: "delegate_data_credits",
             description: `Delegate ${amount} DC to router ${routerKey.substring(
               0,
-              8
+              8,
             )}...`,
           },
         },
@@ -168,5 +159,5 @@ export const delegate = publicProcedure.dataCredits.delegate.handler(
         mint,
       },
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/mint.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/mint.ts
@@ -41,6 +41,11 @@ export const mint = publicProcedure.dataCredits.mint.handler(
 
     const program = await initDc(provider);
 
+    // Note: minting has no Squads propose mode. mintDataCreditsV0 checks Pyth
+    // price freshness on-chain and requires a fresh price posted in the same
+    // transaction; a Squads proposal executes later, by which point any posted
+    // or referenced price is stale (verified: the program throws
+    // PythPriceNotFound). Delegation and burns are proposable; minting is not.
     const { txs } = await mintDataCredits({
       program,
       dcAmount: dcAmount ? new BN(dcAmount) : undefined,
@@ -53,11 +58,19 @@ export const mint = publicProcedure.dataCredits.mint.handler(
     const jitoTipCost = useJito ? getJitoTipAmountLamports() : 0;
 
     // Check if recipient's DC ATA needs creation (init_if_needed on-chain)
-    const recipientPubkey = recipient ? new PublicKey(recipient) : new PublicKey(owner);
-    const recipientDcAta = getAssociatedTokenAddressSync(DC_MINT, recipientPubkey);
+    const recipientPubkey = recipient
+      ? new PublicKey(recipient)
+      : new PublicKey(owner);
+    const recipientDcAta = getAssociatedTokenAddressSync(
+      DC_MINT,
+      recipientPubkey
+    );
     const recipientDcAtaInfo = await connection.getAccountInfo(recipientDcAta);
     const ataRent = recipientDcAtaInfo ? 0 : RENT_COSTS.ATA;
-    const requiredBalance = calculateRequiredBalance(txFees + jitoTipCost, ataRent);
+    const requiredBalance = calculateRequiredBalance(
+      txFees + jitoTipCost,
+      ataRent
+    );
 
     const ownerPubkey = new PublicKey(owner);
     const walletBalance = await connection.getBalance(ownerPubkey);
@@ -105,7 +118,12 @@ export const mint = publicProcedure.dataCredits.mint.handler(
       transactions,
       parallel: false,
       tag,
-      actionMetadata: { type: "mint_data_credits", dcAmount: dcAmount || undefined, hntAmount: hntAmount || undefined, recipient: recipient || undefined },
+      actionMetadata: {
+        type: "mint_data_credits",
+        dcAmount: dcAmount || undefined,
+        hntAmount: hntAmount || undefined,
+        recipient: recipient || undefined,
+      },
     };
   }
 );

--- a/packages/blockchain-api/src/server/api/routers/data-credits/router.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/router.ts
@@ -1,9 +1,11 @@
 import { mint } from "./procedures/mint";
 import { delegate } from "./procedures/delegate";
+import { burn } from "./procedures/burn";
 import { dataCreditsContract } from "@helium/blockchain-api/contracts";
 import { implement } from "@orpc/server";
 
 export const dataCreditsRouter = implement(dataCreditsContract).router({
   mint,
   delegate,
+  burn,
 });

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/addEntityToAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/addEntityToAutomation.ts
@@ -1,0 +1,117 @@
+import { createSolanaConnection, getCluster } from "@/lib/solana";
+import * as anchor from "@coral-xyz/anchor";
+import {
+  cronJobKey,
+  cronJobTransactionKey,
+  init as initCron,
+} from "@helium/cron-sdk";
+import {
+  entityCronAuthorityKey,
+  init as initHplCrons,
+} from "@helium/hpl-crons-sdk";
+import { keyToAssetKey } from "@helium/helium-entity-manager-sdk";
+import { daoKey } from "@helium/helium-sub-daos-sdk";
+import {
+  HELIUM_COMMON_LUT,
+  HELIUM_COMMON_LUT_DEVNET,
+  HNT_MINT,
+  batchInstructionsToTxsWithPriorityFee,
+  toVersionedTx,
+} from "@helium/spl-utils";
+import { PublicKey } from "@solana/web3.js";
+import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
+import { publicProcedure } from "../../../procedures";
+import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+
+const HNT_DAO = daoKey(HNT_MINT)[0];
+
+/**
+ * Create a transaction to add a single hotspot's claim to an existing
+ * automation. The cron claims that one entity each time it fires.
+ */
+export const addEntityToAutomation =
+  publicProcedure.hotspots.addEntityToAutomation.handler(
+    async ({ input, errors }) => {
+      const { walletAddress, entityKey } = input;
+
+      const wallet = new PublicKey(walletAddress);
+      const { provider } = createSolanaConnection(walletAddress);
+      anchor.setProvider(provider);
+
+      const hplCronsProgram = await initHplCrons(provider);
+      const cronProgram = await initCron(provider);
+
+      const authority = entityCronAuthorityKey(wallet)[0];
+      const cronJob = cronJobKey(authority, 0)[0];
+
+      const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
+        cronJob
+      );
+      if (!cronJobAccount) {
+        throw errors.NOT_FOUND({
+          message: "Automation not found. Please set up automation first.",
+        });
+      }
+
+      const [keyToAsset] = keyToAssetKey(HNT_DAO, entityKey);
+
+      const index = cronJobAccount.nextTransactionId || 0;
+      const { instruction } = await hplCronsProgram.methods
+        .addEntityToCronV0({ index })
+        .accounts({
+          keyToAsset,
+          cronJob,
+          cronJobTransaction: cronJobTransactionKey(cronJob, index)[0],
+        })
+        .prepare();
+
+      const vtxs = (
+        await batchInstructionsToTxsWithPriorityFee(provider, [instruction], {
+          addressLookupTableAddresses: [
+            process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
+              ? HELIUM_COMMON_LUT_DEVNET
+              : HELIUM_COMMON_LUT,
+          ],
+          computeUnitLimit: 500000,
+          commitment: "finalized",
+        })
+      ).map((tx) => toVersionedTx(tx));
+
+      if (shouldUseJitoBundle(vtxs.length, getCluster())) {
+        vtxs.push(await getJitoTipTransaction(wallet));
+      }
+
+      const txs = vtxs.map((tx) =>
+        Buffer.from(tx.serialize()).toString("base64")
+      );
+      const txFees = getTotalTransactionFees(vtxs);
+
+      return {
+        transactionData: {
+          transactions: txs.map((serialized) => ({
+            serializedTransaction: serialized,
+            metadata: {
+              type: "add_entity_to_automation",
+              description: "Add hotspot claim to automation",
+              entityKey,
+              index,
+            },
+          })),
+          parallel: false,
+          tag: `add_entity_to_automation:${walletAddress}`,
+          actionMetadata: {
+            type: "add_entity_to_automation",
+            entityKey,
+            index,
+          },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(txFees),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+  );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/addEntityToAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/addEntityToAutomation.ts
@@ -1,30 +1,12 @@
-import { createSolanaConnection, getCluster } from "@/lib/solana";
-import * as anchor from "@coral-xyz/anchor";
-import {
-  cronJobKey,
-  cronJobTransactionKey,
-  init as initCron,
-} from "@helium/cron-sdk";
-import {
-  entityCronAuthorityKey,
-  init as initHplCrons,
-} from "@helium/hpl-crons-sdk";
+import { cronJobTransactionKey } from "@helium/cron-sdk";
 import { keyToAssetKey } from "@helium/helium-entity-manager-sdk";
 import { daoKey } from "@helium/helium-sub-daos-sdk";
-import {
-  HELIUM_COMMON_LUT,
-  HELIUM_COMMON_LUT_DEVNET,
-  HNT_MINT,
-  batchInstructionsToTxsWithPriorityFee,
-  toVersionedTx,
-} from "@helium/spl-utils";
-import { PublicKey } from "@solana/web3.js";
-import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
+import { HNT_MINT } from "@helium/spl-utils";
 import { publicProcedure } from "../../../procedures";
-import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
-import { toTokenAmountOutput } from "@/lib/utils/token-math";
-import { NATIVE_MINT } from "@solana/spl-token";
-import BN from "bn.js";
+import {
+  buildAutomationTransactionResponse,
+  resolveEntityClaimCronJob,
+} from "./automation-transaction";
 
 const HNT_DAO = daoKey(HNT_MINT)[0];
 
@@ -37,24 +19,13 @@ export const addEntityToAutomation =
     async ({ input, errors }) => {
       const { walletAddress, entityKey } = input;
 
-      const wallet = new PublicKey(walletAddress);
-      const { provider } = createSolanaConnection(walletAddress);
-      anchor.setProvider(provider);
-
-      const hplCronsProgram = await initHplCrons(provider);
-      const cronProgram = await initCron(provider);
-
-      const authority = entityCronAuthorityKey(wallet)[0];
-      const cronJob = cronJobKey(authority, 0)[0];
-
-      const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
-        cronJob
-      );
-      if (!cronJobAccount) {
-        throw errors.NOT_FOUND({
-          message: "Automation not found. Please set up automation first.",
+      const { provider, hplCronsProgram, cronJob, cronJobAccount, wallet } =
+        await resolveEntityClaimCronJob({
+          walletAddress,
+          notFoundMessage:
+            "Automation not found. Please set up automation first.",
+          errors,
         });
-      }
 
       const [keyToAsset] = keyToAssetKey(HNT_DAO, entityKey);
 
@@ -68,50 +39,22 @@ export const addEntityToAutomation =
         })
         .prepare();
 
-      const vtxs = (
-        await batchInstructionsToTxsWithPriorityFee(provider, [instruction], {
-          addressLookupTableAddresses: [
-            process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
-              ? HELIUM_COMMON_LUT_DEVNET
-              : HELIUM_COMMON_LUT,
-          ],
-          computeUnitLimit: 500000,
-          commitment: "finalized",
-        })
-      ).map((tx) => toVersionedTx(tx));
-
-      if (shouldUseJitoBundle(vtxs.length, getCluster())) {
-        vtxs.push(await getJitoTipTransaction(wallet));
-      }
-
-      const txs = vtxs.map((tx) =>
-        Buffer.from(tx.serialize()).toString("base64")
-      );
-      const txFees = getTotalTransactionFees(vtxs);
-
-      return {
-        transactionData: {
-          transactions: txs.map((serialized) => ({
-            serializedTransaction: serialized,
-            metadata: {
-              type: "add_entity_to_automation",
-              description: "Add hotspot claim to automation",
-              entityKey,
-              index,
-            },
-          })),
-          parallel: false,
-          tag: `add_entity_to_automation:${walletAddress}`,
-          actionMetadata: {
-            type: "add_entity_to_automation",
-            entityKey,
-            index,
-          },
+      return buildAutomationTransactionResponse({
+        provider,
+        instructions: [instruction],
+        feePayer: wallet,
+        tag: `add_entity_to_automation:${walletAddress}`,
+        transactionMetadata: {
+          type: "add_entity_to_automation",
+          description: "Add hotspot claim to automation",
+          entityKey,
+          index,
         },
-        estimatedSolFee: await toTokenAmountOutput(
-          new BN(txFees),
-          NATIVE_MINT.toBase58()
-        ),
-      };
-    }
+        actionMetadata: {
+          type: "add_entity_to_automation",
+          entityKey,
+          index,
+        },
+      });
+    },
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/addWalletToAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/addWalletToAutomation.ts
@@ -1,0 +1,108 @@
+import { createSolanaConnection, getCluster } from "@/lib/solana";
+import * as anchor from "@coral-xyz/anchor";
+import {
+  cronJobKey,
+  cronJobTransactionKey,
+  init as initCron,
+} from "@helium/cron-sdk";
+import {
+  entityCronAuthorityKey,
+  init as initHplCrons,
+} from "@helium/hpl-crons-sdk";
+import {
+  HELIUM_COMMON_LUT,
+  HELIUM_COMMON_LUT_DEVNET,
+  batchInstructionsToTxsWithPriorityFee,
+  toVersionedTx,
+} from "@helium/spl-utils";
+import { PublicKey } from "@solana/web3.js";
+import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
+import { publicProcedure } from "../../../procedures";
+import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+
+/**
+ * Create a transaction to add a whole-wallet claim to an existing automation.
+ * The cron will claim every hotspot the wallet owns each time it fires.
+ */
+export const addWalletToAutomation =
+  publicProcedure.hotspots.addWalletToAutomation.handler(
+    async ({ input, errors }) => {
+      const { walletAddress } = input;
+
+      const wallet = new PublicKey(walletAddress);
+      const { provider } = createSolanaConnection(walletAddress);
+      anchor.setProvider(provider);
+
+      const hplCronsProgram = await initHplCrons(provider);
+      const cronProgram = await initCron(provider);
+
+      const authority = entityCronAuthorityKey(wallet)[0];
+      const cronJob = cronJobKey(authority, 0)[0];
+
+      const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
+        cronJob
+      );
+      if (!cronJobAccount) {
+        throw errors.NOT_FOUND({
+          message: "Automation not found. Please set up automation first.",
+        });
+      }
+
+      const index = cronJobAccount.nextTransactionId || 0;
+      const { instruction } = await hplCronsProgram.methods
+        .addWalletToEntityCronV0({ index })
+        .accounts({
+          wallet,
+          cronJob,
+          cronJobTransaction: cronJobTransactionKey(cronJob, index)[0],
+        })
+        .prepare();
+
+      const vtxs = (
+        await batchInstructionsToTxsWithPriorityFee(provider, [instruction], {
+          addressLookupTableAddresses: [
+            process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
+              ? HELIUM_COMMON_LUT_DEVNET
+              : HELIUM_COMMON_LUT,
+          ],
+          computeUnitLimit: 500000,
+          commitment: "finalized",
+        })
+      ).map((tx) => toVersionedTx(tx));
+
+      if (shouldUseJitoBundle(vtxs.length, getCluster())) {
+        vtxs.push(await getJitoTipTransaction(wallet));
+      }
+
+      const txs = vtxs.map((tx) =>
+        Buffer.from(tx.serialize()).toString("base64")
+      );
+      const txFees = getTotalTransactionFees(vtxs);
+
+      return {
+        transactionData: {
+          transactions: txs.map((serialized) => ({
+            serializedTransaction: serialized,
+            metadata: {
+              type: "add_wallet_to_automation",
+              description: "Add whole-wallet claim to automation",
+              index,
+            },
+          })),
+          parallel: false,
+          tag: `add_wallet_to_automation:${walletAddress}`,
+          actionMetadata: {
+            type: "add_wallet_to_automation",
+            index,
+          },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(txFees),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+  );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/addWalletToAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/addWalletToAutomation.ts
@@ -1,27 +1,9 @@
-import { createSolanaConnection, getCluster } from "@/lib/solana";
-import * as anchor from "@coral-xyz/anchor";
-import {
-  cronJobKey,
-  cronJobTransactionKey,
-  init as initCron,
-} from "@helium/cron-sdk";
-import {
-  entityCronAuthorityKey,
-  init as initHplCrons,
-} from "@helium/hpl-crons-sdk";
-import {
-  HELIUM_COMMON_LUT,
-  HELIUM_COMMON_LUT_DEVNET,
-  batchInstructionsToTxsWithPriorityFee,
-  toVersionedTx,
-} from "@helium/spl-utils";
-import { PublicKey } from "@solana/web3.js";
-import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
+import { cronJobTransactionKey } from "@helium/cron-sdk";
 import { publicProcedure } from "../../../procedures";
-import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
-import { toTokenAmountOutput } from "@/lib/utils/token-math";
-import { NATIVE_MINT } from "@solana/spl-token";
-import BN from "bn.js";
+import {
+  buildAutomationTransactionResponse,
+  resolveEntityClaimCronJob,
+} from "./automation-transaction";
 
 /**
  * Create a transaction to add a whole-wallet claim to an existing automation.
@@ -32,24 +14,13 @@ export const addWalletToAutomation =
     async ({ input, errors }) => {
       const { walletAddress } = input;
 
-      const wallet = new PublicKey(walletAddress);
-      const { provider } = createSolanaConnection(walletAddress);
-      anchor.setProvider(provider);
-
-      const hplCronsProgram = await initHplCrons(provider);
-      const cronProgram = await initCron(provider);
-
-      const authority = entityCronAuthorityKey(wallet)[0];
-      const cronJob = cronJobKey(authority, 0)[0];
-
-      const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
-        cronJob
-      );
-      if (!cronJobAccount) {
-        throw errors.NOT_FOUND({
-          message: "Automation not found. Please set up automation first.",
+      const { provider, hplCronsProgram, cronJob, cronJobAccount, wallet } =
+        await resolveEntityClaimCronJob({
+          walletAddress,
+          notFoundMessage:
+            "Automation not found. Please set up automation first.",
+          errors,
         });
-      }
 
       const index = cronJobAccount.nextTransactionId || 0;
       const { instruction } = await hplCronsProgram.methods
@@ -61,48 +32,20 @@ export const addWalletToAutomation =
         })
         .prepare();
 
-      const vtxs = (
-        await batchInstructionsToTxsWithPriorityFee(provider, [instruction], {
-          addressLookupTableAddresses: [
-            process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
-              ? HELIUM_COMMON_LUT_DEVNET
-              : HELIUM_COMMON_LUT,
-          ],
-          computeUnitLimit: 500000,
-          commitment: "finalized",
-        })
-      ).map((tx) => toVersionedTx(tx));
-
-      if (shouldUseJitoBundle(vtxs.length, getCluster())) {
-        vtxs.push(await getJitoTipTransaction(wallet));
-      }
-
-      const txs = vtxs.map((tx) =>
-        Buffer.from(tx.serialize()).toString("base64")
-      );
-      const txFees = getTotalTransactionFees(vtxs);
-
-      return {
-        transactionData: {
-          transactions: txs.map((serialized) => ({
-            serializedTransaction: serialized,
-            metadata: {
-              type: "add_wallet_to_automation",
-              description: "Add whole-wallet claim to automation",
-              index,
-            },
-          })),
-          parallel: false,
-          tag: `add_wallet_to_automation:${walletAddress}`,
-          actionMetadata: {
-            type: "add_wallet_to_automation",
-            index,
-          },
+      return buildAutomationTransactionResponse({
+        provider,
+        instructions: [instruction],
+        feePayer: wallet,
+        tag: `add_wallet_to_automation:${walletAddress}`,
+        transactionMetadata: {
+          type: "add_wallet_to_automation",
+          description: "Add whole-wallet claim to automation",
+          index,
         },
-        estimatedSolFee: await toTokenAmountOutput(
-          new BN(txFees),
-          NATIVE_MINT.toBase58()
-        ),
-      };
-    }
+        actionMetadata: {
+          type: "add_wallet_to_automation",
+          index,
+        },
+      });
+    },
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-data-helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-data-helpers.ts
@@ -1,18 +1,34 @@
-import { Connection, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import {
+  AccountInfo,
+  Connection,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+  TransactionInstruction,
+} from "@solana/web3.js";
 import * as anchor from "@coral-xyz/anchor";
-import { entityCronAuthorityKey } from "@helium/hpl-crons-sdk";
+import {
+  entityCronAuthorityKey,
+  init as initHplCrons,
+} from "@helium/hpl-crons-sdk";
 import {
   cronJobKey,
+  cronJobNameMappingKey,
   cronJobTransactionKey,
   init as initCron,
   PROGRAM_ID,
 } from "@helium/cron-sdk";
-import { init as initTuktuk, customSignerKey } from "@helium/tuktuk-sdk";
+import {
+  init as initTuktuk,
+  customSignerKey,
+  nextAvailableTaskIds,
+  taskKey,
+} from "@helium/tuktuk-sdk";
 import { getHotspotsByOwner } from "@/lib/queries/hotspots";
 import { getNumRecipientsNeeded } from "@/lib/queries/hotspots";
 import {
   calculateCronJobCostPerClaim,
   calculatePdaWalletCostPerClaim,
+  ENTITY_CLAIM_CRON_NAME,
   RECIPIENT_RENT,
   ATA_RENT,
   TASK_RETURN_ACCOUNT_SIZE,
@@ -38,8 +54,81 @@ export async function liveCronTransactionIds(
     { length: nextTransactionId },
     (_, i) => cronJobTransactionKey(cronJob, i)[0]
   );
-  const infos = await connection.getMultipleAccountsInfo(keys);
+  // We only need existence, so fetch no account data. getMultipleAccountsInfo
+  // caps at 100 keys per call, so chunk the list.
+  const infos: (AccountInfo<Buffer> | null)[] = [];
+  for (let i = 0; i < keys.length; i += 100) {
+    infos.push(
+      ...(await connection.getMultipleAccountsInfo(keys.slice(i, i + 100), {
+        dataSlice: { offset: 0, length: 0 },
+      }))
+    );
+  }
   return keys.map((_, i) => i).filter((i) => infos[i] != null);
+}
+
+/**
+ * Build the instructions that tear down a wallet's entity-claim cron: remove
+ * every live claim (skipping the holes individually-removed claims leave in the
+ * monotonic nextTransactionId counter) then close the cron and its name
+ * mapping. All freed rent is refunded to `rentRefund`.
+ */
+export async function buildTeardownInstructions(
+  connection: Connection,
+  hplCronsProgram: Awaited<ReturnType<typeof initHplCrons>>,
+  cronJob: PublicKey,
+  authority: PublicKey,
+  rentRefund: PublicKey,
+  nextTransactionId: number
+): Promise<TransactionInstruction[]> {
+  const liveTxIds = await liveCronTransactionIds(
+    connection,
+    cronJob,
+    nextTransactionId
+  );
+
+  return [
+    ...(await Promise.all(
+      liveTxIds.map((txId) =>
+        hplCronsProgram.methods
+          .removeEntityFromCronV0({ index: txId })
+          .accounts({
+            cronJob,
+            rentRefund,
+            cronJobTransaction: cronJobTransactionKey(cronJob, txId)[0],
+          })
+          .instruction()
+      )
+    )),
+    await hplCronsProgram.methods
+      .closeEntityClaimCronV0()
+      .accounts({
+        cronJob,
+        rentRefund,
+        cronJobNameMapping: cronJobNameMappingKey(
+          authority,
+          ENTITY_CLAIM_CRON_NAME
+        )[0],
+      })
+      .instruction(),
+  ];
+}
+
+/**
+ * Fetch the task queue fresh and return the key of the next free task slot.
+ * Throws when the queue has no free slots.
+ */
+export async function nextFreeTaskKey(
+  tuktukProgram: Awaited<ReturnType<typeof initTuktuk>>
+): Promise<PublicKey> {
+  const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
+    TASK_QUEUE_ID
+  );
+  const [taskId] = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 1, false);
+  if (taskId == null) {
+    throw new Error("No available task IDs in task queue");
+  }
+  return taskKey(TASK_QUEUE_ID, taskId)[0];
 }
 
 export interface AutomationData {
@@ -66,8 +155,7 @@ export interface AutomationData {
  */
 export async function fetchAutomationData(
   walletAddress: string,
-  provider: anchor.AnchorProvider,
-  cronId: number = 0
+  provider: anchor.AnchorProvider
 ): Promise<AutomationData> {
   const wallet = new PublicKey(walletAddress);
 
@@ -77,7 +165,7 @@ export async function fetchAutomationData(
 
   // Derive keys
   const authority = entityCronAuthorityKey(wallet)[0];
-  const cronJob = cronJobKey(authority, cronId)[0];
+  const cronJob = cronJobKey(authority, 0)[0];
   const pdaWallet = customSignerKey(TASK_QUEUE_ID, [
     Buffer.from("claim_payer"),
     wallet.toBuffer(),

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-data-helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-data-helpers.ts
@@ -1,7 +1,12 @@
-import { PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { Connection, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import * as anchor from "@coral-xyz/anchor";
 import { entityCronAuthorityKey } from "@helium/hpl-crons-sdk";
-import { cronJobKey, init as initCron, PROGRAM_ID } from "@helium/cron-sdk";
+import {
+  cronJobKey,
+  cronJobTransactionKey,
+  init as initCron,
+  PROGRAM_ID,
+} from "@helium/cron-sdk";
 import { init as initTuktuk, customSignerKey } from "@helium/tuktuk-sdk";
 import { getHotspotsByOwner } from "@/lib/queries/hotspots";
 import { getNumRecipientsNeeded } from "@/lib/queries/hotspots";
@@ -15,6 +20,27 @@ import {
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { HNT_MINT } from "@helium/spl-utils";
 import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
+
+/**
+ * Return the cron-transaction indices in [0, nextTransactionId) whose on-chain
+ * account still exists. nextTransactionId is a monotonic counter, so claims
+ * removed individually leave holes; callers that remove or close every claim
+ * must skip those holes or the remove instruction hits an uninitialized
+ * account (AccountNotInitialized / 0xbc4).
+ */
+export async function liveCronTransactionIds(
+  connection: Connection,
+  cronJob: PublicKey,
+  nextTransactionId: number
+): Promise<number[]> {
+  if (nextTransactionId <= 0) return [];
+  const keys = Array.from(
+    { length: nextTransactionId },
+    (_, i) => cronJobTransactionKey(cronJob, i)[0]
+  );
+  const infos = await connection.getMultipleAccountsInfo(keys);
+  return keys.map((_, i) => i).filter((i) => infos[i] != null);
+}
 
 export interface AutomationData {
   cronJobAccount: any | null; // cronJobV0 account (null if doesn't exist)
@@ -41,6 +67,7 @@ export interface AutomationData {
 export async function fetchAutomationData(
   walletAddress: string,
   provider: anchor.AnchorProvider,
+  cronId: number = 0
 ): Promise<AutomationData> {
   const wallet = new PublicKey(walletAddress);
 
@@ -50,36 +77,40 @@ export async function fetchAutomationData(
 
   // Derive keys
   const authority = entityCronAuthorityKey(wallet)[0];
-  const cronJob = cronJobKey(authority, 0)[0];
+  const cronJob = cronJobKey(authority, cronId)[0];
   const pdaWallet = customSignerKey(TASK_QUEUE_ID, [
     Buffer.from("claim_payer"),
     wallet.toBuffer(),
   ])[0];
 
   // Fetch cron job account
-  const cronJobAccount =
-    await cronProgram.account.cronJobV0.fetchNullable(cronJob);
+  const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
+    cronJob
+  );
 
   // Fetch task queue for minCrankReward
-  const taskQueueAcc =
-    await tuktukProgram.account.taskQueueV0.fetch(TASK_QUEUE_ID);
+  const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
+    TASK_QUEUE_ID
+  );
   const minCrankReward = taskQueueAcc?.minCrankReward?.toNumber() || 10000;
 
   // Get current balances and calculate rent
-  const cronJobSolanaAccount =
-    await provider.connection.getAccountInfo(cronJob);
+  const cronJobSolanaAccount = await provider.connection.getAccountInfo(
+    cronJob
+  );
   const cronJobBalanceLamports = cronJobSolanaAccount?.lamports ?? 0;
 
   // Calculate minimum rent for cron job account based on its data length
   // If account doesn't exist, rent is 0
   const cronJobRentLamports = cronJobSolanaAccount
     ? await provider.connection.getMinimumBalanceForRentExemption(
-        cronJobSolanaAccount.data.length,
+        cronJobSolanaAccount.data.length
       )
     : 0;
 
-  const pdaWalletBalanceLamports =
-    await provider.connection.getBalance(pdaWallet);
+  const pdaWalletBalanceLamports = await provider.connection.getBalance(
+    pdaWallet
+  );
 
   // Get hotspot count
   const hotspotsData = await getHotspotsByOwner({
@@ -94,10 +125,10 @@ export async function fetchAutomationData(
   const numCronTransactions = cronJobAccount?.nextTransactionId || 0;
   const cronJobCostPerClaimLamports = calculateCronJobCostPerClaim(
     minCrankReward,
-    numCronTransactions,
+    numCronTransactions
   );
   const pdaWalletCostPerClaimLamports = calculatePdaWalletCostPerClaim(
-    totalHotspots || 1,
+    totalHotspots || 1
   );
 
   // Calculate recipient rent that's already committed
@@ -118,10 +149,11 @@ export async function fetchAutomationData(
   // We check the first one - if it doesn't exist, we need to account for rent
   const [taskReturnAccount1] = PublicKey.findProgramAddressSync(
     [Buffer.from("task_return_account_1"), cronJob.toBuffer()],
-    PROGRAM_ID,
+    PROGRAM_ID
   );
-  const taskReturnAccountInfo =
-    await provider.connection.getAccountInfo(taskReturnAccount1);
+  const taskReturnAccountInfo = await provider.connection.getAccountInfo(
+    taskReturnAccount1
+  );
   const taskReturnAccountRentLamports = taskReturnAccountInfo
     ? 0
     : Math.ceil(TASK_RETURN_ACCOUNT_SIZE * LAMPORTS_PER_SOL);

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-transaction.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-transaction.ts
@@ -1,0 +1,119 @@
+import * as anchor from "@coral-xyz/anchor";
+import { cronJobKey, init as initCron } from "@helium/cron-sdk";
+import {
+  entityCronAuthorityKey,
+  init as initHplCrons,
+} from "@helium/hpl-crons-sdk";
+import {
+  batchInstructionsToTxsWithPriorityFee,
+  toVersionedTx,
+} from "@helium/spl-utils";
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+import { createSolanaConnection, getCluster, getCommonLut } from "@/lib/solana";
+import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
+import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+
+/**
+ * Resolve the single entity-claim cron job for a wallet: set up the provider,
+ * init the hpl-crons and cron programs, and load the wallet's cron job (index 0
+ * under its entity-cron authority). Throws the caller's NOT_FOUND when no
+ * automation exists yet.
+ */
+export const resolveEntityClaimCronJob = async ({
+  walletAddress,
+  notFoundMessage,
+  errors,
+}: {
+  walletAddress: string;
+  notFoundMessage: string;
+  errors: { NOT_FOUND: (opts: { message: string }) => Error };
+}) => {
+  const wallet = new PublicKey(walletAddress);
+  const { provider } = createSolanaConnection(walletAddress);
+  anchor.setProvider(provider);
+
+  const hplCronsProgram = await initHplCrons(provider);
+  const cronProgram = await initCron(provider);
+
+  const authority = entityCronAuthorityKey(wallet)[0];
+  const cronJob = cronJobKey(authority, 0)[0];
+
+  const cronJobAccount =
+    await cronProgram.account.cronJobV0.fetchNullable(cronJob);
+  if (!cronJobAccount) {
+    throw errors.NOT_FOUND({ message: notFoundMessage });
+  }
+
+  return {
+    wallet,
+    provider,
+    hplCronsProgram,
+    authority,
+    cronJob,
+    cronJobAccount,
+  };
+};
+
+/**
+ * Shared tail for the claim-automation transaction endpoints. They differ only
+ * in the instructions they build and the tag/metadata they attach; the batching
+ * (common LUT, 500k CU limit, finalized commitment), Jito tip, base64 encoding,
+ * fee total, and response envelope are identical. `extraFeeLamports` covers
+ * lamports the transaction actually moves (e.g. operator top-ups) so the
+ * estimated fee reflects the caller's total SOL outlay.
+ */
+export const buildAutomationTransactionResponse = async ({
+  provider,
+  instructions,
+  feePayer,
+  tag,
+  transactionMetadata,
+  actionMetadata,
+  extraFeeLamports = 0,
+}: {
+  provider: anchor.AnchorProvider;
+  instructions: TransactionInstruction[];
+  feePayer: PublicKey;
+  tag: string;
+  transactionMetadata: {
+    type: string;
+    description: string;
+    [key: string]: unknown;
+  };
+  actionMetadata: Record<string, unknown>;
+  extraFeeLamports?: number;
+}) => {
+  const vtxs = (
+    await batchInstructionsToTxsWithPriorityFee(provider, instructions, {
+      addressLookupTableAddresses: [getCommonLut()],
+      computeUnitLimit: 500000,
+      commitment: "finalized",
+    })
+  ).map((tx) => toVersionedTx(tx));
+
+  if (shouldUseJitoBundle(vtxs.length, getCluster())) {
+    vtxs.push(await getJitoTipTransaction(feePayer));
+  }
+
+  const txs = vtxs.map((tx) => Buffer.from(tx.serialize()).toString("base64"));
+  const txFees = getTotalTransactionFees(vtxs);
+
+  return {
+    transactionData: {
+      transactions: txs.map((serialized) => ({
+        serializedTransaction: serialized,
+        metadata: transactionMetadata,
+      })),
+      parallel: false,
+      tag,
+      actionMetadata,
+    },
+    estimatedSolFee: await toTokenAmountOutput(
+      new BN(txFees + extraFeeLamports),
+      NATIVE_MINT.toBase58(),
+    ),
+  };
+};

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-transaction.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-transaction.ts
@@ -11,7 +11,8 @@ import {
 import { PublicKey, TransactionInstruction } from "@solana/web3.js";
 import { NATIVE_MINT } from "@solana/spl-token";
 import BN from "bn.js";
-import { createSolanaConnection, getCluster, getCommonLut } from "@/lib/solana";
+import { createSolanaConnection, getCluster } from "@/lib/solana";
+import { getHeliumLookupTable } from "@/lib/utils/build-transaction";
 import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
 import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
@@ -35,14 +36,17 @@ export const resolveEntityClaimCronJob = async ({
   const { provider } = createSolanaConnection(walletAddress);
   anchor.setProvider(provider);
 
-  const hplCronsProgram = await initHplCrons(provider);
-  const cronProgram = await initCron(provider);
+  const [hplCronsProgram, cronProgram] = await Promise.all([
+    initHplCrons(provider),
+    initCron(provider),
+  ]);
 
   const authority = entityCronAuthorityKey(wallet)[0];
   const cronJob = cronJobKey(authority, 0)[0];
 
-  const cronJobAccount =
-    await cronProgram.account.cronJobV0.fetchNullable(cronJob);
+  const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
+    cronJob
+  );
   if (!cronJobAccount) {
     throw errors.NOT_FOUND({ message: notFoundMessage });
   }
@@ -88,7 +92,7 @@ export const buildAutomationTransactionResponse = async ({
 }) => {
   const vtxs = (
     await batchInstructionsToTxsWithPriorityFee(provider, instructions, {
-      addressLookupTableAddresses: [getCommonLut()],
+      addressLookupTableAddresses: [getHeliumLookupTable()],
       computeUnitLimit: 500000,
       commitment: "finalized",
     })
@@ -113,7 +117,7 @@ export const buildAutomationTransactionResponse = async ({
     },
     estimatedSolFee: await toTokenAmountOutput(
       new BN(txFees + extraFeeLamports),
-      NATIVE_MINT.toBase58(),
+      NATIVE_MINT.toBase58()
     ),
   };
 };

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
@@ -1,7 +1,4 @@
 import { publicProcedure } from "../../../procedures";
-import { Connection, PublicKey } from "@solana/web3.js";
-import { env } from "@/lib/env";
-import { hasRewardContract } from "@/lib/queries/hotspots";
 import {
   generateTransactionTag,
   TRANSACTION_TYPES,
@@ -18,22 +15,16 @@ import {
   buildVersionedTransaction,
   serializeTransaction,
 } from "@/lib/utils/build-transaction";
-import { proofArgsAndAccounts } from "@helium/spl-utils";
 import { createBurnInstruction } from "@metaplex-foundation/mpl-bubblegum";
 import {
   SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
   SPL_NOOP_PROGRAM_ID,
 } from "@solana/spl-account-compression";
 import {
-  getAssetIdFromPubkey,
-  getBubblegumAuthorityPDA,
-  validateHeliumHotspot,
-} from "@/lib/utils/hotspot-helpers";
-import {
   buildActionProposal,
   proposalTransactionData,
-  vaultPda,
 } from "../../squads/procedures/helpers";
+import { resolveOwnedHotspotCnft } from "./hotspot-cnft";
 
 /**
  * Create a transaction to permanently burn (destroy) a hotspot cNFT, using the
@@ -43,74 +34,26 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
   async ({ input, errors }) => {
     const { walletAddress, hotspotPubkey } = input;
 
-    const assetId = await getAssetIdFromPubkey(hotspotPubkey);
-    if (!assetId) {
-      throw errors.NOT_FOUND({ message: "Hotspot not found" });
-    }
-
-    let payerPubkey: PublicKey;
-    try {
-      payerPubkey = new PublicKey(walletAddress);
-    } catch {
-      throw errors.BAD_REQUEST({ message: "Invalid public key format" });
-    }
-
-    const connection = new Connection(env.SOLANA_RPC_URL);
-    const assetEndpoint = env.ASSET_ENDPOINT || connection.rpcEndpoint;
-
-    const { asset, args, accounts, remainingAccounts } =
-      await proofArgsAndAccounts({
-        connection,
-        assetId: new PublicKey(assetId),
-        assetEndpoint,
-      });
-
-    if (!asset) {
-      throw errors.NOT_FOUND({ message: "Asset not found" });
-    }
-    if (!validateHeliumHotspot(asset)) {
-      throw errors.BAD_REQUEST({
-        message: "Asset is not a valid Helium hotspot",
-      });
-    }
-
-    const ownerAddress =
-      typeof asset.ownership.owner === "string"
-        ? asset.ownership.owner
-        : asset.ownership.owner.toBase58();
-
-    // In Squads propose mode the on-chain owner must be the multisig's vault
-    // (walletAddress is only the proposing member); otherwise the wallet itself.
-    const multisigPda = input.multisig
-      ? new PublicKey(input.multisig)
-      : undefined;
-    const expectedOwner = multisigPda ? vaultPda(multisigPda) : payerPubkey;
-    if (ownerAddress !== expectedOwner.toBase58()) {
-      throw errors.UNAUTHORIZED({
-        message: multisigPda
-          ? "Multisig vault is not the owner of this hotspot"
-          : "Wallet is not the owner of this hotspot",
-      });
-    }
-
-    // Refuse to burn a hotspot with an active reward contract, matching the
-    // transfer guard — burning it would orphan the contract.
-    if (await hasRewardContract(hotspotPubkey)) {
-      throw errors.CONFLICT({
-        message:
-          "Cannot burn hotspot with active reward contract. Delete the contract first.",
-      });
-    }
-
-    const leafOwner = new PublicKey(ownerAddress);
-    const leafDelegate = asset.ownership.delegate
-      ? typeof asset.ownership.delegate === "string"
-        ? new PublicKey(asset.ownership.delegate)
-        : asset.ownership.delegate
-      : leafOwner;
-
-    const merkleTree = accounts.merkleTree;
-    const treeAuthority = await getBubblegumAuthorityPDA(merkleTree);
+    const {
+      connection,
+      payerPubkey,
+      multisigPda,
+      assetId,
+      args,
+      remainingAccounts,
+      merkleTree,
+      treeAuthority,
+      leafOwner,
+      leafDelegate,
+      hotspotName,
+    } = await resolveOwnedHotspotCnft({
+      walletAddress,
+      hotspotPubkey,
+      multisig: input.multisig,
+      conflictMessage:
+        "Cannot burn hotspot with active reward contract. Delete the contract first.",
+      errors,
+    });
 
     const burnInstruction = createBurnInstruction(
       {
@@ -125,10 +68,8 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
       {
         ...args,
         nonce: args.index,
-      },
+      }
     );
-
-    const hotspotName = asset.content?.metadata?.name || "Hotspot";
 
     // ---- Squads propose mode ----
     // UNVERIFIED: this path cannot be exercised on a mainnet fork. The proof and
@@ -144,15 +85,8 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
           member: payerPubkey,
           memo: input.memo,
           buildInstructions: () => [burnInstruction],
-          insufficientFunds: ({ required, available }) =>
-            errors.INSUFFICIENT_FUNDS({
-              message: "Insufficient SOL balance to create the burn proposal",
-              data: { required, available },
-            }),
-          notFound: () =>
-            errors.NOT_FOUND({
-              message: `Multisig ${input.multisig} not found`,
-            }),
+          errors,
+          action: "burn",
         });
 
       return {
@@ -169,11 +103,10 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
           multisig: multisigPda.toBase58(),
           transactionIndex,
           metadata: { hotspotKey: assetId, hotspotName },
-          actionMetadata: { hotspotKey: assetId, hotspotName },
         }),
         estimatedSolFee: await toTokenAmountOutput(
           new BN(feeLamports),
-          NATIVE_MINT.toBase58(),
+          NATIVE_MINT.toBase58()
         ),
       };
     }
@@ -225,8 +158,8 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(txFee),
-        NATIVE_MINT.toBase58(),
+        NATIVE_MINT.toBase58()
       ),
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
@@ -30,6 +30,7 @@ import {
 import { entityCreatorKey } from "@helium/helium-entity-manager-sdk";
 import { daoKey } from "@helium/helium-sub-daos-sdk";
 import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
+import { buildActionProposal, vaultPda } from "../../squads/procedures/helpers";
 
 const DAO_KEY = daoKey(HNT_MINT)[0];
 
@@ -100,9 +101,18 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
       typeof asset.ownership.owner === "string"
         ? asset.ownership.owner
         : asset.ownership.owner.toBase58();
-    if (ownerAddress !== walletAddress) {
+
+    // In Squads propose mode the on-chain owner must be the multisig's vault
+    // (walletAddress is only the proposing member); otherwise the wallet itself.
+    const multisigPda = input.multisig
+      ? new PublicKey(input.multisig)
+      : undefined;
+    const expectedOwner = multisigPda ? vaultPda(multisigPda) : payerPubkey;
+    if (ownerAddress !== expectedOwner.toBase58()) {
       throw errors.UNAUTHORIZED({
-        message: "Wallet is not the owner of this hotspot",
+        message: multisigPda
+          ? "Multisig vault is not the owner of this hotspot"
+          : "Wallet is not the owner of this hotspot",
       });
     }
 
@@ -115,19 +125,7 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
       });
     }
 
-    const walletBalance = await connection.getBalance(payerPubkey);
-    const required = calculateRequiredBalance(BASE_TX_FEE_LAMPORTS, 0);
-    if (walletBalance < required) {
-      throw errors.INSUFFICIENT_FUNDS({
-        message: "Insufficient SOL balance for transaction fees",
-        data: { required, available: walletBalance },
-      });
-    }
-
-    const leafOwner =
-      typeof asset.ownership.owner === "string"
-        ? new PublicKey(asset.ownership.owner)
-        : asset.ownership.owner;
+    const leafOwner = new PublicKey(ownerAddress);
     const leafDelegate = asset.ownership.delegate
       ? typeof asset.ownership.delegate === "string"
         ? new PublicKey(asset.ownership.delegate)
@@ -153,6 +151,78 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
       }
     );
 
+    const hotspotName = asset.content?.metadata?.name || "Hotspot";
+
+    // ---- Squads propose mode ----
+    // UNVERIFIED: this path cannot be exercised on a mainnet fork. The proof and
+    // ownership come from the real DAS index, so the vault must actually own the
+    // hotspot on-chain — a fork-created vault never does, and surfpool can't set
+    // cNFT ownership. Verify against a live multisig vault that owns a test
+    // hotspot before relying on this in production.
+    if (multisigPda) {
+      const { serializedTransaction, transactionIndex, feeLamports } =
+        await buildActionProposal({
+          connection,
+          multisigPda,
+          member: payerPubkey,
+          memo: input.memo,
+          buildInstructions: () => [burnInstruction],
+          insufficientFunds: ({ required, available }) =>
+            errors.INSUFFICIENT_FUNDS({
+              message: "Insufficient SOL balance to create the burn proposal",
+              data: { required, available },
+            }),
+          notFound: () =>
+            errors.NOT_FOUND({
+              message: `Multisig ${input.multisig} not found`,
+            }),
+        });
+
+      return {
+        transactionData: {
+          transactions: [
+            {
+              serializedTransaction,
+              metadata: {
+                type: "hotspot_burn_proposal",
+                description: `Propose burn of ${hotspotName}`,
+                hotspotKey: assetId,
+                hotspotName,
+              },
+            },
+          ],
+          parallel: false,
+          tag: generateTransactionTag({
+            type: TRANSACTION_TYPES.HOTSPOT_BURN,
+            walletAddress,
+            assetId,
+            multisig: input.multisig,
+          }),
+          actionMetadata: {
+            type: "hotspot_burn_proposal",
+            multisig: input.multisig,
+            transactionIndex,
+            hotspotKey: assetId,
+            hotspotName,
+          },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(feeLamports),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+
+    // ---- Direct burn from the wallet ----
+    const walletBalance = await connection.getBalance(payerPubkey);
+    const required = calculateRequiredBalance(BASE_TX_FEE_LAMPORTS, 0);
+    if (walletBalance < required) {
+      throw errors.INSUFFICIENT_FUNDS({
+        message: "Insufficient SOL balance for transaction fees",
+        data: { required, available: walletBalance },
+      });
+    }
+
     const tx = await buildVersionedTransaction({
       connection,
       draft: { instructions: [burnInstruction], feePayer: payerPubkey },
@@ -165,7 +235,6 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
       timestamp: Date.now(),
     });
 
-    const hotspotName = asset.content?.metadata?.name || "Hotspot";
     const txFee = getTransactionFee(tx);
 
     return {

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
@@ -1,0 +1,198 @@
+import { publicProcedure } from "../../../procedures";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { env } from "@/lib/env";
+import { hasRewardContract } from "@/lib/queries/hotspots";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "@/lib/utils/transaction-tags";
+import {
+  calculateRequiredBalance,
+  getTransactionFee,
+  BASE_TX_FEE_LAMPORTS,
+} from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+import {
+  buildVersionedTransaction,
+  serializeTransaction,
+} from "@/lib/utils/build-transaction";
+import { proofArgsAndAccounts, type Asset, HNT_MINT } from "@helium/spl-utils";
+import {
+  PROGRAM_ID as BUBBLEGUM_PROGRAM_ID,
+  createBurnInstruction,
+} from "@metaplex-foundation/mpl-bubblegum";
+import {
+  SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+  SPL_NOOP_PROGRAM_ID,
+} from "@solana/spl-account-compression";
+import { entityCreatorKey } from "@helium/helium-entity-manager-sdk";
+import { daoKey } from "@helium/helium-sub-daos-sdk";
+import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
+
+const DAO_KEY = daoKey(HNT_MINT)[0];
+
+async function getBubblegumAuthorityPDA(
+  merkleRollPubKey: PublicKey
+): Promise<PublicKey> {
+  const [bubblegumAuthorityPDAKey] = await PublicKey.findProgramAddress(
+    [merkleRollPubKey.toBuffer()],
+    BUBBLEGUM_PROGRAM_ID
+  );
+  return bubblegumAuthorityPDAKey;
+}
+
+function validateHeliumHotspot(asset: Asset): boolean {
+  const heliumEntityCreator = entityCreatorKey(DAO_KEY)[0].toBase58();
+  return (
+    asset.creators?.some((creator) => {
+      const address =
+        typeof creator.address === "string"
+          ? creator.address
+          : creator.address.toBase58();
+      return address === heliumEntityCreator && creator.verified;
+    }) || false
+  );
+}
+
+/**
+ * Create a transaction to permanently burn (destroy) a hotspot cNFT. Mirrors
+ * transferHotspot's bubblegum + Merkle-proof wiring, using the burn
+ * instruction instead of transfer.
+ */
+export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
+  async ({ input, errors }) => {
+    const { walletAddress, hotspotPubkey } = input;
+
+    const assetId = await getAssetIdFromPubkey(hotspotPubkey);
+    if (!assetId) {
+      throw errors.NOT_FOUND({ message: "Hotspot not found" });
+    }
+
+    let payerPubkey: PublicKey;
+    try {
+      payerPubkey = new PublicKey(walletAddress);
+    } catch {
+      throw errors.BAD_REQUEST({ message: "Invalid public key format" });
+    }
+
+    const connection = new Connection(env.SOLANA_RPC_URL);
+    const assetEndpoint = env.ASSET_ENDPOINT || connection.rpcEndpoint;
+
+    const { asset, args, accounts, remainingAccounts } =
+      await proofArgsAndAccounts({
+        connection,
+        assetId: new PublicKey(assetId),
+        assetEndpoint,
+      });
+
+    if (!asset) {
+      throw errors.NOT_FOUND({ message: "Asset not found" });
+    }
+    if (!validateHeliumHotspot(asset)) {
+      throw errors.BAD_REQUEST({
+        message: "Asset is not a valid Helium hotspot",
+      });
+    }
+
+    const ownerAddress =
+      typeof asset.ownership.owner === "string"
+        ? asset.ownership.owner
+        : asset.ownership.owner.toBase58();
+    if (ownerAddress !== walletAddress) {
+      throw errors.UNAUTHORIZED({
+        message: "Wallet is not the owner of this hotspot",
+      });
+    }
+
+    // Refuse to burn a hotspot with an active reward contract, matching the
+    // transfer guard — burning it would orphan the contract.
+    if (await hasRewardContract(hotspotPubkey)) {
+      throw errors.CONFLICT({
+        message:
+          "Cannot burn hotspot with active reward contract. Delete the contract first.",
+      });
+    }
+
+    const walletBalance = await connection.getBalance(payerPubkey);
+    const required = calculateRequiredBalance(BASE_TX_FEE_LAMPORTS, 0);
+    if (walletBalance < required) {
+      throw errors.INSUFFICIENT_FUNDS({
+        message: "Insufficient SOL balance for transaction fees",
+        data: { required, available: walletBalance },
+      });
+    }
+
+    const leafOwner =
+      typeof asset.ownership.owner === "string"
+        ? new PublicKey(asset.ownership.owner)
+        : asset.ownership.owner;
+    const leafDelegate = asset.ownership.delegate
+      ? typeof asset.ownership.delegate === "string"
+        ? new PublicKey(asset.ownership.delegate)
+        : asset.ownership.delegate
+      : leafOwner;
+
+    const merkleTree = accounts.merkleTree;
+    const treeAuthority = await getBubblegumAuthorityPDA(merkleTree);
+
+    const burnInstruction = createBurnInstruction(
+      {
+        treeAuthority,
+        leafOwner,
+        leafDelegate,
+        merkleTree,
+        logWrapper: SPL_NOOP_PROGRAM_ID,
+        compressionProgram: SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+        anchorRemainingAccounts: remainingAccounts,
+      },
+      {
+        ...args,
+        nonce: args.index,
+      }
+    );
+
+    const tx = await buildVersionedTransaction({
+      connection,
+      draft: { instructions: [burnInstruction], feePayer: payerPubkey },
+    });
+
+    const tag = generateTransactionTag({
+      type: TRANSACTION_TYPES.HOTSPOT_BURN,
+      walletAddress,
+      assetId,
+      timestamp: Date.now(),
+    });
+
+    const hotspotName = asset.content?.metadata?.name || "Hotspot";
+    const txFee = getTransactionFee(tx);
+
+    return {
+      transactionData: {
+        transactions: [
+          {
+            serializedTransaction: serializeTransaction(tx),
+            metadata: {
+              type: TRANSACTION_TYPES.HOTSPOT_BURN,
+              description: `Burn ${hotspotName}`,
+              hotspotKey: assetId,
+              hotspotName,
+            },
+          },
+        ],
+        parallel: false,
+        tag,
+        actionMetadata: {
+          type: TRANSACTION_TYPES.HOTSPOT_BURN,
+          hotspotKey: assetId,
+          hotspotName,
+        },
+      },
+      estimatedSolFee: await toTokenAmountOutput(
+        new BN(txFee),
+        NATIVE_MINT.toBase58()
+      ),
+    };
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
@@ -18,49 +18,22 @@ import {
   buildVersionedTransaction,
   serializeTransaction,
 } from "@/lib/utils/build-transaction";
-import { proofArgsAndAccounts, type Asset, HNT_MINT } from "@helium/spl-utils";
-import {
-  PROGRAM_ID as BUBBLEGUM_PROGRAM_ID,
-  createBurnInstruction,
-} from "@metaplex-foundation/mpl-bubblegum";
+import { proofArgsAndAccounts } from "@helium/spl-utils";
+import { createBurnInstruction } from "@metaplex-foundation/mpl-bubblegum";
 import {
   SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
   SPL_NOOP_PROGRAM_ID,
 } from "@solana/spl-account-compression";
-import { entityCreatorKey } from "@helium/helium-entity-manager-sdk";
-import { daoKey } from "@helium/helium-sub-daos-sdk";
-import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
+import {
+  getAssetIdFromPubkey,
+  getBubblegumAuthorityPDA,
+  validateHeliumHotspot,
+} from "@/lib/utils/hotspot-helpers";
 import { buildActionProposal, vaultPda } from "../../squads/procedures/helpers";
 
-const DAO_KEY = daoKey(HNT_MINT)[0];
-
-async function getBubblegumAuthorityPDA(
-  merkleRollPubKey: PublicKey
-): Promise<PublicKey> {
-  const [bubblegumAuthorityPDAKey] = await PublicKey.findProgramAddress(
-    [merkleRollPubKey.toBuffer()],
-    BUBBLEGUM_PROGRAM_ID
-  );
-  return bubblegumAuthorityPDAKey;
-}
-
-function validateHeliumHotspot(asset: Asset): boolean {
-  const heliumEntityCreator = entityCreatorKey(DAO_KEY)[0].toBase58();
-  return (
-    asset.creators?.some((creator) => {
-      const address =
-        typeof creator.address === "string"
-          ? creator.address
-          : creator.address.toBase58();
-      return address === heliumEntityCreator && creator.verified;
-    }) || false
-  );
-}
-
 /**
- * Create a transaction to permanently burn (destroy) a hotspot cNFT. Mirrors
- * transferHotspot's bubblegum + Merkle-proof wiring, using the burn
- * instruction instead of transfer.
+ * Create a transaction to permanently burn (destroy) a hotspot cNFT, using the
+ * bubblegum + Merkle-proof wiring with the burn instruction.
  */
 export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
   async ({ input, errors }) => {

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/burnHotspot.ts
@@ -29,7 +29,11 @@ import {
   getBubblegumAuthorityPDA,
   validateHeliumHotspot,
 } from "@/lib/utils/hotspot-helpers";
-import { buildActionProposal, vaultPda } from "../../squads/procedures/helpers";
+import {
+  buildActionProposal,
+  proposalTransactionData,
+  vaultPda,
+} from "../../squads/procedures/helpers";
 
 /**
  * Create a transaction to permanently burn (destroy) a hotspot cNFT, using the
@@ -121,7 +125,7 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
       {
         ...args,
         nonce: args.index,
-      }
+      },
     );
 
     const hotspotName = asset.content?.metadata?.name || "Hotspot";
@@ -152,36 +156,24 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
         });
 
       return {
-        transactionData: {
-          transactions: [
-            {
-              serializedTransaction,
-              metadata: {
-                type: "hotspot_burn_proposal",
-                description: `Propose burn of ${hotspotName}`,
-                hotspotKey: assetId,
-                hotspotName,
-              },
-            },
-          ],
-          parallel: false,
+        transactionData: proposalTransactionData({
+          serializedTransaction,
+          type: TRANSACTION_TYPES.HOTSPOT_BURN_PROPOSAL,
+          description: `Propose burn of ${hotspotName}`,
           tag: generateTransactionTag({
             type: TRANSACTION_TYPES.HOTSPOT_BURN,
             walletAddress,
             assetId,
             multisig: input.multisig,
           }),
-          actionMetadata: {
-            type: "hotspot_burn_proposal",
-            multisig: input.multisig,
-            transactionIndex,
-            hotspotKey: assetId,
-            hotspotName,
-          },
-        },
+          multisig: multisigPda.toBase58(),
+          transactionIndex,
+          metadata: { hotspotKey: assetId, hotspotName },
+          actionMetadata: { hotspotKey: assetId, hotspotName },
+        }),
         estimatedSolFee: await toTokenAmountOutput(
           new BN(feeLamports),
-          NATIVE_MINT.toBase58()
+          NATIVE_MINT.toBase58(),
         ),
       };
     }
@@ -233,8 +225,8 @@ export const burnHotspot = publicProcedure.hotspots.burnHotspot.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(txFee),
-        NATIVE_MINT.toBase58()
+        NATIVE_MINT.toBase58(),
       ),
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimHotspotRewards.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimHotspotRewards.ts
@@ -1,0 +1,169 @@
+import animalName from "angry-purple-tiger";
+import { publicProcedure } from "../../../procedures";
+import { env } from "@/lib/env";
+import { createSolanaConnection, getCluster } from "@/lib/solana";
+import { init as initLd, recipientKey } from "@helium/lazy-distributor-sdk";
+import { init as initMiniFanout } from "@helium/mini-fanout-sdk";
+import { filterHotspotsWithoutMiniFanout } from "@/lib/utils/mini-fanout-helpers";
+import {
+  formBulkTransactions,
+  getBulkRewards,
+} from "@/utils/distributorOracle";
+import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import {
+  getJitoTipAmountLamports,
+  getJitoTipTransaction,
+  shouldUseJitoBundle,
+} from "@/lib/utils/jito";
+import {
+  getTotalTransactionFees,
+  calculateRequiredBalance,
+} from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+import { getLazyDistributorForNetwork } from "@/lib/utils/network-mint";
+import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
+
+const RECIPIENT_RENT = 0.00242208;
+const RECIPIENT_RENT_LAMPORTS = Math.ceil(RECIPIENT_RENT * LAMPORTS_PER_SOL);
+
+/**
+ * Create transactions to claim the full pending rewards for a single hotspot.
+ * This is the direct-claim path from `claimRewards` scoped to one asset: no
+ * pagination, no Tuktuk fallback, and no partial-amount option (the oracle
+ * signs for the full pending amount).
+ */
+export const claimHotspotRewards =
+  publicProcedure.hotspots.claimHotspotRewards.handler(
+    async ({ input, errors }) => {
+      const { entityPubKey, walletAddress, network } = input;
+      const lazyDistributor = getLazyDistributorForNetwork(network);
+
+      const assetId = await getAssetIdFromPubkey(entityPubKey);
+      if (!assetId) {
+        throw errors.NOT_FOUND({ message: "Hotspot not found" });
+      }
+      const asset = new PublicKey(assetId);
+      // For a hotspot the helium pubkey is its reward entity key.
+      const entityKey = entityPubKey;
+
+      const { provider, connection } = createSolanaConnection(walletAddress);
+      const ldProgram = await initLd(provider);
+      const mfProgram = await initMiniFanout(provider);
+
+      const rewards = await getBulkRewards(ldProgram, lazyDistributor, [
+        entityKey,
+      ]);
+      const [recipientPk] = recipientKey(lazyDistributor, asset);
+      const recipientAcc = await ldProgram.account.recipientV0.fetchNullable(
+        recipientPk
+      );
+
+      // Positive pending = oracle median minus what's already been distributed.
+      const sortedOracleRewards = rewards
+        .map((rew) => new BN(rew.currentRewards[entityKey] || 0))
+        .sort((a, b) => a.sub(b).toNumber());
+      const oracleMedian =
+        sortedOracleRewards[Math.floor(sortedOracleRewards.length / 2)] ||
+        new BN(0);
+      const alreadyDistributed = recipientAcc?.totalRewards || new BN(0);
+      const hasPending = oracleMedian.sub(alreadyDistributed).gtn(0);
+
+      const emptyResponse = async () => ({
+        transactionData: {
+          transactions: [],
+          parallel: false,
+          tag: `claim_hotspot_rewards:${walletAddress}:${entityKey}:empty`,
+          actionMetadata: {
+            type: "claim_rewards",
+            hotspotKey: entityKey,
+            hotspotName: animalName(entityKey),
+            network,
+          },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(0),
+          NATIVE_MINT.toBase58()
+        ),
+      });
+
+      if (!hasPending) {
+        return emptyResponse();
+      }
+
+      // Hotspots routed through a mini fanout are claimed via the fanout, not a
+      // direct claim, so exclude them.
+      const { claimable } = await filterHotspotsWithoutMiniFanout(
+        ldProgram,
+        mfProgram,
+        connection,
+        lazyDistributor,
+        [{ asset, entityKey }]
+      );
+      if (claimable.length === 0) {
+        return emptyResponse();
+      }
+
+      const vtxs = await formBulkTransactions({
+        program: ldProgram,
+        rewards,
+        assets: [asset],
+        lazyDistributor,
+        assetEndpoint: env.ASSET_ENDPOINT,
+        isDevnet: getCluster() === "devnet",
+        useCache: false,
+        skipOracleSign: false,
+      });
+
+      const useJito = shouldUseJitoBundle(vtxs.length, getCluster());
+      if (useJito) {
+        vtxs.push(await getJitoTipTransaction(new PublicKey(walletAddress)));
+      }
+
+      const txFees = getTotalTransactionFees(vtxs);
+      const jitoTipCost = useJito ? getJitoTipAmountLamports() : 0;
+      const rentCost = recipientAcc ? 0 : RECIPIENT_RENT_LAMPORTS;
+      const requiredLamports = calculateRequiredBalance(
+        txFees + jitoTipCost,
+        rentCost
+      );
+      const senderBalance = await connection.getBalance(
+        new PublicKey(walletAddress)
+      );
+      if (senderBalance < requiredLamports) {
+        throw errors.INSUFFICIENT_FUNDS({
+          message: "Insufficient SOL balance to claim rewards",
+          data: { available: senderBalance, required: requiredLamports },
+        });
+      }
+
+      const transactions = vtxs.map((tx) => ({
+        serializedTransaction: Buffer.from(tx.serialize()).toString("base64"),
+        metadata: {
+          type: "claim_rewards",
+          description: "Claim hotspot rewards",
+        },
+      }));
+
+      return {
+        transactionData: {
+          transactions,
+          // Sequential: a recipient's init and distribute ixs may land in
+          // different packed txs; parallel submission races them.
+          parallel: false,
+          tag: `claim_hotspot_rewards:${walletAddress}:${entityKey}`,
+          actionMetadata: {
+            type: "claim_rewards",
+            hotspotKey: entityKey,
+            hotspotName: animalName(entityKey),
+            network,
+          },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(txFees + rentCost),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+  );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimHotspotRewards.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimHotspotRewards.ts
@@ -9,7 +9,7 @@ import {
   formBulkTransactions,
   getBulkRewards,
 } from "@/utils/distributorOracle";
-import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 import {
   getJitoTipAmountLamports,
   getJitoTipTransaction,
@@ -18,15 +18,14 @@ import {
 import {
   getTotalTransactionFees,
   calculateRequiredBalance,
+  RENT_COSTS,
 } from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
 import { NATIVE_MINT } from "@solana/spl-token";
 import BN from "bn.js";
 import { getLazyDistributorForNetwork } from "@/lib/utils/network-mint";
 import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
-
-const RECIPIENT_RENT = 0.00242208;
-const RECIPIENT_RENT_LAMPORTS = Math.ceil(RECIPIENT_RENT * LAMPORTS_PER_SOL);
+import { pendingOracleRewards } from "@/lib/utils/pending-rewards";
 
 /**
  * Create transactions to claim the full pending rewards for a single hotspot.
@@ -49,26 +48,23 @@ export const claimHotspotRewards =
       const entityKey = entityPubKey;
 
       const { provider, connection } = createSolanaConnection(walletAddress);
-      const ldProgram = await initLd(provider);
-      const mfProgram = await initMiniFanout(provider);
-
-      const rewards = await getBulkRewards(ldProgram, lazyDistributor, [
-        entityKey,
+      const [ldProgram, mfProgram] = await Promise.all([
+        initLd(provider),
+        initMiniFanout(provider),
       ]);
+
       const [recipientPk] = recipientKey(lazyDistributor, asset);
-      const recipientAcc = await ldProgram.account.recipientV0.fetchNullable(
-        recipientPk
-      );
+      const [rewards, recipientAcc] = await Promise.all([
+        getBulkRewards(ldProgram, lazyDistributor, [entityKey]),
+        ldProgram.account.recipientV0.fetchNullable(recipientPk),
+      ]);
 
       // Positive pending = oracle median minus what's already been distributed.
-      const sortedOracleRewards = rewards
-        .map((rew) => new BN(rew.currentRewards[entityKey] || 0))
-        .sort((a, b) => a.sub(b).toNumber());
-      const oracleMedian =
-        sortedOracleRewards[Math.floor(sortedOracleRewards.length / 2)] ||
-        new BN(0);
-      const alreadyDistributed = recipientAcc?.totalRewards || new BN(0);
-      const hasPending = oracleMedian.sub(alreadyDistributed).gtn(0);
+      const hasPending = pendingOracleRewards(
+        rewards,
+        entityKey,
+        recipientAcc
+      ).gtn(0);
 
       const emptyResponse = async () => ({
         transactionData: {
@@ -123,7 +119,7 @@ export const claimHotspotRewards =
 
       const txFees = getTotalTransactionFees(vtxs);
       const jitoTipCost = useJito ? getJitoTipAmountLamports() : 0;
-      const rentCost = recipientAcc ? 0 : RECIPIENT_RENT_LAMPORTS;
+      const rentCost = recipientAcc ? 0 : RENT_COSTS.RECIPIENT;
       const requiredLamports = calculateRequiredBalance(
         txFees + jitoTipCost,
         rentCost

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/closeAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/closeAutomation.ts
@@ -17,6 +17,8 @@ import {
   toVersionedTx,
 } from "@helium/spl-utils";
 import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { ENTITY_CLAIM_CRON_NAME } from "@/lib/utils/automation-helpers";
+import { liveCronTransactionIds } from "./automation-data-helpers";
 import {
   getJitoTipAmountLamports,
   getJitoTipTransaction,
@@ -52,8 +54,9 @@ export const closeAutomation = publicProcedure.hotspots.closeAutomation.handler(
     const cronJob = cronJobKey(authority, 0)[0];
 
     // Fetch cron job account using fetchNullable
-    const cronJobAccount =
-      await cronProgram.account.cronJobV0.fetchNullable(cronJob);
+    const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
+      cronJob
+    );
 
     if (!cronJobAccount) {
       throw errors.NOT_FOUND({
@@ -70,7 +73,7 @@ export const closeAutomation = publicProcedure.hotspots.closeAutomation.handler(
         : 0;
     const required = calculateRequiredBalance(
       BASE_TX_FEE_LAMPORTS + estimatedJitoTipCost,
-      0,
+      0
     );
     if (walletBalance < required) {
       throw errors.INSUFFICIENT_FUNDS({
@@ -79,13 +82,18 @@ export const closeAutomation = publicProcedure.hotspots.closeAutomation.handler(
       });
     }
 
-    // Build instructions to remove all entities and close cron job
-    const maxTxId = cronJobAccount.nextTransactionId || 0;
-    const txIds = Array.from({ length: maxTxId }, (_, i) => i);
+    // Build instructions to remove all entities and close cron job.
+    // nextTransactionId is a monotonic counter, so individually-removed claims
+    // leave holes: only remove slots whose transaction account still exists.
+    const liveTxIds = await liveCronTransactionIds(
+      provider.connection,
+      cronJob,
+      cronJobAccount.nextTransactionId || 0
+    );
 
     const instructions: TransactionInstruction[] = [
       ...(await Promise.all(
-        txIds.map((txId) =>
+        liveTxIds.map((txId) =>
           hplCronsProgram.methods
             .removeEntityFromCronV0({
               index: txId,
@@ -95,8 +103,8 @@ export const closeAutomation = publicProcedure.hotspots.closeAutomation.handler(
               rentRefund: wallet,
               cronJobTransaction: cronJobTransactionKey(cronJob, txId)[0],
             })
-            .instruction(),
-        ),
+            .instruction()
+        )
       )),
       await hplCronsProgram.methods
         .closeEntityClaimCronV0()
@@ -105,7 +113,7 @@ export const closeAutomation = publicProcedure.hotspots.closeAutomation.handler(
           rentRefund: wallet,
           cronJobNameMapping: cronJobNameMappingKey(
             authority,
-            "entity_claim",
+            ENTITY_CLAIM_CRON_NAME
           )[0],
         })
         .instruction(),
@@ -130,7 +138,7 @@ export const closeAutomation = publicProcedure.hotspots.closeAutomation.handler(
     }
 
     const txs: Array<string> = vtxs.map((tx) =>
-      Buffer.from(tx.serialize()).toString("base64"),
+      Buffer.from(tx.serialize()).toString("base64")
     );
 
     const txFees = getTotalTransactionFees(vtxs);
@@ -150,8 +158,8 @@ export const closeAutomation = publicProcedure.hotspots.closeAutomation.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(txFees),
-        NATIVE_MINT.toBase58(),
+        NATIVE_MINT.toBase58()
       ),
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/closeAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/closeAutomation.ts
@@ -1,11 +1,6 @@
 import { createSolanaConnection, getCluster } from "@/lib/solana";
 import * as anchor from "@coral-xyz/anchor";
-import {
-  cronJobKey,
-  cronJobNameMappingKey,
-  cronJobTransactionKey,
-  init as initCron,
-} from "@helium/cron-sdk";
+import { cronJobKey, init as initCron } from "@helium/cron-sdk";
 import {
   entityCronAuthorityKey,
   init as initHplCrons,
@@ -16,9 +11,8 @@ import {
   batchInstructionsToTxsWithPriorityFee,
   toVersionedTx,
 } from "@helium/spl-utils";
-import { PublicKey, TransactionInstruction } from "@solana/web3.js";
-import { ENTITY_CLAIM_CRON_NAME } from "@/lib/utils/automation-helpers";
-import { liveCronTransactionIds } from "./automation-data-helpers";
+import { PublicKey } from "@solana/web3.js";
+import { buildTeardownInstructions } from "./automation-data-helpers";
 import {
   getJitoTipAmountLamports,
   getJitoTipTransaction,
@@ -82,42 +76,15 @@ export const closeAutomation = publicProcedure.hotspots.closeAutomation.handler(
       });
     }
 
-    // Build instructions to remove all entities and close cron job.
-    // nextTransactionId is a monotonic counter, so individually-removed claims
-    // leave holes: only remove slots whose transaction account still exists.
-    const liveTxIds = await liveCronTransactionIds(
+    // Remove all entities and close the cron job.
+    const instructions = await buildTeardownInstructions(
       provider.connection,
+      hplCronsProgram,
       cronJob,
+      authority,
+      wallet,
       cronJobAccount.nextTransactionId || 0
     );
-
-    const instructions: TransactionInstruction[] = [
-      ...(await Promise.all(
-        liveTxIds.map((txId) =>
-          hplCronsProgram.methods
-            .removeEntityFromCronV0({
-              index: txId,
-            })
-            .accounts({
-              cronJob,
-              rentRefund: wallet,
-              cronJobTransaction: cronJobTransactionKey(cronJob, txId)[0],
-            })
-            .instruction()
-        )
-      )),
-      await hplCronsProgram.methods
-        .closeEntityClaimCronV0()
-        .accounts({
-          cronJob,
-          rentRefund: wallet,
-          cronJobNameMapping: cronJobNameMappingKey(
-            authority,
-            ENTITY_CLAIM_CRON_NAME
-          )[0],
-        })
-        .instruction(),
-    ];
 
     // Build and serialize transactions
     const vtxs = (

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createAutomation.ts
@@ -9,7 +9,6 @@ import * as anchor from "@coral-xyz/anchor";
 import {
   cronJobKey,
   cronJobNameMappingKey,
-  cronJobTransactionKey,
   init as initCron,
 } from "@helium/cron-sdk";
 import {
@@ -22,11 +21,7 @@ import {
   HELIUM_COMMON_LUT_DEVNET,
   toVersionedTx,
 } from "@helium/spl-utils";
-import {
-  init as initTuktuk,
-  nextAvailableTaskIds,
-  taskKey,
-} from "@helium/tuktuk-sdk";
+import { init as initTuktuk } from "@helium/tuktuk-sdk";
 import {
   LAMPORTS_PER_SOL,
   PublicKey,
@@ -47,8 +42,9 @@ import {
 } from "@/lib/utils/jito";
 import { publicProcedure } from "../../../procedures";
 import {
+  buildTeardownInstructions,
   fetchAutomationData,
-  liveCronTransactionIds,
+  nextFreeTaskKey,
 } from "./automation-data-helpers";
 import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
 
@@ -91,56 +87,20 @@ export const createAutomation =
         // If it exists but schedule changed, remove it first. Skip holes left
         // by individually-removed claims (nextTransactionId is monotonic).
         if (cronJobAccount) {
-          const liveTxIds = await liveCronTransactionIds(
-            provider.connection,
-            cronJob,
-            cronJobAccount.nextTransactionId || 0
-          );
-
           instructions.push(
-            ...(await Promise.all(
-              liveTxIds.map((txId) =>
-                hplCronsProgram.methods
-                  .removeEntityFromCronV0({
-                    index: txId,
-                  })
-                  .accounts({
-                    cronJob,
-                    rentRefund: wallet,
-                    cronJobTransaction: cronJobTransactionKey(cronJob, txId)[0],
-                  })
-                  .instruction()
-              )
-            )),
-            await hplCronsProgram.methods
-              .closeEntityClaimCronV0()
-              .accounts({
-                cronJob,
-                rentRefund: wallet,
-                cronJobNameMapping: cronJobNameMappingKey(
-                  authority,
-                  ENTITY_CLAIM_CRON_NAME
-                )[0],
-              })
-              .instruction()
+            ...(await buildTeardownInstructions(
+              provider.connection,
+              hplCronsProgram,
+              cronJob,
+              authority,
+              wallet,
+              cronJobAccount.nextTransactionId || 0
+            ))
           );
         }
 
-        // Create new cron job
-        // Fetch task queue fresh to ensure we have the latest state
-        const freshTaskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
-          TASK_QUEUE_ID
-        );
-        const freshAvailableTaskIds = nextAvailableTaskIds(
-          freshTaskQueueAcc.taskBitmap,
-          1,
-          false
-        );
-        if (freshAvailableTaskIds.length === 0) {
-          throw new Error("No available task IDs in task queue");
-        }
-        const freshTaskId = freshAvailableTaskIds[0];
-        const [freshTask] = taskKey(TASK_QUEUE_ID, freshTaskId);
+        // Create new cron job. Fetch the task queue fresh to get the latest state.
+        const freshTask = await nextFreeTaskKey(tuktukProgram);
 
         instructions.push(
           await hplCronsProgram.methods
@@ -159,21 +119,9 @@ export const createAutomation =
             .instruction()
         );
       } else if (cronJobAccount?.removedFromQueue) {
-        // If cron exists but was removed from queue due to insufficient SOL, requeue it
-        // Fetch task queue fresh to ensure we have the latest state
-        const freshTaskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
-          TASK_QUEUE_ID
-        );
-        const freshAvailableTaskIds = nextAvailableTaskIds(
-          freshTaskQueueAcc.taskBitmap,
-          1,
-          false
-        );
-        if (freshAvailableTaskIds.length === 0) {
-          throw new Error("No available task IDs in task queue");
-        }
-        const freshTaskId = freshAvailableTaskIds[0];
-        const [freshTask] = taskKey(TASK_QUEUE_ID, freshTaskId);
+        // If cron exists but was removed from queue due to insufficient SOL,
+        // requeue it. Fetch the task queue fresh to get the latest state.
+        const freshTask = await nextFreeTaskKey(tuktukProgram);
 
         instructions.push(
           await hplCronsProgram.methods

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createAutomation.ts
@@ -3,6 +3,7 @@ import {
   BASE_AUTOMATION_RENT,
   calculateFundingForAdditionalDuration,
   ENTITY_CLAIM_CRON_NAME,
+  resolveScheduleToCron,
 } from "@/lib/utils/automation-helpers";
 import * as anchor from "@coral-xyz/anchor";
 import {
@@ -57,7 +58,10 @@ import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
 export const createAutomation =
   publicProcedure.hotspots.createAutomation.handler(
     async ({ input, errors }) => {
-      const { walletAddress, cronSchedule, duration } = input;
+      const { walletAddress, schedule, duration } = input;
+      // Accept a preset (daily/weekly/monthly) or a raw crontab; presets map to
+      // a crontab here so everything downstream deals in a single cron string.
+      const cronSchedule = resolveScheduleToCron(schedule);
 
       const wallet = new PublicKey(walletAddress);
       const { provider } = createSolanaConnection(walletAddress);

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createAutomation.ts
@@ -2,8 +2,7 @@ import { createSolanaConnection, getCluster } from "@/lib/solana";
 import {
   BASE_AUTOMATION_RENT,
   calculateFundingForAdditionalDuration,
-  getScheduleCronString,
-  interpretCronString,
+  ENTITY_CLAIM_CRON_NAME,
 } from "@/lib/utils/automation-helpers";
 import * as anchor from "@coral-xyz/anchor";
 import {
@@ -46,7 +45,10 @@ import {
   shouldUseJitoBundle,
 } from "@/lib/utils/jito";
 import { publicProcedure } from "../../../procedures";
-import { fetchAutomationData } from "./automation-data-helpers";
+import {
+  fetchAutomationData,
+  liveCronTransactionIds,
+} from "./automation-data-helpers";
 import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
 
 /**
@@ -55,7 +57,7 @@ import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
 export const createAutomation =
   publicProcedure.hotspots.createAutomation.handler(
     async ({ input, errors }) => {
-      const { walletAddress, schedule, duration } = input;
+      const { walletAddress, cronSchedule, duration } = input;
 
       const wallet = new PublicKey(walletAddress);
       const { provider } = createSolanaConnection(walletAddress);
@@ -66,29 +68,34 @@ export const createAutomation =
       const cronProgram = await initCron(provider);
       const tuktukProgram = await initTuktuk(provider);
 
-      // Derive keys
+      // Derive keys. hpl_crons pins a single entity-claim cron per wallet
+      // (id 0, name "entity_claim"), so both are fixed.
       const authority = entityCronAuthorityKey(wallet)[0];
       const cronJob = cronJobKey(authority, 0)[0];
 
-      const cronJobAccount =
-        await cronProgram.account.cronJobV0.fetchNullable(cronJob);
+      const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
+        cronJob
+      );
 
       const instructions: TransactionInstruction[] = [];
 
       // If cronJob doesn't exist or schedule changed, create/recreate it
       if (
         !cronJobAccount ||
-        (cronJobAccount.schedule &&
-          interpretCronString(cronJobAccount.schedule).schedule !== schedule)
+        (cronJobAccount.schedule && cronJobAccount.schedule !== cronSchedule)
       ) {
-        // If it exists but schedule changed, remove it first
+        // If it exists but schedule changed, remove it first. Skip holes left
+        // by individually-removed claims (nextTransactionId is monotonic).
         if (cronJobAccount) {
-          const maxTxId = cronJobAccount.nextTransactionId || 0;
-          const txIds = Array.from({ length: maxTxId }, (_, i) => i);
+          const liveTxIds = await liveCronTransactionIds(
+            provider.connection,
+            cronJob,
+            cronJobAccount.nextTransactionId || 0
+          );
 
           instructions.push(
             ...(await Promise.all(
-              txIds.map((txId) =>
+              liveTxIds.map((txId) =>
                 hplCronsProgram.methods
                   .removeEntityFromCronV0({
                     index: txId,
@@ -98,8 +105,8 @@ export const createAutomation =
                     rentRefund: wallet,
                     cronJobTransaction: cronJobTransactionKey(cronJob, txId)[0],
                   })
-                  .instruction(),
-              ),
+                  .instruction()
+              )
             )),
             await hplCronsProgram.methods
               .closeEntityClaimCronV0()
@@ -108,21 +115,22 @@ export const createAutomation =
                 rentRefund: wallet,
                 cronJobNameMapping: cronJobNameMappingKey(
                   authority,
-                  "entity_claim",
+                  ENTITY_CLAIM_CRON_NAME
                 )[0],
               })
-              .instruction(),
+              .instruction()
           );
         }
 
         // Create new cron job
         // Fetch task queue fresh to ensure we have the latest state
-        const freshTaskQueueAcc =
-          await tuktukProgram.account.taskQueueV0.fetch(TASK_QUEUE_ID);
+        const freshTaskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
+          TASK_QUEUE_ID
+        );
         const freshAvailableTaskIds = nextAvailableTaskIds(
           freshTaskQueueAcc.taskBitmap,
           1,
-          false,
+          false
         );
         if (freshAvailableTaskIds.length === 0) {
           throw new Error("No available task IDs in task queue");
@@ -130,11 +138,10 @@ export const createAutomation =
         const freshTaskId = freshAvailableTaskIds[0];
         const [freshTask] = taskKey(TASK_QUEUE_ID, freshTaskId);
 
-        const cronString = getScheduleCronString(schedule);
         instructions.push(
           await hplCronsProgram.methods
             .initEntityClaimCronV0({
-              schedule: cronString,
+              schedule: cronSchedule,
             })
             .accounts({
               taskQueue: TASK_QUEUE_ID,
@@ -142,20 +149,21 @@ export const createAutomation =
               task: freshTask,
               cronJobNameMapping: cronJobNameMappingKey(
                 authority,
-                "entity_claim",
+                ENTITY_CLAIM_CRON_NAME
               )[0],
             })
-            .instruction(),
+            .instruction()
         );
       } else if (cronJobAccount?.removedFromQueue) {
         // If cron exists but was removed from queue due to insufficient SOL, requeue it
         // Fetch task queue fresh to ensure we have the latest state
-        const freshTaskQueueAcc =
-          await tuktukProgram.account.taskQueueV0.fetch(TASK_QUEUE_ID);
+        const freshTaskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
+          TASK_QUEUE_ID
+        );
         const freshAvailableTaskIds = nextAvailableTaskIds(
           freshTaskQueueAcc.taskBitmap,
           1,
-          false,
+          false
         );
         if (freshAvailableTaskIds.length === 0) {
           throw new Error("No available task IDs in task queue");
@@ -172,10 +180,10 @@ export const createAutomation =
               task: freshTask,
               cronJobNameMapping: cronJobNameMappingKey(
                 authority,
-                "entity_claim",
+                ENTITY_CLAIM_CRON_NAME
               )[0],
             })
-            .instruction(),
+            .instruction()
         );
       }
 
@@ -240,20 +248,9 @@ export const createAutomation =
         });
       }
 
-      if (!cronJobAccount) {
-        const { instruction } = await hplCronsProgram.methods
-          .addWalletToEntityCronV0({
-            index: 0,
-          })
-          .accounts({
-            wallet,
-            cronJob,
-            cronJobTransaction: cronJobTransactionKey(cronJob, 0)[0],
-          })
-          .prepare();
-
-        instructions.push(instruction);
-      }
+      // Note: this only sets up (and funds) the cron itself. Claims are added
+      // separately via addWalletToAutomation / addEntityToAutomation, so the
+      // same cron can mix whole-wallet and per-hotspot claims.
 
       if (minCrankSolFee > 0) {
         instructions.push(
@@ -261,7 +258,7 @@ export const createAutomation =
             fromPubkey: wallet,
             toPubkey: cronJob,
             lamports: minCrankSolFee,
-          }),
+          })
         );
       }
 
@@ -271,7 +268,7 @@ export const createAutomation =
             fromPubkey: wallet,
             toPubkey: pdaWallet,
             lamports: minPdaWalletSolFee,
-          }),
+          })
         );
       }
 
@@ -294,7 +291,7 @@ export const createAutomation =
       }
 
       const txs: Array<string> = vtxs.map((tx) =>
-        Buffer.from(tx.serialize()).toString("base64"),
+        Buffer.from(tx.serialize()).toString("base64")
       );
 
       // Estimated fee includes tx fees + operational funding (cronJob + pdaWallet)
@@ -308,18 +305,18 @@ export const createAutomation =
             metadata: {
               type: "setup_automation",
               description: "Set up hotspot claim automation",
-              schedule,
+              cronSchedule,
               duration,
             },
           })),
           parallel: false,
           tag: `setup_automation:${walletAddress}`,
-          actionMetadata: { type: "setup_automation", schedule, duration },
+          actionMetadata: { type: "setup_automation", cronSchedule, duration },
         },
         estimatedSolFee: await toTokenAmountOutput(
           new BN(estimatedSolFeeLamports),
-          NATIVE_MINT.toBase58(),
+          NATIVE_MINT.toBase58()
         ),
       };
-    },
+    }
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/fundAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/fundAutomation.ts
@@ -107,7 +107,7 @@ export const fundAutomation = publicProcedure.hotspots.fundAutomation.handler(
           fromPubkey: wallet,
           toPubkey: cronJob,
           lamports: cronJobFundingLamports,
-        }),
+        })
       );
     }
 
@@ -118,7 +118,7 @@ export const fundAutomation = publicProcedure.hotspots.fundAutomation.handler(
           fromPubkey: wallet,
           toPubkey: pdaWallet,
           lamports: pdaWalletFundingLamports,
-        }),
+        })
       );
     }
 
@@ -132,7 +132,7 @@ export const fundAutomation = publicProcedure.hotspots.fundAutomation.handler(
           fromPubkey: wallet,
           toPubkey: cronJob,
           lamports: minFunding,
-        }),
+        })
       );
     }
 
@@ -155,7 +155,7 @@ export const fundAutomation = publicProcedure.hotspots.fundAutomation.handler(
     }
 
     const txs: Array<string> = vtxs.map((tx) =>
-      Buffer.from(tx.serialize()).toString("base64"),
+      Buffer.from(tx.serialize()).toString("base64")
     );
 
     // Estimated fee includes tx fees + funding amounts
@@ -178,8 +178,8 @@ export const fundAutomation = publicProcedure.hotspots.fundAutomation.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(estimatedSolFeeLamports),
-        NATIVE_MINT.toBase58(),
+        NATIVE_MINT.toBase58()
       ),
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/getAutomationStatus.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/getAutomationStatus.ts
@@ -72,6 +72,7 @@ export const getAutomationStatus =
         | undefined;
       let currentSchedule:
         | {
+            cron: string;
             schedule: "daily" | "weekly" | "monthly";
             time: string;
             nextRun: string;
@@ -81,6 +82,7 @@ export const getAutomationStatus =
       if (cronJobAccount?.schedule) {
         const scheduleInfo = interpretCronString(cronJobAccount.schedule);
         currentSchedule = {
+          cron: cronJobAccount.schedule,
           schedule: scheduleInfo.schedule,
           time: scheduleInfo.time,
           nextRun: scheduleInfo.nextRun.toISOString(),
@@ -127,5 +129,5 @@ export const getAutomationStatus =
         cronJobBalance: cronJobBalanceLamports.toString(),
         pdaWalletBalance: pdaWalletBalanceLamports.toString(),
       };
-    },
+    }
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/getFundingEstimate.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/getFundingEstimate.ts
@@ -76,5 +76,5 @@ export const getFundingEstimate =
         currentCronJobBalance: cronJobBalanceLamports.toString(),
         currentPdaWalletBalance: pdaWalletBalanceLamports.toString(),
       };
-    },
+    }
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/hotspot-cnft.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/hotspot-cnft.ts
@@ -25,8 +25,9 @@ type HotspotCnftErrors = {
  * instruction. `conflictMessage` is the reward-contract guard message — the only
  * wording that differs between the two endpoints.
  *
- * The reward-contract lookup is independent of the Merkle proof, so the two run
- * concurrently and are awaited together at the guard.
+ * The reward-contract lookup runs only after the ownership check passes, so an
+ * unauthorized caller never triggers the DB query and a lookup failure can't
+ * mask an UNAUTHORIZED response.
  */
 export const resolveOwnedHotspotCnft = async ({
   walletAddress,
@@ -58,15 +59,12 @@ export const resolveOwnedHotspotCnft = async ({
   const connection = new Connection(env.SOLANA_RPC_URL);
   const assetEndpoint = env.ASSET_ENDPOINT || connection.rpcEndpoint;
 
-  const [{ asset, args, accounts, remainingAccounts }, contractExists] =
-    await Promise.all([
-      proofArgsAndAccounts({
-        connection,
-        assetId: new PublicKey(assetId),
-        assetEndpoint,
-      }),
-      hasRewardContract(hotspotPubkey),
-    ]);
+  const { asset, args, accounts, remainingAccounts } =
+    await proofArgsAndAccounts({
+      connection,
+      assetId: new PublicKey(assetId),
+      assetEndpoint,
+    });
 
   if (!asset) {
     throw errors.NOT_FOUND({ message: "Asset not found" });
@@ -93,6 +91,7 @@ export const resolveOwnedHotspotCnft = async ({
     });
   }
 
+  const contractExists = await hasRewardContract(hotspotPubkey);
   if (contractExists) {
     throw errors.CONFLICT({ message: conflictMessage });
   }

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/hotspot-cnft.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/hotspot-cnft.ts
@@ -1,0 +1,126 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+import { env } from "@/lib/env";
+import { hasRewardContract } from "@/lib/queries/hotspots";
+import { proofArgsAndAccounts } from "@helium/spl-utils";
+import {
+  getAssetIdFromPubkey,
+  getBubblegumAuthorityPDA,
+  validateHeliumHotspot,
+} from "@/lib/utils/hotspot-helpers";
+import { vaultPda } from "../../squads/procedures/helpers";
+
+/** The typed error builders the hotspot cNFT preamble throws. */
+type HotspotCnftErrors = {
+  NOT_FOUND: (opts: { message: string }) => Error;
+  BAD_REQUEST: (opts: { message: string }) => Error;
+  UNAUTHORIZED: (opts: { message: string }) => Error;
+  CONFLICT: (opts: { message: string }) => Error;
+};
+
+/**
+ * Shared preamble for the burn/transfer hotspot endpoints: resolve the cNFT,
+ * validate it is a Helium hotspot owned by the expected authority (the wallet,
+ * or the multisig vault in propose mode), reject one with an active reward
+ * contract, and derive the bubblegum accounts needed to build the leaf
+ * instruction. `conflictMessage` is the reward-contract guard message — the only
+ * wording that differs between the two endpoints.
+ *
+ * The reward-contract lookup is independent of the Merkle proof, so the two run
+ * concurrently and are awaited together at the guard.
+ */
+export const resolveOwnedHotspotCnft = async ({
+  walletAddress,
+  hotspotPubkey,
+  multisig,
+  conflictMessage,
+  errors,
+}: {
+  walletAddress: string;
+  hotspotPubkey: string;
+  multisig?: string;
+  conflictMessage: string;
+  errors: HotspotCnftErrors;
+}) => {
+  const assetId = await getAssetIdFromPubkey(hotspotPubkey);
+  if (!assetId) {
+    throw errors.NOT_FOUND({ message: "Hotspot not found" });
+  }
+
+  let payerPubkey: PublicKey;
+  let multisigPda: PublicKey | undefined;
+  try {
+    payerPubkey = new PublicKey(walletAddress);
+    multisigPda = multisig ? new PublicKey(multisig) : undefined;
+  } catch {
+    throw errors.BAD_REQUEST({ message: "Invalid public key format" });
+  }
+
+  const connection = new Connection(env.SOLANA_RPC_URL);
+  const assetEndpoint = env.ASSET_ENDPOINT || connection.rpcEndpoint;
+
+  const [{ asset, args, accounts, remainingAccounts }, contractExists] =
+    await Promise.all([
+      proofArgsAndAccounts({
+        connection,
+        assetId: new PublicKey(assetId),
+        assetEndpoint,
+      }),
+      hasRewardContract(hotspotPubkey),
+    ]);
+
+  if (!asset) {
+    throw errors.NOT_FOUND({ message: "Asset not found" });
+  }
+  if (!validateHeliumHotspot(asset)) {
+    throw errors.BAD_REQUEST({
+      message: "Asset is not a valid Helium hotspot",
+    });
+  }
+
+  const ownerAddress =
+    typeof asset.ownership.owner === "string"
+      ? asset.ownership.owner
+      : asset.ownership.owner.toBase58();
+
+  // In Squads propose mode the on-chain owner must be the multisig's vault
+  // (walletAddress is only the proposing member); otherwise the wallet itself.
+  const expectedOwner = multisigPda ? vaultPda(multisigPda) : payerPubkey;
+  if (ownerAddress !== expectedOwner.toBase58()) {
+    throw errors.UNAUTHORIZED({
+      message: multisigPda
+        ? "Multisig vault is not the owner of this hotspot"
+        : "Wallet is not the owner of this hotspot",
+    });
+  }
+
+  if (contractExists) {
+    throw errors.CONFLICT({ message: conflictMessage });
+  }
+
+  const leafOwner = new PublicKey(ownerAddress);
+  const leafDelegate = asset.ownership.delegate
+    ? typeof asset.ownership.delegate === "string"
+      ? new PublicKey(asset.ownership.delegate)
+      : asset.ownership.delegate
+    : leafOwner;
+
+  const merkleTree = accounts.merkleTree;
+  const treeAuthority = await getBubblegumAuthorityPDA(merkleTree);
+
+  const hotspotName = asset.content?.metadata?.name || "Hotspot";
+
+  return {
+    connection,
+    payerPubkey,
+    multisigPda,
+    assetId,
+    asset,
+    args,
+    remainingAccounts,
+    merkleTree,
+    treeAuthority,
+    leafOwner,
+    leafDelegate,
+    hotspotName,
+  };
+};

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
@@ -64,7 +64,14 @@ export const issueDataOnlyHotspot =
       }
       const gatewaySignature = addGateway.gatewaySignature;
       // The gateway is a Helium public key; its entity key is the base58 form.
-      const entityKey = Address.fromBin(Buffer.from(addGateway.gateway)).b58;
+      // Address.fromBin throws on an unsupported net-/key-type byte, so treat a
+      // bad gateway as a client error rather than letting it surface as a 500.
+      let entityKey: string;
+      try {
+        entityKey = Address.fromBin(Buffer.from(addGateway.gateway)).b58;
+      } catch {
+        throw errors.BAD_REQUEST({ message: "Invalid gateway public key" });
+      }
 
       const program = await init(provider);
       const dao = daoKey(HNT_MINT)[0];
@@ -126,19 +133,33 @@ export const issueDataOnlyHotspot =
         });
         eccSignedBytes = Buffer.from(data.transaction, "hex");
       } catch (e) {
-        const detail = axios.isAxiosError(e)
-          ? JSON.stringify(e.response?.data) || e.message
-          : e instanceof Error
-            ? e.message
-            : "unknown error";
+        // Log the verifier's detail server-side; don't reflect it to the caller.
+        console.error(
+          "ECC verifier /verify failed",
+          axios.isAxiosError(e) ? (e.response?.data ?? e.message) : e,
+        );
         throw errors.BAD_REQUEST({
-          message: `ECC verifier could not co-sign the issue transaction: ${detail}`,
+          message: "ECC verifier could not co-sign the issue transaction",
         });
       }
 
       // The verifier returns the legacy transaction co-signed with the ECC
       // verifier key; the wallet fills the remaining owner signature.
       const eccSignedTx = VersionedTransaction.deserialize(eccSignedBytes);
+
+      // Defense in depth: the verifier must return the exact transaction we
+      // built with only signatures added. Reject any message difference so a
+      // compromised or on-path verifier cannot substitute a transaction the
+      // wallet would sign (under --commit it signs without re-simulating).
+      const builtMessage = tx.compileMessage().serialize();
+      const returnedMessage = Buffer.from(eccSignedTx.message.serialize());
+      if (!builtMessage.equals(returnedMessage)) {
+        throw errors.BAD_REQUEST({
+          message:
+            "ECC verifier returned a modified transaction; refusing to relay it",
+        });
+      }
+
       const totalFee = getTransactionFee(eccSignedTx);
       const walletBalance = await connection.getBalance(owner);
       const required = calculateRequiredBalance(totalFee, 0);

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
@@ -93,14 +93,37 @@ export const issueDataOnlyHotspot =
       // instructions before the issue instruction (it reads the issue at a fixed
       // index), so include both a unit-limit and a unit-price instruction.
       const { blockhash } = await connection.getLatestBlockhash();
-      const tx = new Transaction();
-      tx.add(
-        ComputeBudgetProgram.setComputeUnitLimit({ units: 500000 }),
-        ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1 }),
-        issueIx,
-      );
-      tx.recentBlockhash = blockhash;
-      tx.feePayer = owner;
+      const buildIssueTx = (units: number) => {
+        const built = new Transaction();
+        built.add(
+          ComputeBudgetProgram.setComputeUnitLimit({ units }),
+          ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1 }),
+          issueIx,
+        );
+        built.recentBlockhash = blockhash;
+        built.feePayer = owner;
+        return built;
+      };
+
+      // Requested CU is what the user pays for under SIMD-0553, so measure via
+      // simulation (simulated × 1.1) and only fall back to a conservative limit
+      // when simulation is unavailable.
+      const FALLBACK_UNITS = 500000;
+      let units = FALLBACK_UNITS;
+      try {
+        const sim = await connection.simulateTransaction(
+          new VersionedTransaction(
+            buildIssueTx(FALLBACK_UNITS).compileMessage(),
+          ),
+          { sigVerify: false, replaceRecentBlockhash: true },
+        );
+        if (!sim.value.err && sim.value.unitsConsumed) {
+          units = Math.ceil(sim.value.unitsConsumed * 1.1);
+        }
+      } catch {
+        // Simulation is best-effort; keep the conservative fallback.
+      }
+      const tx = buildIssueTx(units);
 
       // The message the gateway signed is the add-gateway proto with its
       // signatures cleared (matching AddGatewayV1.toProto(forSigning=true), which

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
@@ -1,53 +1,146 @@
-import OnboardingClient from "@helium/onboarding";
-import { PublicKey, VersionedTransaction } from "@solana/web3.js";
 import { publicProcedure } from "../../../procedures";
+import {
+  ComputeBudgetProgram,
+  PublicKey,
+  Transaction,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import { env } from "@/lib/env";
 import { createSolanaConnection } from "@/lib/solana";
+import { init } from "@helium/helium-entity-manager-sdk";
+import { daoKey } from "@helium/helium-sub-daos-sdk";
+import { HNT_MINT } from "@helium/spl-utils";
+import { helium } from "@helium/proto";
+import Address from "@helium/address";
 import {
-  getTransactionFee,
   calculateRequiredBalance,
+  getTransactionFee,
 } from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
 import { NATIVE_MINT } from "@solana/spl-token";
 import BN from "bn.js";
+import bs58 from "bs58";
+import axios from "axios";
+
+// The ECC verifier is a required signer on IssueDataOnlyEntityV0. Only the ECC
+// verifier service holds the private key; it co-signs after re-checking the
+// gateway's ECC signature. This pubkey matches the one the on-chain program and
+// the SDK resolver expect.
+const ECC_VERIFIER = new PublicKey(
+  "eccSAJM3tq7nQSpQTm8roxv4FPoipCkMsGizW2KBhqZ",
+);
 
 /**
- * Issue (mint) a data-only hotspot. The onboarding server verifies the
- * hotspot's key against the ECC verifier and co-signs the issue transaction; we
- * relay it for the wallet to add the owner signature and submit.
+ * Issue (mint) a data-only hotspot. Data-only hotspots are issued
+ * permissionlessly through the data-only escrow — no maker is involved. We build
+ * the IssueDataOnlyEntityV0 instruction locally and hand the unsigned
+ * transaction to the ECC verifier, which validates the gateway's ECC key
+ * signature and co-signs. The wallet then adds the owner signature and submits.
  */
 export const issueDataOnlyHotspot =
   publicProcedure.hotspots.issueDataOnlyHotspot.handler(
     async ({ input, errors }) => {
       const { walletAddress, addGatewayTxn } = input;
+      const owner = new PublicKey(walletAddress);
+      const { connection, provider } = createSolanaConnection(walletAddress);
 
-      const { connection } = createSolanaConnection(walletAddress);
-      const onboardingClient = new OnboardingClient(env.ONBOARDING_ENDPOINT);
+      let addGateway;
+      try {
+        addGateway = helium.blockchain_txn.decode(
+          Buffer.from(addGatewayTxn, "base64"),
+        ).addGateway;
+      } catch {
+        throw errors.BAD_REQUEST({
+          message: "Invalid add-gateway transaction",
+        });
+      }
+      if (
+        !addGateway?.gateway?.length ||
+        !addGateway.gatewaySignature?.length
+      ) {
+        throw errors.BAD_REQUEST({
+          message: "Add-gateway transaction is missing the gateway signature",
+        });
+      }
+      const gatewaySignature = addGateway.gatewaySignature;
+      // The gateway is a Helium public key; its entity key is the base58 form.
+      const entityKey = Address.fromBin(Buffer.from(addGateway.gateway)).b58;
 
-      const response = await onboardingClient.createHotspot({
-        transaction: addGatewayTxn,
-        payer: walletAddress,
-        format: "v0",
-      });
+      const program = await init(provider);
+      const dao = daoKey(HNT_MINT)[0];
 
-      const rawTxs = response.data?.solanaTransactions ?? [];
-      if (rawTxs.length === 0) {
-        throw errors.NOT_FOUND({
-          message:
-            "Onboarding server returned no transactions to issue this hotspot",
+      const issueIx = await program.methods
+        .issueDataOnlyEntityV0({
+          entityKey: Buffer.from(bs58.decode(entityKey)),
+        })
+        .accountsPartial({
+          payer: owner,
+          recipient: owner,
+          dao,
+          eccVerifier: ECC_VERIFIER,
+        })
+        .instruction();
+
+      // The ECC verifier deserializes the wire bytes as a (legacy)
+      // VersionedTransaction and expects exactly two leading compute-budget
+      // instructions before the issue instruction (it reads the issue at a fixed
+      // index), so include both a unit-limit and a unit-price instruction.
+      const { blockhash } = await connection.getLatestBlockhash();
+      const tx = new Transaction();
+      tx.add(
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 500000 }),
+        ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1 }),
+        issueIx,
+      );
+      tx.recentBlockhash = blockhash;
+      tx.feePayer = owner;
+
+      // The message the gateway signed is the add-gateway proto with its
+      // signatures cleared (matching AddGatewayV1.toProto(forSigning=true), which
+      // is private). The verifier checks `signature` over `msg`, confirms it
+      // matches the gateway key referenced in the transaction, and signs.
+      const msg = helium.blockchain_txn_add_gateway_v1
+        .encode({
+          owner: addGateway.owner?.length ? addGateway.owner : null,
+          gateway: addGateway.gateway,
+          payer: addGateway.payer?.length ? addGateway.payer : null,
+          stakingFee:
+            addGateway.stakingFee && Number(addGateway.stakingFee) > 0
+              ? addGateway.stakingFee
+              : null,
+          fee:
+            addGateway.fee && Number(addGateway.fee) > 0
+              ? addGateway.fee
+              : null,
+        })
+        .finish();
+
+      let eccSignedBytes: Buffer;
+      try {
+        const { data } = await axios.post(`${env.ECC_VERIFIER_URL}/verify`, {
+          transaction: tx
+            .serialize({ requireAllSignatures: false, verifySignatures: false })
+            .toString("hex"),
+          msg: Buffer.from(msg).toString("hex"),
+          signature: Buffer.from(gatewaySignature).toString("hex"),
+        });
+        eccSignedBytes = Buffer.from(data.transaction, "hex");
+      } catch (e) {
+        const detail = axios.isAxiosError(e)
+          ? JSON.stringify(e.response?.data) || e.message
+          : e instanceof Error
+            ? e.message
+            : "unknown error";
+        throw errors.BAD_REQUEST({
+          message: `ECC verifier could not co-sign the issue transaction: ${detail}`,
         });
       }
 
-      const rawTxBytes = rawTxs.map((t) => Buffer.from(t));
-      const totalFee = rawTxBytes.reduce(
-        (sum, bytes) =>
-          sum + getTransactionFee(VersionedTransaction.deserialize(bytes)),
-        0
-      );
-
-      const walletBalance = await connection.getBalance(
-        new PublicKey(walletAddress)
-      );
+      // The verifier returns the legacy transaction co-signed with the ECC
+      // verifier key; the wallet fills the remaining owner signature.
+      const eccSignedTx = VersionedTransaction.deserialize(eccSignedBytes);
+      const totalFee = getTransactionFee(eccSignedTx);
+      const walletBalance = await connection.getBalance(owner);
       const required = calculateRequiredBalance(totalFee, 0);
       if (walletBalance < required) {
         throw errors.INSUFFICIENT_FUNDS({
@@ -58,21 +151,23 @@ export const issueDataOnlyHotspot =
 
       return {
         transactionData: {
-          transactions: rawTxBytes.map((bytes) => ({
-            serializedTransaction: bytes.toString("base64"),
-            metadata: {
-              type: "issue_data_only_hotspot",
-              description: "Issue a data-only hotspot",
+          transactions: [
+            {
+              serializedTransaction: eccSignedBytes.toString("base64"),
+              metadata: {
+                type: "issue_data_only_hotspot",
+                description: "Issue a data-only hotspot",
+              },
             },
-          })),
+          ],
           parallel: false,
           tag: `issue_data_only_hotspot:${walletAddress}`,
           actionMetadata: { type: "issue_data_only_hotspot" },
         },
         estimatedSolFee: await toTokenAmountOutput(
           new BN(totalFee),
-          NATIVE_MINT.toBase58()
+          NATIVE_MINT.toBase58(),
         ),
       };
-    }
+    },
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
@@ -93,37 +93,14 @@ export const issueDataOnlyHotspot =
       // instructions before the issue instruction (it reads the issue at a fixed
       // index), so include both a unit-limit and a unit-price instruction.
       const { blockhash } = await connection.getLatestBlockhash();
-      const buildIssueTx = (units: number) => {
-        const built = new Transaction();
-        built.add(
-          ComputeBudgetProgram.setComputeUnitLimit({ units }),
-          ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1 }),
-          issueIx,
-        );
-        built.recentBlockhash = blockhash;
-        built.feePayer = owner;
-        return built;
-      };
-
-      // Requested CU is what the user pays for under SIMD-0553, so measure via
-      // simulation (simulated × 1.1) and only fall back to a conservative limit
-      // when simulation is unavailable.
-      const FALLBACK_UNITS = 500000;
-      let units = FALLBACK_UNITS;
-      try {
-        const sim = await connection.simulateTransaction(
-          new VersionedTransaction(
-            buildIssueTx(FALLBACK_UNITS).compileMessage(),
-          ),
-          { sigVerify: false, replaceRecentBlockhash: true },
-        );
-        if (!sim.value.err && sim.value.unitsConsumed) {
-          units = Math.ceil(sim.value.unitsConsumed * 1.1);
-        }
-      } catch {
-        // Simulation is best-effort; keep the conservative fallback.
-      }
-      const tx = buildIssueTx(units);
+      const tx = new Transaction();
+      tx.add(
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 500000 }),
+        ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1 }),
+        issueIx,
+      );
+      tx.recentBlockhash = blockhash;
+      tx.feePayer = owner;
 
       // The message the gateway signed is the add-gateway proto with its
       // signatures cleared (matching AddGatewayV1.toProto(forSigning=true), which

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/issueDataOnlyHotspot.ts
@@ -1,0 +1,78 @@
+import OnboardingClient from "@helium/onboarding";
+import { PublicKey, VersionedTransaction } from "@solana/web3.js";
+import { publicProcedure } from "../../../procedures";
+import { env } from "@/lib/env";
+import { createSolanaConnection } from "@/lib/solana";
+import {
+  getTransactionFee,
+  calculateRequiredBalance,
+} from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+
+/**
+ * Issue (mint) a data-only hotspot. The onboarding server verifies the
+ * hotspot's key against the ECC verifier and co-signs the issue transaction; we
+ * relay it for the wallet to add the owner signature and submit.
+ */
+export const issueDataOnlyHotspot =
+  publicProcedure.hotspots.issueDataOnlyHotspot.handler(
+    async ({ input, errors }) => {
+      const { walletAddress, addGatewayTxn } = input;
+
+      const { connection } = createSolanaConnection(walletAddress);
+      const onboardingClient = new OnboardingClient(env.ONBOARDING_ENDPOINT);
+
+      const response = await onboardingClient.createHotspot({
+        transaction: addGatewayTxn,
+        payer: walletAddress,
+        format: "v0",
+      });
+
+      const rawTxs = response.data?.solanaTransactions ?? [];
+      if (rawTxs.length === 0) {
+        throw errors.NOT_FOUND({
+          message:
+            "Onboarding server returned no transactions to issue this hotspot",
+        });
+      }
+
+      const rawTxBytes = rawTxs.map((t) => Buffer.from(t));
+      const totalFee = rawTxBytes.reduce(
+        (sum, bytes) =>
+          sum + getTransactionFee(VersionedTransaction.deserialize(bytes)),
+        0
+      );
+
+      const walletBalance = await connection.getBalance(
+        new PublicKey(walletAddress)
+      );
+      const required = calculateRequiredBalance(totalFee, 0);
+      if (walletBalance < required) {
+        throw errors.INSUFFICIENT_FUNDS({
+          message: "Insufficient SOL balance for transaction fees",
+          data: { required, available: walletBalance },
+        });
+      }
+
+      return {
+        transactionData: {
+          transactions: rawTxBytes.map((bytes) => ({
+            serializedTransaction: bytes.toString("base64"),
+            metadata: {
+              type: "issue_data_only_hotspot",
+              description: "Issue a data-only hotspot",
+            },
+          })),
+          parallel: false,
+          tag: `issue_data_only_hotspot:${walletAddress}`,
+          actionMetadata: { type: "issue_data_only_hotspot" },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(totalFee),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+  );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/onboardDataOnlyHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/onboardDataOnlyHotspot.ts
@@ -1,0 +1,104 @@
+import OnboardingClient from "@helium/onboarding";
+import { PublicKey, VersionedTransaction } from "@solana/web3.js";
+import { publicProcedure } from "../../../procedures";
+import { env } from "@/lib/env";
+import { createSolanaConnection } from "@/lib/solana";
+import { latLngToH3 } from "@/lib/location/h3";
+import {
+  getTransactionFee,
+  calculateRequiredBalance,
+} from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+
+/**
+ * Onboard a previously-issued data-only hotspot into a sub-DAO, asserting its
+ * location (and, for IoT, gain/elevation). The onboarding server builds the
+ * onboard transaction; we relay it for local signing.
+ */
+export const onboardDataOnlyHotspot =
+  publicProcedure.hotspots.onboardDataOnlyHotspot.handler(
+    async ({ input, errors }) => {
+      const {
+        walletAddress,
+        network,
+        hotspotAddress,
+        lat,
+        lng,
+        elevation,
+        gain,
+      } = input;
+
+      const { connection } = createSolanaConnection(walletAddress);
+      const onboardingClient = new OnboardingClient(env.ONBOARDING_ENDPOINT);
+
+      const h3 =
+        lat !== undefined && lng !== undefined
+          ? latLngToH3({ lat, lng })
+          : null;
+
+      const response =
+        network === "iot"
+          ? await onboardingClient.onboardIot({
+              hotspotAddress,
+              payer: walletAddress,
+              format: "v0",
+              location: h3?.iot,
+              elevation,
+              gain,
+            })
+          : await onboardingClient.onboardMobile({
+              hotspotAddress,
+              payer: walletAddress,
+              format: "v0",
+              location: h3?.mobile,
+            });
+
+      const rawTxs = response.data?.solanaTransactions ?? [];
+      if (rawTxs.length === 0) {
+        throw errors.NOT_FOUND({
+          message:
+            "Onboarding server returned no transactions to onboard this hotspot",
+        });
+      }
+
+      const rawTxBytes = rawTxs.map((t) => Buffer.from(t));
+      const totalFee = rawTxBytes.reduce(
+        (sum, bytes) =>
+          sum + getTransactionFee(VersionedTransaction.deserialize(bytes)),
+        0
+      );
+
+      const walletBalance = await connection.getBalance(
+        new PublicKey(walletAddress)
+      );
+      const required = calculateRequiredBalance(totalFee, 0);
+      if (walletBalance < required) {
+        throw errors.INSUFFICIENT_FUNDS({
+          message: "Insufficient SOL balance for transaction fees",
+          data: { required, available: walletBalance },
+        });
+      }
+
+      return {
+        transactionData: {
+          transactions: rawTxBytes.map((bytes) => ({
+            serializedTransaction: bytes.toString("base64"),
+            metadata: {
+              type: "onboard_data_only_hotspot",
+              description: "Onboard a data-only hotspot",
+              network,
+            },
+          })),
+          parallel: false,
+          tag: `onboard_data_only_hotspot:${walletAddress}:${hotspotAddress}`,
+          actionMetadata: { type: "onboard_data_only_hotspot", network },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(totalFee),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+  );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/onboardDataOnlyHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/onboardDataOnlyHotspot.ts
@@ -1,21 +1,41 @@
-import OnboardingClient from "@helium/onboarding";
-import { PublicKey, VersionedTransaction } from "@solana/web3.js";
 import { publicProcedure } from "../../../procedures";
+import { PublicKey } from "@solana/web3.js";
 import { env } from "@/lib/env";
 import { createSolanaConnection } from "@/lib/solana";
 import { latLngToH3 } from "@/lib/location/h3";
 import {
-  getTransactionFee,
+  init,
+  iotInfoKey,
+  mobileInfoKey,
+  keyToAssetKey,
+  rewardableEntityConfigKey,
+} from "@helium/helium-entity-manager-sdk";
+import { daoKey, subDaoKey } from "@helium/helium-sub-daos-sdk";
+import {
+  HNT_MINT,
+  IOT_MINT,
+  MOBILE_MINT,
+  proofArgsAndAccounts,
+} from "@helium/spl-utils";
+import {
+  buildVersionedTransaction,
+  serializeTransaction,
+} from "@/lib/utils/build-transaction";
+import {
   calculateRequiredBalance,
+  getTransactionFee,
 } from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
 import { NATIVE_MINT } from "@solana/spl-token";
 import BN from "bn.js";
 
 /**
  * Onboard a previously-issued data-only hotspot into a sub-DAO, asserting its
- * location (and, for IoT, gain/elevation). The onboarding server builds the
- * onboard transaction; we relay it for local signing.
+ * location (and, for IoT, gain/elevation). Data-only onboarding is permissionless:
+ * we build the OnboardDataOnly{Iot,Mobile}HotspotV0 instruction locally with the
+ * hotspot's compressed-NFT merkle proof, and the wallet (the sole signer, payer,
+ * and DC fee payer) signs and submits. No onboarding server or maker is involved.
  */
 export const onboardDataOnlyHotspot =
   publicProcedure.hotspots.onboardDataOnlyHotspot.handler(
@@ -29,50 +49,102 @@ export const onboardDataOnlyHotspot =
         elevation,
         gain,
       } = input;
+      const owner = new PublicKey(walletAddress);
+      const { connection, provider } = createSolanaConnection(walletAddress);
 
-      const { connection } = createSolanaConnection(walletAddress);
-      const onboardingClient = new OnboardingClient(env.ONBOARDING_ENDPOINT);
+      // The hotspot must already be issued (its cNFT must exist) before it can
+      // be onboarded.
+      const assetId = await getAssetIdFromPubkey(hotspotAddress);
+      if (!assetId) {
+        throw errors.NOT_FOUND({
+          message: "Hotspot not found on-chain; issue it before onboarding",
+        });
+      }
 
+      const program = await init(provider);
+      const dao = daoKey(HNT_MINT)[0];
+      const keyToAsset = keyToAssetKey(dao, hotspotAddress)[0];
+
+      const assetEndpoint = env.ASSET_ENDPOINT || connection.rpcEndpoint;
+      const { args, accounts, remainingAccounts } = await proofArgsAndAccounts({
+        connection,
+        assetId: new PublicKey(assetId),
+        assetEndpoint,
+      });
+
+      // Assert a location only when both coordinates are given; the on-chain
+      // location is the H3 cell index as a u64.
       const h3 =
         lat !== undefined && lng !== undefined
           ? latLngToH3({ lat, lng })
           : null;
 
-      const response =
-        network === "iot"
-          ? await onboardingClient.onboardIot({
+      let onboardIx;
+      if (network === "iot") {
+        const subDao = subDaoKey(IOT_MINT)[0];
+        const rewardableEntityConfig = rewardableEntityConfigKey(
+          subDao,
+          "IOT",
+        )[0];
+        onboardIx = await program.methods
+          .onboardDataOnlyIotHotspotV0({
+            ...args,
+            location: h3 ? new BN(h3.iot, "hex") : null,
+            // On-chain gain is tenths of a dBi (i32); elevation is whole meters.
+            elevation: elevation !== undefined ? Math.trunc(elevation) : null,
+            gain: gain !== undefined ? Math.trunc(gain * 10) : null,
+          })
+          .accountsPartial({
+            payer: owner,
+            dcFeePayer: owner,
+            hotspotOwner: owner,
+            rewardableEntityConfig,
+            keyToAsset,
+            iotInfo: iotInfoKey(rewardableEntityConfig, hotspotAddress)[0],
+            subDao,
+            merkleTree: accounts.merkleTree,
+          })
+          .remainingAccounts(remainingAccounts)
+          .instruction();
+      } else {
+        const subDao = subDaoKey(MOBILE_MINT)[0];
+        const rewardableEntityConfig = rewardableEntityConfigKey(
+          subDao,
+          "MOBILE",
+        )[0];
+        onboardIx = await program.methods
+          .onboardDataOnlyMobileHotspotV0({
+            ...args,
+            location: h3 ? new BN(h3.mobile, "hex") : null,
+          })
+          .accountsPartial({
+            payer: owner,
+            dcFeePayer: owner,
+            hotspotOwner: owner,
+            rewardableEntityConfig,
+            keyToAsset,
+            mobileInfo: mobileInfoKey(
+              rewardableEntityConfig,
               hotspotAddress,
-              payer: walletAddress,
-              format: "v0",
-              location: h3?.iot,
-              elevation,
-              gain,
-            })
-          : await onboardingClient.onboardMobile({
-              hotspotAddress,
-              payer: walletAddress,
-              format: "v0",
-              location: h3?.mobile,
-            });
-
-      const rawTxs = response.data?.solanaTransactions ?? [];
-      if (rawTxs.length === 0) {
-        throw errors.NOT_FOUND({
-          message:
-            "Onboarding server returned no transactions to onboard this hotspot",
-        });
+            )[0],
+            subDao,
+            merkleTree: accounts.merkleTree,
+          })
+          .remainingAccounts(remainingAccounts)
+          .instruction();
       }
 
-      const rawTxBytes = rawTxs.map((t) => Buffer.from(t));
-      const totalFee = rawTxBytes.reduce(
-        (sum, bytes) =>
-          sum + getTransactionFee(VersionedTransaction.deserialize(bytes)),
-        0
-      );
+      const tx = await buildVersionedTransaction({
+        connection,
+        draft: {
+          instructions: [onboardIx],
+          feePayer: owner,
+          addressLookupTableAddresses: [],
+        },
+      });
 
-      const walletBalance = await connection.getBalance(
-        new PublicKey(walletAddress)
-      );
+      const totalFee = getTransactionFee(tx);
+      const walletBalance = await connection.getBalance(owner);
       const required = calculateRequiredBalance(totalFee, 0);
       if (walletBalance < required) {
         throw errors.INSUFFICIENT_FUNDS({
@@ -83,22 +155,24 @@ export const onboardDataOnlyHotspot =
 
       return {
         transactionData: {
-          transactions: rawTxBytes.map((bytes) => ({
-            serializedTransaction: bytes.toString("base64"),
-            metadata: {
-              type: "onboard_data_only_hotspot",
-              description: "Onboard a data-only hotspot",
-              network,
+          transactions: [
+            {
+              serializedTransaction: serializeTransaction(tx),
+              metadata: {
+                type: "onboard_data_only_hotspot",
+                description: "Onboard a data-only hotspot",
+                network,
+              },
             },
-          })),
+          ],
           parallel: false,
           tag: `onboard_data_only_hotspot:${walletAddress}:${hotspotAddress}`,
           actionMetadata: { type: "onboard_data_only_hotspot", network },
         },
         estimatedSolFee: await toTokenAmountOutput(
           new BN(totalFee),
-          NATIVE_MINT.toBase58()
+          NATIVE_MINT.toBase58(),
         ),
       };
-    }
+    },
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/removeEntityFromAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/removeEntityFromAutomation.ts
@@ -1,0 +1,112 @@
+import { createSolanaConnection, getCluster } from "@/lib/solana";
+import * as anchor from "@coral-xyz/anchor";
+import {
+  cronJobKey,
+  cronJobTransactionKey,
+  init as initCron,
+} from "@helium/cron-sdk";
+import {
+  entityCronAuthorityKey,
+  init as initHplCrons,
+} from "@helium/hpl-crons-sdk";
+import {
+  HELIUM_COMMON_LUT,
+  HELIUM_COMMON_LUT_DEVNET,
+  batchInstructionsToTxsWithPriorityFee,
+  toVersionedTx,
+} from "@helium/spl-utils";
+import { PublicKey } from "@solana/web3.js";
+import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
+import { publicProcedure } from "../../../procedures";
+import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+
+/**
+ * Create a transaction to remove a single claim entry (by its cron transaction
+ * index) from an existing automation. The freed rent is refunded to the wallet.
+ */
+export const removeEntityFromAutomation =
+  publicProcedure.hotspots.removeEntityFromAutomation.handler(
+    async ({ input, errors }) => {
+      const { walletAddress, index } = input;
+
+      const wallet = new PublicKey(walletAddress);
+      const { provider } = createSolanaConnection(walletAddress);
+      anchor.setProvider(provider);
+
+      const hplCronsProgram = await initHplCrons(provider);
+      const cronProgram = await initCron(provider);
+
+      const authority = entityCronAuthorityKey(wallet)[0];
+      const cronJob = cronJobKey(authority, 0)[0];
+
+      const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
+        cronJob
+      );
+      if (!cronJobAccount) {
+        throw errors.NOT_FOUND({ message: "Automation not found" });
+      }
+      if (index >= (cronJobAccount.nextTransactionId || 0)) {
+        throw errors.NOT_FOUND({
+          message: `Automation has no claim entry at index ${index}`,
+        });
+      }
+
+      const instructions = [
+        await hplCronsProgram.methods
+          .removeEntityFromCronV0({ index })
+          .accounts({
+            cronJob,
+            rentRefund: wallet,
+            cronJobTransaction: cronJobTransactionKey(cronJob, index)[0],
+          })
+          .instruction(),
+      ];
+
+      const vtxs = (
+        await batchInstructionsToTxsWithPriorityFee(provider, instructions, {
+          addressLookupTableAddresses: [
+            process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
+              ? HELIUM_COMMON_LUT_DEVNET
+              : HELIUM_COMMON_LUT,
+          ],
+          computeUnitLimit: 500000,
+          commitment: "finalized",
+        })
+      ).map((tx) => toVersionedTx(tx));
+
+      if (shouldUseJitoBundle(vtxs.length, getCluster())) {
+        vtxs.push(await getJitoTipTransaction(wallet));
+      }
+
+      const txs = vtxs.map((tx) =>
+        Buffer.from(tx.serialize()).toString("base64")
+      );
+      const txFees = getTotalTransactionFees(vtxs);
+
+      return {
+        transactionData: {
+          transactions: txs.map((serialized) => ({
+            serializedTransaction: serialized,
+            metadata: {
+              type: "remove_entity_from_automation",
+              description: "Remove claim from automation",
+              index,
+            },
+          })),
+          parallel: false,
+          tag: `remove_entity_from_automation:${walletAddress}`,
+          actionMetadata: {
+            type: "remove_entity_from_automation",
+            index,
+          },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(txFees),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+  );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/removeEntityFromAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/removeEntityFromAutomation.ts
@@ -1,27 +1,9 @@
-import { createSolanaConnection, getCluster } from "@/lib/solana";
-import * as anchor from "@coral-xyz/anchor";
-import {
-  cronJobKey,
-  cronJobTransactionKey,
-  init as initCron,
-} from "@helium/cron-sdk";
-import {
-  entityCronAuthorityKey,
-  init as initHplCrons,
-} from "@helium/hpl-crons-sdk";
-import {
-  HELIUM_COMMON_LUT,
-  HELIUM_COMMON_LUT_DEVNET,
-  batchInstructionsToTxsWithPriorityFee,
-  toVersionedTx,
-} from "@helium/spl-utils";
-import { PublicKey } from "@solana/web3.js";
-import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
+import { cronJobTransactionKey } from "@helium/cron-sdk";
 import { publicProcedure } from "../../../procedures";
-import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
-import { toTokenAmountOutput } from "@/lib/utils/token-math";
-import { NATIVE_MINT } from "@solana/spl-token";
-import BN from "bn.js";
+import {
+  buildAutomationTransactionResponse,
+  resolveEntityClaimCronJob,
+} from "./automation-transaction";
 
 /**
  * Create a transaction to remove a single claim entry (by its cron transaction
@@ -32,22 +14,13 @@ export const removeEntityFromAutomation =
     async ({ input, errors }) => {
       const { walletAddress, index } = input;
 
-      const wallet = new PublicKey(walletAddress);
-      const { provider } = createSolanaConnection(walletAddress);
-      anchor.setProvider(provider);
+      const { provider, hplCronsProgram, cronJob, cronJobAccount, wallet } =
+        await resolveEntityClaimCronJob({
+          walletAddress,
+          notFoundMessage: "Automation not found",
+          errors,
+        });
 
-      const hplCronsProgram = await initHplCrons(provider);
-      const cronProgram = await initCron(provider);
-
-      const authority = entityCronAuthorityKey(wallet)[0];
-      const cronJob = cronJobKey(authority, 0)[0];
-
-      const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
-        cronJob
-      );
-      if (!cronJobAccount) {
-        throw errors.NOT_FOUND({ message: "Automation not found" });
-      }
       if (index >= (cronJobAccount.nextTransactionId || 0)) {
         throw errors.NOT_FOUND({
           message: `Automation has no claim entry at index ${index}`,
@@ -65,48 +38,20 @@ export const removeEntityFromAutomation =
           .instruction(),
       ];
 
-      const vtxs = (
-        await batchInstructionsToTxsWithPriorityFee(provider, instructions, {
-          addressLookupTableAddresses: [
-            process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
-              ? HELIUM_COMMON_LUT_DEVNET
-              : HELIUM_COMMON_LUT,
-          ],
-          computeUnitLimit: 500000,
-          commitment: "finalized",
-        })
-      ).map((tx) => toVersionedTx(tx));
-
-      if (shouldUseJitoBundle(vtxs.length, getCluster())) {
-        vtxs.push(await getJitoTipTransaction(wallet));
-      }
-
-      const txs = vtxs.map((tx) =>
-        Buffer.from(tx.serialize()).toString("base64")
-      );
-      const txFees = getTotalTransactionFees(vtxs);
-
-      return {
-        transactionData: {
-          transactions: txs.map((serialized) => ({
-            serializedTransaction: serialized,
-            metadata: {
-              type: "remove_entity_from_automation",
-              description: "Remove claim from automation",
-              index,
-            },
-          })),
-          parallel: false,
-          tag: `remove_entity_from_automation:${walletAddress}`,
-          actionMetadata: {
-            type: "remove_entity_from_automation",
-            index,
-          },
+      return buildAutomationTransactionResponse({
+        provider,
+        instructions,
+        feePayer: wallet,
+        tag: `remove_entity_from_automation:${walletAddress}`,
+        transactionMetadata: {
+          type: "remove_entity_from_automation",
+          description: "Remove claim from automation",
+          index,
         },
-        estimatedSolFee: await toTokenAmountOutput(
-          new BN(txFees),
-          NATIVE_MINT.toBase58()
-        ),
-      };
-    }
+        actionMetadata: {
+          type: "remove_entity_from_automation",
+          index,
+        },
+      });
+    },
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/requeueAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/requeueAutomation.ts
@@ -1,12 +1,9 @@
 import { ENTITY_CLAIM_CRON_NAME } from "@/lib/utils/automation-helpers";
 import { cronJobNameMappingKey } from "@helium/cron-sdk";
-import {
-  init as initTuktuk,
-  nextAvailableTaskIds,
-  taskKey,
-} from "@helium/tuktuk-sdk";
+import { init as initTuktuk } from "@helium/tuktuk-sdk";
 import { publicProcedure } from "../../../procedures";
 import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
+import { nextFreeTaskKey } from "./automation-data-helpers";
 import {
   buildAutomationTransactionResponse,
   resolveEntityClaimCronJob,
@@ -30,10 +27,7 @@ export const requeueAutomation =
         });
 
       const tuktukProgram = await initTuktuk(provider);
-      const taskQueueAcc =
-        await tuktukProgram.account.taskQueueV0.fetch(TASK_QUEUE_ID);
-      const [taskId] = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 1, false);
-      const [task] = taskKey(TASK_QUEUE_ID, taskId);
+      const task = await nextFreeTaskKey(tuktukProgram);
 
       const instructions = [
         await hplCronsProgram.methods
@@ -44,7 +38,7 @@ export const requeueAutomation =
             task,
             cronJobNameMapping: cronJobNameMappingKey(
               authority,
-              ENTITY_CLAIM_CRON_NAME,
+              ENTITY_CLAIM_CRON_NAME
             )[0],
           })
           .instruction(),
@@ -61,5 +55,5 @@ export const requeueAutomation =
         },
         actionMetadata: { type: "requeue_automation" },
       });
-    },
+    }
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/requeueAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/requeueAutomation.ts
@@ -1,0 +1,122 @@
+import { createSolanaConnection, getCluster } from "@/lib/solana";
+import { ENTITY_CLAIM_CRON_NAME } from "@/lib/utils/automation-helpers";
+import * as anchor from "@coral-xyz/anchor";
+import {
+  cronJobKey,
+  cronJobNameMappingKey,
+  init as initCron,
+} from "@helium/cron-sdk";
+import {
+  entityCronAuthorityKey,
+  init as initHplCrons,
+} from "@helium/hpl-crons-sdk";
+import {
+  HELIUM_COMMON_LUT,
+  HELIUM_COMMON_LUT_DEVNET,
+  batchInstructionsToTxsWithPriorityFee,
+  toVersionedTx,
+} from "@helium/spl-utils";
+import {
+  init as initTuktuk,
+  nextAvailableTaskIds,
+  taskKey,
+} from "@helium/tuktuk-sdk";
+import { PublicKey } from "@solana/web3.js";
+import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
+import { publicProcedure } from "../../../procedures";
+import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
+
+/**
+ * Create a transaction to requeue an automation that was removed from the task
+ * queue after running out of SOL. Fund it first (fundAutomation) so it stays
+ * queued.
+ */
+export const requeueAutomation =
+  publicProcedure.hotspots.requeueAutomation.handler(
+    async ({ input, errors }) => {
+      const { walletAddress } = input;
+
+      const wallet = new PublicKey(walletAddress);
+      const { provider } = createSolanaConnection(walletAddress);
+      anchor.setProvider(provider);
+
+      const hplCronsProgram = await initHplCrons(provider);
+      const cronProgram = await initCron(provider);
+      const tuktukProgram = await initTuktuk(provider);
+
+      const authority = entityCronAuthorityKey(wallet)[0];
+      const cronJob = cronJobKey(authority, 0)[0];
+
+      const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
+        cronJob
+      );
+      if (!cronJobAccount) {
+        throw errors.NOT_FOUND({ message: "Automation not found" });
+      }
+
+      const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
+        TASK_QUEUE_ID
+      );
+      const [taskId] = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 1, false);
+      const [task] = taskKey(TASK_QUEUE_ID, taskId);
+
+      const instructions = [
+        await hplCronsProgram.methods
+          .requeueEntityClaimCronV0()
+          .accounts({
+            taskQueue: TASK_QUEUE_ID,
+            cronJob,
+            task,
+            cronJobNameMapping: cronJobNameMappingKey(
+              authority,
+              ENTITY_CLAIM_CRON_NAME
+            )[0],
+          })
+          .instruction(),
+      ];
+
+      const vtxs = (
+        await batchInstructionsToTxsWithPriorityFee(provider, instructions, {
+          addressLookupTableAddresses: [
+            process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
+              ? HELIUM_COMMON_LUT_DEVNET
+              : HELIUM_COMMON_LUT,
+          ],
+          computeUnitLimit: 500000,
+          commitment: "finalized",
+        })
+      ).map((tx) => toVersionedTx(tx));
+
+      if (shouldUseJitoBundle(vtxs.length, getCluster())) {
+        vtxs.push(await getJitoTipTransaction(wallet));
+      }
+
+      const txs = vtxs.map((tx) =>
+        Buffer.from(tx.serialize()).toString("base64")
+      );
+      const txFees = getTotalTransactionFees(vtxs);
+
+      return {
+        transactionData: {
+          transactions: txs.map((serialized) => ({
+            serializedTransaction: serialized,
+            metadata: {
+              type: "requeue_automation",
+              description: "Requeue hotspot claim automation",
+            },
+          })),
+          parallel: false,
+          tag: `requeue_automation:${walletAddress}`,
+          actionMetadata: { type: "requeue_automation" },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(txFees),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+  );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/requeueAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/requeueAutomation.ts
@@ -1,34 +1,16 @@
-import { createSolanaConnection, getCluster } from "@/lib/solana";
 import { ENTITY_CLAIM_CRON_NAME } from "@/lib/utils/automation-helpers";
-import * as anchor from "@coral-xyz/anchor";
-import {
-  cronJobKey,
-  cronJobNameMappingKey,
-  init as initCron,
-} from "@helium/cron-sdk";
-import {
-  entityCronAuthorityKey,
-  init as initHplCrons,
-} from "@helium/hpl-crons-sdk";
-import {
-  HELIUM_COMMON_LUT,
-  HELIUM_COMMON_LUT_DEVNET,
-  batchInstructionsToTxsWithPriorityFee,
-  toVersionedTx,
-} from "@helium/spl-utils";
+import { cronJobNameMappingKey } from "@helium/cron-sdk";
 import {
   init as initTuktuk,
   nextAvailableTaskIds,
   taskKey,
 } from "@helium/tuktuk-sdk";
-import { PublicKey } from "@solana/web3.js";
-import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
 import { publicProcedure } from "../../../procedures";
-import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
-import { toTokenAmountOutput } from "@/lib/utils/token-math";
-import { NATIVE_MINT } from "@solana/spl-token";
-import BN from "bn.js";
 import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
+import {
+  buildAutomationTransactionResponse,
+  resolveEntityClaimCronJob,
+} from "./automation-transaction";
 
 /**
  * Create a transaction to requeue an automation that was removed from the task
@@ -40,27 +22,16 @@ export const requeueAutomation =
     async ({ input, errors }) => {
       const { walletAddress } = input;
 
-      const wallet = new PublicKey(walletAddress);
-      const { provider } = createSolanaConnection(walletAddress);
-      anchor.setProvider(provider);
+      const { provider, hplCronsProgram, cronJob, authority, wallet } =
+        await resolveEntityClaimCronJob({
+          walletAddress,
+          notFoundMessage: "Automation not found",
+          errors,
+        });
 
-      const hplCronsProgram = await initHplCrons(provider);
-      const cronProgram = await initCron(provider);
       const tuktukProgram = await initTuktuk(provider);
-
-      const authority = entityCronAuthorityKey(wallet)[0];
-      const cronJob = cronJobKey(authority, 0)[0];
-
-      const cronJobAccount = await cronProgram.account.cronJobV0.fetchNullable(
-        cronJob
-      );
-      if (!cronJobAccount) {
-        throw errors.NOT_FOUND({ message: "Automation not found" });
-      }
-
-      const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
-        TASK_QUEUE_ID
-      );
+      const taskQueueAcc =
+        await tuktukProgram.account.taskQueueV0.fetch(TASK_QUEUE_ID);
       const [taskId] = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 1, false);
       const [task] = taskKey(TASK_QUEUE_ID, taskId);
 
@@ -73,50 +44,22 @@ export const requeueAutomation =
             task,
             cronJobNameMapping: cronJobNameMappingKey(
               authority,
-              ENTITY_CLAIM_CRON_NAME
+              ENTITY_CLAIM_CRON_NAME,
             )[0],
           })
           .instruction(),
       ];
 
-      const vtxs = (
-        await batchInstructionsToTxsWithPriorityFee(provider, instructions, {
-          addressLookupTableAddresses: [
-            process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
-              ? HELIUM_COMMON_LUT_DEVNET
-              : HELIUM_COMMON_LUT,
-          ],
-          computeUnitLimit: 500000,
-          commitment: "finalized",
-        })
-      ).map((tx) => toVersionedTx(tx));
-
-      if (shouldUseJitoBundle(vtxs.length, getCluster())) {
-        vtxs.push(await getJitoTipTransaction(wallet));
-      }
-
-      const txs = vtxs.map((tx) =>
-        Buffer.from(tx.serialize()).toString("base64")
-      );
-      const txFees = getTotalTransactionFees(vtxs);
-
-      return {
-        transactionData: {
-          transactions: txs.map((serialized) => ({
-            serializedTransaction: serialized,
-            metadata: {
-              type: "requeue_automation",
-              description: "Requeue hotspot claim automation",
-            },
-          })),
-          parallel: false,
-          tag: `requeue_automation:${walletAddress}`,
-          actionMetadata: { type: "requeue_automation" },
+      return buildAutomationTransactionResponse({
+        provider,
+        instructions,
+        feePayer: wallet,
+        tag: `requeue_automation:${walletAddress}`,
+        transactionMetadata: {
+          type: "requeue_automation",
+          description: "Requeue hotspot claim automation",
         },
-        estimatedSolFee: await toTokenAmountOutput(
-          new BN(txFees),
-          NATIVE_MINT.toBase58()
-        ),
-      };
-    }
+        actionMetadata: { type: "requeue_automation" },
+      });
+    },
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/topUpAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/topUpAutomation.ts
@@ -1,26 +1,16 @@
-import { createSolanaConnection, getCluster } from "@/lib/solana";
+import { createSolanaConnection } from "@/lib/solana";
 import * as anchor from "@coral-xyz/anchor";
 import { cronJobKey } from "@helium/cron-sdk";
 import { entityCronAuthorityKey } from "@helium/hpl-crons-sdk";
-import {
-  HELIUM_COMMON_LUT,
-  HELIUM_COMMON_LUT_DEVNET,
-  batchInstructionsToTxsWithPriorityFee,
-  toVersionedTx,
-} from "@helium/spl-utils";
 import { customSignerKey } from "@helium/tuktuk-sdk";
 import {
   PublicKey,
   SystemProgram,
   TransactionInstruction,
 } from "@solana/web3.js";
-import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
 import { publicProcedure } from "../../../procedures";
-import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
-import { toTokenAmountOutput } from "@/lib/utils/token-math";
-import { NATIVE_MINT } from "@solana/spl-token";
-import BN from "bn.js";
 import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
+import { buildAutomationTransactionResponse } from "./automation-transaction";
 
 /**
  * Operator floor top-up. For each target the operator funds the two pools that
@@ -64,7 +54,7 @@ export const topUpAutomation = publicProcedure.hotspots.topUpAutomation.handler(
               fromPubkey: operator,
               toPubkey: pool,
               lamports: fundLamports,
-            })
+            }),
           );
           funded++;
         }
@@ -86,45 +76,18 @@ export const topUpAutomation = publicProcedure.hotspots.topUpAutomation.handler(
       });
     }
 
-    const vtxs = (
-      await batchInstructionsToTxsWithPriorityFee(provider, instructions, {
-        addressLookupTableAddresses: [
-          process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
-            ? HELIUM_COMMON_LUT_DEVNET
-            : HELIUM_COMMON_LUT,
-        ],
-        computeUnitLimit: 500000,
-        commitment: "finalized",
-      })
-    ).map((tx) => toVersionedTx(tx));
-
-    if (shouldUseJitoBundle(vtxs.length, getCluster())) {
-      vtxs.push(await getJitoTipTransaction(operator));
-    }
-
-    const txs = vtxs.map((tx) =>
-      Buffer.from(tx.serialize()).toString("base64")
-    );
-    const txFees = getTotalTransactionFees(vtxs);
-
-    return {
-      transactionData: {
-        transactions: txs.map((serialized) => ({
-          serializedTransaction: serialized,
-          metadata: {
-            type: "top_up_automation",
-            description: "Operator floor top-up of automation funding",
-            poolsFunded: funded,
-          },
-        })),
-        parallel: false,
-        tag: `top_up_automation:${operatorAddress}`,
-        actionMetadata: { type: "top_up_automation", poolsFunded: funded },
+    return buildAutomationTransactionResponse({
+      provider,
+      instructions,
+      feePayer: operator,
+      tag: `top_up_automation:${operatorAddress}`,
+      transactionMetadata: {
+        type: "top_up_automation",
+        description: "Operator floor top-up of automation funding",
+        poolsFunded: funded,
       },
-      estimatedSolFee: await toTokenAmountOutput(
-        new BN(txFees + totalFundingNeeded),
-        NATIVE_MINT.toBase58()
-      ),
-    };
-  }
+      actionMetadata: { type: "top_up_automation", poolsFunded: funded },
+      extraFeeLamports: totalFundingNeeded,
+    });
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/topUpAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/topUpAutomation.ts
@@ -1,0 +1,130 @@
+import { createSolanaConnection, getCluster } from "@/lib/solana";
+import * as anchor from "@coral-xyz/anchor";
+import { cronJobKey } from "@helium/cron-sdk";
+import { entityCronAuthorityKey } from "@helium/hpl-crons-sdk";
+import {
+  HELIUM_COMMON_LUT,
+  HELIUM_COMMON_LUT_DEVNET,
+  batchInstructionsToTxsWithPriorityFee,
+  toVersionedTx,
+} from "@helium/spl-utils";
+import { customSignerKey } from "@helium/tuktuk-sdk";
+import {
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { getJitoTipTransaction, shouldUseJitoBundle } from "@/lib/utils/jito";
+import { publicProcedure } from "../../../procedures";
+import { getTotalTransactionFees } from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { NATIVE_MINT } from "@solana/spl-token";
+import BN from "bn.js";
+import { TASK_QUEUE_ID } from "@/lib/constants/tuktuk";
+
+/**
+ * Operator floor top-up. For each target the operator funds the two pools that
+ * keep claim automation running — the cron-job pool (crank rewards) and the
+ * claim-payer pool (claim costs) — with `fundLamports` whenever that pool's
+ * balance is at or below `floorLamports`. The operator is the fee payer and
+ * funding source; nothing is deducted from the target wallets.
+ */
+export const topUpAutomation = publicProcedure.hotspots.topUpAutomation.handler(
+  async ({ input, errors }) => {
+    const { operatorAddress, targets, floorLamports, fundLamports } = input;
+
+    const operator = new PublicKey(operatorAddress);
+    const { provider } = createSolanaConnection(operatorAddress);
+    anchor.setProvider(provider);
+
+    const instructions: TransactionInstruction[] = [];
+    let funded = 0;
+
+    for (const targetWallet of targets) {
+      const wallet = new PublicKey(targetWallet);
+      const authority = entityCronAuthorityKey(wallet)[0];
+      const cronJob = cronJobKey(authority, 0)[0];
+      const pdaWallet = customSignerKey(TASK_QUEUE_ID, [
+        Buffer.from("claim_payer"),
+        wallet.toBuffer(),
+      ])[0];
+
+      const [cronJobBalance, pdaWalletBalance] = await Promise.all([
+        provider.connection.getBalance(cronJob),
+        provider.connection.getBalance(pdaWallet),
+      ]);
+
+      for (const [pool, balance] of [
+        [cronJob, cronJobBalance] as const,
+        [pdaWallet, pdaWalletBalance] as const,
+      ]) {
+        if (balance <= floorLamports) {
+          instructions.push(
+            SystemProgram.transfer({
+              fromPubkey: operator,
+              toPubkey: pool,
+              lamports: fundLamports,
+            })
+          );
+          funded++;
+        }
+      }
+    }
+
+    if (instructions.length === 0) {
+      throw errors.NOT_FOUND({
+        message: "No target pools are at or below the funding floor",
+      });
+    }
+
+    const totalFundingNeeded = funded * fundLamports;
+    const operatorBalance = await provider.connection.getBalance(operator);
+    if (operatorBalance < totalFundingNeeded) {
+      throw errors.INSUFFICIENT_FUNDS({
+        message: "Operator has insufficient SOL to fund the requested top-ups",
+        data: { required: totalFundingNeeded, available: operatorBalance },
+      });
+    }
+
+    const vtxs = (
+      await batchInstructionsToTxsWithPriorityFee(provider, instructions, {
+        addressLookupTableAddresses: [
+          process.env.NEXT_PUBLIC_SOLANA_CLUSTER?.trim() === "devnet"
+            ? HELIUM_COMMON_LUT_DEVNET
+            : HELIUM_COMMON_LUT,
+        ],
+        computeUnitLimit: 500000,
+        commitment: "finalized",
+      })
+    ).map((tx) => toVersionedTx(tx));
+
+    if (shouldUseJitoBundle(vtxs.length, getCluster())) {
+      vtxs.push(await getJitoTipTransaction(operator));
+    }
+
+    const txs = vtxs.map((tx) =>
+      Buffer.from(tx.serialize()).toString("base64")
+    );
+    const txFees = getTotalTransactionFees(vtxs);
+
+    return {
+      transactionData: {
+        transactions: txs.map((serialized) => ({
+          serializedTransaction: serialized,
+          metadata: {
+            type: "top_up_automation",
+            description: "Operator floor top-up of automation funding",
+            poolsFunded: funded,
+          },
+        })),
+        parallel: false,
+        tag: `top_up_automation:${operatorAddress}`,
+        actionMetadata: { type: "top_up_automation", poolsFunded: funded },
+      },
+      estimatedSolFee: await toTokenAmountOutput(
+        new BN(txFees + totalFundingNeeded),
+        NATIVE_MINT.toBase58()
+      ),
+    };
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/topUpAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/topUpAutomation.ts
@@ -27,39 +27,39 @@ export const topUpAutomation = publicProcedure.hotspots.topUpAutomation.handler(
     const { provider } = createSolanaConnection(operatorAddress);
     anchor.setProvider(provider);
 
-    const instructions: TransactionInstruction[] = [];
-    let funded = 0;
+    // Check every target's pools in parallel; flatten back in target order so
+    // the produced instructions stay deterministic.
+    const perTargetInstructions = await Promise.all(
+      targets.map(async (targetWallet) => {
+        const wallet = new PublicKey(targetWallet);
+        const authority = entityCronAuthorityKey(wallet)[0];
+        const cronJob = cronJobKey(authority, 0)[0];
+        const pdaWallet = customSignerKey(TASK_QUEUE_ID, [
+          Buffer.from("claim_payer"),
+          wallet.toBuffer(),
+        ])[0];
 
-    for (const targetWallet of targets) {
-      const wallet = new PublicKey(targetWallet);
-      const authority = entityCronAuthorityKey(wallet)[0];
-      const cronJob = cronJobKey(authority, 0)[0];
-      const pdaWallet = customSignerKey(TASK_QUEUE_ID, [
-        Buffer.from("claim_payer"),
-        wallet.toBuffer(),
-      ])[0];
+        const [cronJobBalance, pdaWalletBalance] = await Promise.all([
+          provider.connection.getBalance(cronJob),
+          provider.connection.getBalance(pdaWallet),
+        ]);
 
-      const [cronJobBalance, pdaWalletBalance] = await Promise.all([
-        provider.connection.getBalance(cronJob),
-        provider.connection.getBalance(pdaWallet),
-      ]);
-
-      for (const [pool, balance] of [
-        [cronJob, cronJobBalance] as const,
-        [pdaWallet, pdaWalletBalance] as const,
-      ]) {
-        if (balance <= floorLamports) {
-          instructions.push(
+        return [
+          [cronJob, cronJobBalance] as const,
+          [pdaWallet, pdaWalletBalance] as const,
+        ]
+          .filter(([, balance]) => balance <= floorLamports)
+          .map(([pool]) =>
             SystemProgram.transfer({
               fromPubkey: operator,
               toPubkey: pool,
               lamports: fundLamports,
-            }),
+            })
           );
-          funded++;
-        }
-      }
-    }
+      })
+    );
+
+    const instructions: TransactionInstruction[] = perTargetInstructions.flat();
 
     if (instructions.length === 0) {
       throw errors.NOT_FOUND({
@@ -67,7 +67,8 @@ export const topUpAutomation = publicProcedure.hotspots.topUpAutomation.handler(
       });
     }
 
-    const totalFundingNeeded = funded * fundLamports;
+    const poolsFunded = instructions.length;
+    const totalFundingNeeded = poolsFunded * fundLamports;
     const operatorBalance = await provider.connection.getBalance(operator);
     if (operatorBalance < totalFundingNeeded) {
       throw errors.INSUFFICIENT_FUNDS({
@@ -84,10 +85,10 @@ export const topUpAutomation = publicProcedure.hotspots.topUpAutomation.handler(
       transactionMetadata: {
         type: "top_up_automation",
         description: "Operator floor top-up of automation funding",
-        poolsFunded: funded,
+        poolsFunded,
       },
-      actionMetadata: { type: "top_up_automation", poolsFunded: funded },
+      actionMetadata: { type: "top_up_automation", poolsFunded },
       extraFeeLamports: totalFundingNeeded,
     });
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
@@ -1,7 +1,5 @@
 import { publicProcedure } from "../../../procedures";
-import { Connection, PublicKey } from "@solana/web3.js";
-import { env } from "@/lib/env";
-import { hasRewardContract } from "@/lib/queries/hotspots";
+import { PublicKey } from "@solana/web3.js";
 import {
   generateTransactionTag,
   TRANSACTION_TYPES,
@@ -18,22 +16,16 @@ import {
   buildVersionedTransaction,
   serializeTransaction,
 } from "@/lib/utils/build-transaction";
-import { proofArgsAndAccounts } from "@helium/spl-utils";
 import { createTransferInstruction } from "@metaplex-foundation/mpl-bubblegum";
 import {
   SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
   SPL_NOOP_PROGRAM_ID,
 } from "@solana/spl-account-compression";
 import {
-  getAssetIdFromPubkey,
-  getBubblegumAuthorityPDA,
-  validateHeliumHotspot,
-} from "@/lib/utils/hotspot-helpers";
-import {
   buildActionProposal,
   proposalTransactionData,
-  vaultPda,
 } from "../../squads/procedures/helpers";
+import { resolveOwnedHotspotCnft } from "./hotspot-cnft";
 
 /**
  * Create a transaction to transfer a hotspot to a new owner.
@@ -42,83 +34,33 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
   async ({ input, errors }) => {
     const { walletAddress, hotspotPubkey, recipient } = input;
 
-    // Resolve hotspot pubkey to asset ID
-    const assetId = await getAssetIdFromPubkey(hotspotPubkey);
-    if (!assetId) {
-      throw errors.NOT_FOUND({ message: "Hotspot not found" });
-    }
+    const {
+      connection,
+      payerPubkey,
+      multisigPda,
+      assetId,
+      args,
+      remainingAccounts,
+      merkleTree,
+      treeAuthority,
+      leafOwner,
+      leafDelegate,
+      hotspotName,
+    } = await resolveOwnedHotspotCnft({
+      walletAddress,
+      hotspotPubkey,
+      multisig: input.multisig,
+      conflictMessage:
+        "Cannot transfer hotspot with active reward contract. Delete the contract first.",
+      errors,
+    });
 
-    // Validate public keys
-    let payerPubkey: PublicKey;
     let recipientPubkey: PublicKey;
-
     try {
-      payerPubkey = new PublicKey(walletAddress);
       recipientPubkey = new PublicKey(recipient);
     } catch {
       throw errors.BAD_REQUEST({ message: "Invalid public key format" });
     }
-
-    const connection = new Connection(env.SOLANA_RPC_URL);
-    const assetEndpoint = env.ASSET_ENDPOINT || connection.rpcEndpoint;
-    const assetPubkey = new PublicKey(assetId);
-
-    const { asset, args, accounts, remainingAccounts } =
-      await proofArgsAndAccounts({
-        connection,
-        assetId: assetPubkey,
-        assetEndpoint,
-      });
-
-    if (!asset) {
-      throw errors.NOT_FOUND({ message: "Asset not found" });
-    }
-
-    // Validate asset is a Helium hotspot
-    if (!validateHeliumHotspot(asset)) {
-      throw errors.BAD_REQUEST({
-        message: "Asset is not a valid Helium hotspot",
-      });
-    }
-
-    // Validate ownership
-    const ownerAddress =
-      typeof asset.ownership.owner === "string"
-        ? asset.ownership.owner
-        : asset.ownership.owner.toBase58();
-
-    // In Squads propose mode the on-chain owner must be the multisig's vault
-    // (walletAddress is only the proposing member); otherwise the wallet itself.
-    const multisigPda = input.multisig
-      ? new PublicKey(input.multisig)
-      : undefined;
-    const expectedOwner = multisigPda ? vaultPda(multisigPda) : payerPubkey;
-    if (ownerAddress !== expectedOwner.toBase58()) {
-      throw errors.UNAUTHORIZED({
-        message: multisigPda
-          ? "Multisig vault is not the owner of this hotspot"
-          : "Wallet is not the owner of this hotspot",
-      });
-    }
-
-    // Check if a contract exists for this hotspot
-    const contractExists = await hasRewardContract(hotspotPubkey);
-    if (contractExists) {
-      throw errors.CONFLICT({
-        message:
-          "Cannot transfer hotspot with active reward contract. Delete the contract first.",
-      });
-    }
-
-    const leafOwner = new PublicKey(ownerAddress);
-    const leafDelegate = asset.ownership.delegate
-      ? typeof asset.ownership.delegate === "string"
-        ? new PublicKey(asset.ownership.delegate)
-        : asset.ownership.delegate
-      : leafOwner;
-
-    const merkleTree = accounts.merkleTree;
-    const treeAuthority = await getBubblegumAuthorityPDA(merkleTree);
 
     const transferInstruction = createTransferInstruction(
       {
@@ -134,10 +76,9 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
       {
         ...args,
         nonce: args.index,
-      },
+      }
     );
 
-    const hotspotName = asset.content?.metadata?.name || "Hotspot";
     const shortRecipient = `${recipient.slice(0, 4)}...${recipient.slice(-4)}`;
 
     // ---- Squads propose mode ----
@@ -154,16 +95,8 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
           member: payerPubkey,
           memo: input.memo,
           buildInstructions: () => [transferInstruction],
-          insufficientFunds: ({ required, available }) =>
-            errors.INSUFFICIENT_FUNDS({
-              message:
-                "Insufficient SOL balance to create the transfer proposal",
-              data: { required, available },
-            }),
-          notFound: () =>
-            errors.NOT_FOUND({
-              message: `Multisig ${input.multisig} not found`,
-            }),
+          errors,
+          action: "transfer",
         });
 
       return {
@@ -181,11 +114,10 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
           multisig: multisigPda.toBase58(),
           transactionIndex,
           metadata: { hotspotKey: assetId, hotspotName, recipient },
-          actionMetadata: { hotspotKey: assetId, hotspotName, recipient },
         }),
         estimatedSolFee: await toTokenAmountOutput(
           new BN(feeLamports),
-          NATIVE_MINT.toBase58(),
+          NATIVE_MINT.toBase58()
         ),
       };
     }
@@ -244,8 +176,8 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(txFee),
-        NATIVE_MINT.toBase58(),
+        NATIVE_MINT.toBase58()
       ),
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
@@ -34,6 +34,13 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
   async ({ input, errors }) => {
     const { walletAddress, hotspotPubkey, recipient } = input;
 
+    let recipientPubkey: PublicKey;
+    try {
+      recipientPubkey = new PublicKey(recipient);
+    } catch {
+      throw errors.BAD_REQUEST({ message: "Invalid public key format" });
+    }
+
     const {
       connection,
       payerPubkey,
@@ -54,13 +61,6 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
         "Cannot transfer hotspot with active reward contract. Delete the contract first.",
       errors,
     });
-
-    let recipientPubkey: PublicKey;
-    try {
-      recipientPubkey = new PublicKey(recipient);
-    } catch {
-      throw errors.BAD_REQUEST({ message: "Invalid public key format" });
-    }
 
     const transferInstruction = createTransferInstruction(
       {

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
@@ -29,7 +29,11 @@ import {
   getBubblegumAuthorityPDA,
   validateHeliumHotspot,
 } from "@/lib/utils/hotspot-helpers";
-import { buildActionProposal, vaultPda } from "../../squads/procedures/helpers";
+import {
+  buildActionProposal,
+  proposalTransactionData,
+  vaultPda,
+} from "../../squads/procedures/helpers";
 
 /**
  * Create a transaction to transfer a hotspot to a new owner.
@@ -130,7 +134,7 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
       {
         ...args,
         nonce: args.index,
-      }
+      },
     );
 
     const hotspotName = asset.content?.metadata?.name || "Hotspot";
@@ -163,20 +167,10 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
         });
 
       return {
-        transactionData: {
-          transactions: [
-            {
-              serializedTransaction,
-              metadata: {
-                type: "hotspot_transfer_proposal",
-                description: `Propose transfer of ${hotspotName} to ${shortRecipient}`,
-                hotspotKey: assetId,
-                hotspotName,
-                recipient,
-              },
-            },
-          ],
-          parallel: false,
+        transactionData: proposalTransactionData({
+          serializedTransaction,
+          type: TRANSACTION_TYPES.HOTSPOT_TRANSFER_PROPOSAL,
+          description: `Propose transfer of ${hotspotName} to ${shortRecipient}`,
           tag: generateTransactionTag({
             type: TRANSACTION_TYPES.HOTSPOT_TRANSFER,
             walletAddress,
@@ -184,18 +178,14 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
             recipient,
             multisig: input.multisig,
           }),
-          actionMetadata: {
-            type: "hotspot_transfer_proposal",
-            multisig: input.multisig,
-            transactionIndex,
-            hotspotKey: assetId,
-            hotspotName,
-            recipient,
-          },
-        },
+          multisig: multisigPda.toBase58(),
+          transactionIndex,
+          metadata: { hotspotKey: assetId, hotspotName, recipient },
+          actionMetadata: { hotspotKey: assetId, hotspotName, recipient },
+        }),
         estimatedSolFee: await toTokenAmountOutput(
           new BN(feeLamports),
-          NATIVE_MINT.toBase58()
+          NATIVE_MINT.toBase58(),
         ),
       };
     }
@@ -254,8 +244,8 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(txFee),
-        NATIVE_MINT.toBase58()
+        NATIVE_MINT.toBase58(),
       ),
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
@@ -30,15 +30,16 @@ import {
 import { entityCreatorKey } from "@helium/helium-entity-manager-sdk";
 import { daoKey } from "@helium/helium-sub-daos-sdk";
 import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
+import { buildActionProposal, vaultPda } from "../../squads/procedures/helpers";
 
 const DAO_KEY = daoKey(HNT_MINT)[0];
 
 async function getBubblegumAuthorityPDA(
-  merkleRollPubKey: PublicKey,
+  merkleRollPubKey: PublicKey
 ): Promise<PublicKey> {
   const [bubblegumAuthorityPDAKey] = await PublicKey.findProgramAddress(
     [merkleRollPubKey.toBuffer()],
-    BUBBLEGUM_PROGRAM_ID,
+    BUBBLEGUM_PROGRAM_ID
   );
   return bubblegumAuthorityPDAKey;
 }
@@ -109,19 +110,17 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
         ? asset.ownership.owner
         : asset.ownership.owner.toBase58();
 
-    if (ownerAddress !== walletAddress) {
+    // In Squads propose mode the on-chain owner must be the multisig's vault
+    // (walletAddress is only the proposing member); otherwise the wallet itself.
+    const multisigPda = input.multisig
+      ? new PublicKey(input.multisig)
+      : undefined;
+    const expectedOwner = multisigPda ? vaultPda(multisigPda) : payerPubkey;
+    if (ownerAddress !== expectedOwner.toBase58()) {
       throw errors.UNAUTHORIZED({
-        message: "Wallet is not the owner of this hotspot",
-      });
-    }
-
-    // Check wallet has sufficient balance for transaction fees
-    const walletBalance = await connection.getBalance(payerPubkey);
-    const required = calculateRequiredBalance(BASE_TX_FEE_LAMPORTS, 0);
-    if (walletBalance < required) {
-      throw errors.INSUFFICIENT_FUNDS({
-        message: "Insufficient SOL balance for transaction fees",
-        data: { required, available: walletBalance },
+        message: multisigPda
+          ? "Multisig vault is not the owner of this hotspot"
+          : "Wallet is not the owner of this hotspot",
       });
     }
 
@@ -134,11 +133,7 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
       });
     }
 
-    const leafOwner =
-      typeof asset.ownership.owner === "string"
-        ? new PublicKey(asset.ownership.owner)
-        : asset.ownership.owner;
-
+    const leafOwner = new PublicKey(ownerAddress);
     const leafDelegate = asset.ownership.delegate
       ? typeof asset.ownership.delegate === "string"
         ? new PublicKey(asset.ownership.delegate)
@@ -162,8 +157,85 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
       {
         ...args,
         nonce: args.index,
-      },
+      }
     );
+
+    const hotspotName = asset.content?.metadata?.name || "Hotspot";
+    const shortRecipient = `${recipient.slice(0, 4)}...${recipient.slice(-4)}`;
+
+    // ---- Squads propose mode ----
+    // UNVERIFIED: this path cannot be exercised on a mainnet fork. The proof and
+    // ownership come from the real DAS index, so the vault must actually own the
+    // hotspot on-chain — a fork-created vault never does, and surfpool can't set
+    // cNFT ownership. Verify against a live multisig vault that owns a test
+    // hotspot before relying on this in production.
+    if (multisigPda) {
+      const { serializedTransaction, transactionIndex, feeLamports } =
+        await buildActionProposal({
+          connection,
+          multisigPda,
+          member: payerPubkey,
+          memo: input.memo,
+          buildInstructions: () => [transferInstruction],
+          insufficientFunds: ({ required, available }) =>
+            errors.INSUFFICIENT_FUNDS({
+              message:
+                "Insufficient SOL balance to create the transfer proposal",
+              data: { required, available },
+            }),
+          notFound: () =>
+            errors.NOT_FOUND({
+              message: `Multisig ${input.multisig} not found`,
+            }),
+        });
+
+      return {
+        transactionData: {
+          transactions: [
+            {
+              serializedTransaction,
+              metadata: {
+                type: "hotspot_transfer_proposal",
+                description: `Propose transfer of ${hotspotName} to ${shortRecipient}`,
+                hotspotKey: assetId,
+                hotspotName,
+                recipient,
+              },
+            },
+          ],
+          parallel: false,
+          tag: generateTransactionTag({
+            type: TRANSACTION_TYPES.HOTSPOT_TRANSFER,
+            walletAddress,
+            assetId,
+            recipient,
+            multisig: input.multisig,
+          }),
+          actionMetadata: {
+            type: "hotspot_transfer_proposal",
+            multisig: input.multisig,
+            transactionIndex,
+            hotspotKey: assetId,
+            hotspotName,
+            recipient,
+          },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(feeLamports),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+
+    // ---- Direct transfer from the wallet ----
+    const walletBalance = await connection.getBalance(payerPubkey);
+    const required = calculateRequiredBalance(BASE_TX_FEE_LAMPORTS, 0);
+    if (walletBalance < required) {
+      throw errors.INSUFFICIENT_FUNDS({
+        message: "Insufficient SOL balance for transaction fees",
+        data: { required, available: walletBalance },
+      });
+    }
 
     const tx = await buildVersionedTransaction({
       connection,
@@ -182,7 +254,6 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
       timestamp: Date.now(),
     });
 
-    const hotspotName = asset.content?.metadata?.name || "Hotspot";
     const txFee = getTransactionFee(tx);
 
     return {
@@ -192,10 +263,7 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
             serializedTransaction,
             metadata: {
               type: TRANSACTION_TYPES.HOTSPOT_TRANSFER,
-              description: `Transfer ${hotspotName} to ${recipient.slice(
-                0,
-                4,
-              )}...${recipient.slice(-4)}`,
+              description: `Transfer ${hotspotName} to ${shortRecipient}`,
               hotspotKey: assetId,
               hotspotName,
               recipient,
@@ -204,12 +272,17 @@ export const transferHotspot = publicProcedure.hotspots.transferHotspot.handler(
         ],
         parallel: false,
         tag,
-        actionMetadata: { type: TRANSACTION_TYPES.HOTSPOT_TRANSFER, hotspotKey: assetId, hotspotName, recipient },
+        actionMetadata: {
+          type: TRANSACTION_TYPES.HOTSPOT_TRANSFER,
+          hotspotKey: assetId,
+          hotspotName,
+          recipient,
+        },
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(txFee),
-        NATIVE_MINT.toBase58(),
+        NATIVE_MINT.toBase58()
       ),
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/transferHotspot.ts
@@ -18,45 +18,18 @@ import {
   buildVersionedTransaction,
   serializeTransaction,
 } from "@/lib/utils/build-transaction";
-import { proofArgsAndAccounts, type Asset, HNT_MINT } from "@helium/spl-utils";
-import {
-  PROGRAM_ID as BUBBLEGUM_PROGRAM_ID,
-  createTransferInstruction,
-} from "@metaplex-foundation/mpl-bubblegum";
+import { proofArgsAndAccounts } from "@helium/spl-utils";
+import { createTransferInstruction } from "@metaplex-foundation/mpl-bubblegum";
 import {
   SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
   SPL_NOOP_PROGRAM_ID,
 } from "@solana/spl-account-compression";
-import { entityCreatorKey } from "@helium/helium-entity-manager-sdk";
-import { daoKey } from "@helium/helium-sub-daos-sdk";
-import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
+import {
+  getAssetIdFromPubkey,
+  getBubblegumAuthorityPDA,
+  validateHeliumHotspot,
+} from "@/lib/utils/hotspot-helpers";
 import { buildActionProposal, vaultPda } from "../../squads/procedures/helpers";
-
-const DAO_KEY = daoKey(HNT_MINT)[0];
-
-async function getBubblegumAuthorityPDA(
-  merkleRollPubKey: PublicKey
-): Promise<PublicKey> {
-  const [bubblegumAuthorityPDAKey] = await PublicKey.findProgramAddress(
-    [merkleRollPubKey.toBuffer()],
-    BUBBLEGUM_PROGRAM_ID
-  );
-  return bubblegumAuthorityPDAKey;
-}
-
-function validateHeliumHotspot(asset: Asset): boolean {
-  const heliumEntityCreator = entityCreatorKey(DAO_KEY)[0].toBase58();
-
-  return (
-    asset.creators?.some((creator) => {
-      const address =
-        typeof creator.address === "string"
-          ? creator.address
-          : creator.address.toBase58();
-      return address === heliumEntityCreator && creator.verified;
-    }) || false
-  );
-}
 
 /**
  * Create a transaction to transfer a hotspot to a new owner.

--- a/packages/blockchain-api/src/server/api/routers/hotspots/router.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/router.ts
@@ -18,6 +18,8 @@ import { addWalletToAutomation } from "./procedures/addWalletToAutomation";
 import { addEntityToAutomation } from "./procedures/addEntityToAutomation";
 import { removeEntityFromAutomation } from "./procedures/removeEntityFromAutomation";
 import { topUpAutomation } from "./procedures/topUpAutomation";
+import { issueDataOnlyHotspot } from "./procedures/issueDataOnlyHotspot";
+import { onboardDataOnlyHotspot } from "./procedures/onboardDataOnlyHotspot";
 import { updateHotspotInfo } from "./procedures/updateHotspotInfo";
 import { hotspotsContract } from "@helium/blockchain-api/contracts";
 import { implement } from "@orpc/server";
@@ -66,6 +68,10 @@ export const hotspotsRouter = implement(hotspotsContract).router({
   removeEntityFromAutomation,
   /** Operator floor top-up for a batch of automations */
   topUpAutomation,
+  /** Issue a data-only hotspot (relays the onboarding server) */
+  issueDataOnlyHotspot,
+  /** Onboard a data-only hotspot (relays the onboarding server) */
+  onboardDataOnlyHotspot,
   /** Update hotspot info (location, gain, elevation, deployment info) */
   updateHotspotInfo,
 });

--- a/packages/blockchain-api/src/server/api/routers/hotspots/router.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/router.ts
@@ -1,5 +1,7 @@
 import { getHotspots } from "./procedures/getHotspots";
 import { claimRewards } from "./procedures/claimRewards";
+import { claimHotspotRewards } from "./procedures/claimHotspotRewards";
+import { burnHotspot } from "./procedures/burnHotspot";
 import { getPendingRewards } from "./procedures/getPendingRewards";
 import { transferHotspot } from "./procedures/transferHotspot";
 import { updateRewardsDestination } from "./procedures/updateRewardsDestination";
@@ -23,6 +25,10 @@ export const hotspotsRouter = implement(hotspotsContract).router({
   getHotspots,
   /** Create transactions to claim rewards for hotspots */
   claimRewards,
+  /** Create transactions to claim rewards for a single hotspot */
+  claimHotspotRewards,
+  /** Create a transaction to burn (destroy) a hotspot */
+  burnHotspot,
   /** Get pending rewards for all hotspots in a wallet */
   getPendingRewards,
   /** Create a transaction to transfer a hotspot to a new owner */

--- a/packages/blockchain-api/src/server/api/routers/hotspots/router.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/router.ts
@@ -13,6 +13,11 @@ import { createAutomation } from "./procedures/createAutomation";
 import { fundAutomation } from "./procedures/fundAutomation";
 import { closeAutomation } from "./procedures/closeAutomation";
 import { getFundingEstimate } from "./procedures/getFundingEstimate";
+import { requeueAutomation } from "./procedures/requeueAutomation";
+import { addWalletToAutomation } from "./procedures/addWalletToAutomation";
+import { addEntityToAutomation } from "./procedures/addEntityToAutomation";
+import { removeEntityFromAutomation } from "./procedures/removeEntityFromAutomation";
+import { topUpAutomation } from "./procedures/topUpAutomation";
 import { updateHotspotInfo } from "./procedures/updateHotspotInfo";
 import { hotspotsContract } from "@helium/blockchain-api/contracts";
 import { implement } from "@orpc/server";
@@ -51,6 +56,16 @@ export const hotspotsRouter = implement(hotspotsContract).router({
   getFundingEstimate,
   /** Create transactions to close and remove automation */
   closeAutomation,
+  /** Requeue an automation that ran out of SOL */
+  requeueAutomation,
+  /** Add a whole-wallet claim to an automation */
+  addWalletToAutomation,
+  /** Add a single hotspot claim to an automation */
+  addEntityToAutomation,
+  /** Remove a claim entry from an automation */
+  removeEntityFromAutomation,
+  /** Operator floor top-up for a batch of automations */
+  topUpAutomation,
   /** Update hotspot info (location, gain, elevation, deployment info) */
   updateHotspotInfo,
 });

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/approve.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/approve.ts
@@ -1,8 +1,7 @@
 import { publicProcedure } from "../../../procedures";
 import * as multisig from "@sqds/multisig";
 import { createSolanaConnection } from "@/lib/solana";
-import { TRANSACTION_TYPES } from "@/lib/utils/transaction-tags";
-import { buildProposalVote } from "./helpers";
+import { buildProposalVote, SQUADS_VOTE_ACTIONS } from "./helpers";
 
 export const approveProposal = publicProcedure.squads.approveProposal.handler(
   async ({ input, errors }) => {
@@ -11,14 +10,12 @@ export const approveProposal = publicProcedure.squads.approveProposal.handler(
       input,
       connection,
       buildIx: multisig.instructions.proposalApprove,
-      tagType: TRANSACTION_TYPES.SQUADS_PROPOSAL_APPROVE,
-      metaType: "squads_proposal_approve",
-      verb: "Approve",
+      action: SQUADS_VOTE_ACTIONS.approve,
       insufficientFunds: ({ required, available }) =>
         errors.INSUFFICIENT_FUNDS({
           message: "Insufficient SOL balance to approve the proposal",
           data: { required, available },
         }),
     });
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/approve.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/approve.ts
@@ -1,0 +1,24 @@
+import { publicProcedure } from "../../../procedures";
+import * as multisig from "@sqds/multisig";
+import { createSolanaConnection } from "@/lib/solana";
+import { TRANSACTION_TYPES } from "@/lib/utils/transaction-tags";
+import { buildProposalVote } from "./helpers";
+
+export const approveProposal = publicProcedure.squads.approveProposal.handler(
+  async ({ input, errors }) => {
+    const { connection } = createSolanaConnection(input.member);
+    return buildProposalVote({
+      input,
+      connection,
+      buildIx: multisig.instructions.proposalApprove,
+      tagType: TRANSACTION_TYPES.SQUADS_PROPOSAL_APPROVE,
+      metaType: "squads_proposal_approve",
+      verb: "Approve",
+      insufficientFunds: ({ required, available }) =>
+        errors.INSUFFICIENT_FUNDS({
+          message: "Insufficient SOL balance to approve the proposal",
+          data: { required, available },
+        }),
+    });
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/approve.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/approve.ts
@@ -1,5 +1,4 @@
 import { publicProcedure } from "../../../procedures";
-import * as multisig from "@sqds/multisig";
 import { createSolanaConnection } from "@/lib/solana";
 import { buildProposalVote, SQUADS_VOTE_ACTIONS } from "./helpers";
 
@@ -9,13 +8,8 @@ export const approveProposal = publicProcedure.squads.approveProposal.handler(
     return buildProposalVote({
       input,
       connection,
-      buildIx: multisig.instructions.proposalApprove,
       action: SQUADS_VOTE_ACTIONS.approve,
-      insufficientFunds: ({ required, available }) =>
-        errors.INSUFFICIENT_FUNDS({
-          message: "Insufficient SOL balance to approve the proposal",
-          data: { required, available },
-        }),
+      errors,
     });
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/cancel.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/cancel.ts
@@ -1,8 +1,7 @@
 import { publicProcedure } from "../../../procedures";
 import * as multisig from "@sqds/multisig";
 import { createSolanaConnection } from "@/lib/solana";
-import { TRANSACTION_TYPES } from "@/lib/utils/transaction-tags";
-import { buildProposalVote } from "./helpers";
+import { buildProposalVote, SQUADS_VOTE_ACTIONS } from "./helpers";
 
 export const cancelProposal = publicProcedure.squads.cancelProposal.handler(
   async ({ input, errors }) => {
@@ -11,14 +10,12 @@ export const cancelProposal = publicProcedure.squads.cancelProposal.handler(
       input,
       connection,
       buildIx: multisig.instructions.proposalCancel,
-      tagType: TRANSACTION_TYPES.SQUADS_PROPOSAL_CANCEL,
-      metaType: "squads_proposal_cancel",
-      verb: "Cancel",
+      action: SQUADS_VOTE_ACTIONS.cancel,
       insufficientFunds: ({ required, available }) =>
         errors.INSUFFICIENT_FUNDS({
           message: "Insufficient SOL balance to cancel the proposal",
           data: { required, available },
         }),
     });
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/cancel.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/cancel.ts
@@ -1,0 +1,24 @@
+import { publicProcedure } from "../../../procedures";
+import * as multisig from "@sqds/multisig";
+import { createSolanaConnection } from "@/lib/solana";
+import { TRANSACTION_TYPES } from "@/lib/utils/transaction-tags";
+import { buildProposalVote } from "./helpers";
+
+export const cancelProposal = publicProcedure.squads.cancelProposal.handler(
+  async ({ input, errors }) => {
+    const { connection } = createSolanaConnection(input.member);
+    return buildProposalVote({
+      input,
+      connection,
+      buildIx: multisig.instructions.proposalCancel,
+      tagType: TRANSACTION_TYPES.SQUADS_PROPOSAL_CANCEL,
+      metaType: "squads_proposal_cancel",
+      verb: "Cancel",
+      insufficientFunds: ({ required, available }) =>
+        errors.INSUFFICIENT_FUNDS({
+          message: "Insufficient SOL balance to cancel the proposal",
+          data: { required, available },
+        }),
+    });
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/cancel.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/cancel.ts
@@ -1,5 +1,4 @@
 import { publicProcedure } from "../../../procedures";
-import * as multisig from "@sqds/multisig";
 import { createSolanaConnection } from "@/lib/solana";
 import { buildProposalVote, SQUADS_VOTE_ACTIONS } from "./helpers";
 
@@ -9,13 +8,8 @@ export const cancelProposal = publicProcedure.squads.cancelProposal.handler(
     return buildProposalVote({
       input,
       connection,
-      buildIx: multisig.instructions.proposalCancel,
       action: SQUADS_VOTE_ACTIONS.cancel,
-      insufficientFunds: ({ required, available }) =>
-        errors.INSUFFICIENT_FUNDS({
-          message: "Insufficient SOL balance to cancel the proposal",
-          data: { required, available },
-        }),
+      errors,
     });
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/execute.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/execute.ts
@@ -1,0 +1,109 @@
+import { publicProcedure } from "../../../procedures";
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import * as multisig from "@sqds/multisig";
+import { createSolanaConnection } from "@/lib/solana";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "@/lib/utils/transaction-tags";
+import { buildSquadsTransaction } from "./helpers";
+
+export const executeProposal = publicProcedure.squads.executeProposal.handler(
+  async ({ input, errors }) => {
+    const { member, multisig: multisigAddress, transactionIndex } = input;
+    const memberKey = new PublicKey(member);
+    const multisigPda = new PublicKey(multisigAddress);
+    const index = BigInt(transactionIndex);
+    const { connection } = createSolanaConnection(member);
+
+    // A proposal's transaction index can back either a vault transaction (an
+    // action proposal) or a config transaction (a membership/threshold
+    // change); each executes with a different Squads instruction. Read the
+    // transaction account once and detect which it is by its discriminator.
+    const [transactionPda] = multisig.getTransactionPda({
+      multisigPda,
+      index,
+    });
+    const account = await connection.getAccountInfo(transactionPda);
+    if (!account) {
+      throw errors.NOT_FOUND({
+        message: `No Squads transaction found at index ${transactionIndex}`,
+      });
+    }
+
+    let isVault = true;
+    try {
+      multisig.accounts.VaultTransaction.fromAccountInfo(account);
+    } catch {
+      isVault = false;
+      try {
+        multisig.accounts.ConfigTransaction.fromAccountInfo(account);
+      } catch {
+        throw errors.BAD_REQUEST({
+          message: `Transaction at index ${transactionIndex} is neither a vault nor a config transaction`,
+        });
+      }
+    }
+
+    let instructions: TransactionInstruction[];
+    let addressLookupTableAddresses: PublicKey[] = [];
+    if (isVault) {
+      const { instruction, lookupTableAccounts } =
+        await multisig.instructions.vaultTransactionExecute({
+          connection,
+          multisigPda,
+          transactionIndex: index,
+          member: memberKey,
+        });
+      instructions = [instruction];
+      addressLookupTableAddresses = lookupTableAccounts.map((a) => a.key);
+    } else {
+      instructions = [
+        multisig.instructions.configTransactionExecute({
+          multisigPda,
+          transactionIndex: index,
+          member: memberKey,
+        }),
+      ];
+    }
+
+    const serializedTransaction = await buildSquadsTransaction({
+      connection,
+      member: memberKey,
+      instructions,
+      addressLookupTableAddresses,
+      insufficientFunds: ({ required, available }) =>
+        errors.INSUFFICIENT_FUNDS({
+          message: "Insufficient SOL balance to execute the proposal",
+          data: { required, available },
+        }),
+    });
+
+    const tag = generateTransactionTag({
+      type: TRANSACTION_TYPES.SQUADS_PROPOSAL_EXECUTE,
+      member,
+      multisig: multisigAddress,
+      transactionIndex,
+    });
+
+    return {
+      transactions: [
+        {
+          serializedTransaction,
+          metadata: {
+            type: "squads_proposal_execute",
+            description: `Execute proposal #${transactionIndex}`,
+          },
+        },
+      ],
+      parallel: false,
+      tag,
+      actionMetadata: {
+        type: "squads_proposal_execute",
+        multisig: multisigAddress,
+        transactionIndex,
+        kind: isVault ? "vault" : "config",
+      },
+    };
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/execute.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/execute.ts
@@ -91,7 +91,7 @@ export const executeProposal = publicProcedure.squads.executeProposal.handler(
         {
           serializedTransaction,
           metadata: {
-            type: "squads_proposal_execute",
+            type: TRANSACTION_TYPES.SQUADS_PROPOSAL_EXECUTE,
             description: `Execute proposal #${transactionIndex}`,
           },
         },
@@ -99,11 +99,11 @@ export const executeProposal = publicProcedure.squads.executeProposal.handler(
       parallel: false,
       tag,
       actionMetadata: {
-        type: "squads_proposal_execute",
+        type: TRANSACTION_TYPES.SQUADS_PROPOSAL_EXECUTE,
         multisig: multisigAddress,
         transactionIndex,
         kind: isVault ? "vault" : "config",
       },
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/execute.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/execute.ts
@@ -31,23 +31,25 @@ export const executeProposal = publicProcedure.squads.executeProposal.handler(
       });
     }
 
-    let isVault = true;
-    try {
-      multisig.accounts.VaultTransaction.fromAccountInfo(account);
-    } catch {
-      isVault = false;
-      try {
-        multisig.accounts.ConfigTransaction.fromAccountInfo(account);
-      } catch {
-        throw errors.BAD_REQUEST({
-          message: `Transaction at index ${transactionIndex} is neither a vault nor a config transaction`,
-        });
-      }
+    const discriminator = account.data.subarray(0, 8);
+    const kind = discriminator.equals(
+      Buffer.from(multisig.accounts.vaultTransactionDiscriminator)
+    )
+      ? "vault"
+      : discriminator.equals(
+          Buffer.from(multisig.accounts.configTransactionDiscriminator)
+        )
+      ? "config"
+      : null;
+    if (!kind) {
+      throw errors.BAD_REQUEST({
+        message: `Transaction at index ${transactionIndex} is neither a vault nor a config transaction`,
+      });
     }
 
     let instructions: TransactionInstruction[];
     let addressLookupTableAddresses: PublicKey[] = [];
-    if (isVault) {
+    if (kind === "vault") {
       const { instruction, lookupTableAccounts } =
         await multisig.instructions.vaultTransactionExecute({
           connection,
@@ -102,8 +104,8 @@ export const executeProposal = publicProcedure.squads.executeProposal.handler(
         type: TRANSACTION_TYPES.SQUADS_PROPOSAL_EXECUTE,
         multisig: multisigAddress,
         transactionIndex,
-        kind: isVault ? "vault" : "config",
+        kind,
       },
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/execute.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/execute.ts
@@ -67,7 +67,7 @@ export const executeProposal = publicProcedure.squads.executeProposal.handler(
       ];
     }
 
-    const serializedTransaction = await buildSquadsTransaction({
+    const { serializedTransaction } = await buildSquadsTransaction({
       connection,
       member: memberKey,
       instructions,

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
@@ -11,7 +11,10 @@ import {
   serializeTransaction,
 } from "@/lib/utils/build-transaction";
 import { getTransactionFee } from "@/lib/utils/balance-validation";
-import { generateTransactionTag } from "@/lib/utils/transaction-tags";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "@/lib/utils/transaction-tags";
 
 /** Fee-shortfall reporter, wired to a procedure's typed INSUFFICIENT_FUNDS error. */
 export type InsufficientFundsReporter = (info: {
@@ -65,6 +68,28 @@ type VoteIxBuilder = (args: {
   memo?: string;
 }) => TransactionInstruction;
 
+/** The three fields that identify a specific proposal across squads inputs. */
+export type ProposalRef = {
+  member: string;
+  multisig: string;
+  transactionIndex: string;
+};
+
+/**
+ * Per-vote-action descriptor. `type` is the single transaction type that keys
+ * both the tag and the metadata; `verb` is its human-readable label.
+ */
+export type ProposalVoteAction = {
+  type: string;
+  verb: string;
+};
+
+export const SQUADS_VOTE_ACTIONS = {
+  approve: { type: TRANSACTION_TYPES.SQUADS_PROPOSAL_APPROVE, verb: "Approve" },
+  reject: { type: TRANSACTION_TYPES.SQUADS_PROPOSAL_REJECT, verb: "Reject" },
+  cancel: { type: TRANSACTION_TYPES.SQUADS_PROPOSAL_CANCEL, verb: "Cancel" },
+} as const satisfies Record<string, ProposalVoteAction>;
+
 /**
  * Shared body for the approve / reject / cancel proposal endpoints, which
  * differ only in the Squads instruction they build and their labels.
@@ -73,22 +98,13 @@ export async function buildProposalVote({
   input,
   connection,
   buildIx,
-  tagType,
-  metaType,
-  verb,
+  action,
   insufficientFunds,
 }: {
-  input: {
-    member: string;
-    multisig: string;
-    transactionIndex: string;
-    memo?: string;
-  };
+  input: ProposalRef & { memo?: string };
   connection: Connection;
   buildIx: VoteIxBuilder;
-  tagType: string;
-  metaType: string;
-  verb: string;
+  action: ProposalVoteAction;
   insufficientFunds: InsufficientFundsReporter;
 }) {
   const member = new PublicKey(input.member);
@@ -109,7 +125,7 @@ export async function buildProposalVote({
   });
 
   const tag = generateTransactionTag({
-    type: tagType,
+    type: action.type,
     member: input.member,
     multisig: input.multisig,
     transactionIndex: input.transactionIndex,
@@ -120,15 +136,15 @@ export async function buildProposalVote({
       {
         serializedTransaction,
         metadata: {
-          type: metaType,
-          description: `${verb} proposal #${input.transactionIndex}`,
+          type: action.type,
+          description: `${action.verb} proposal #${input.transactionIndex}`,
         },
       },
     ],
     parallel: false,
     tag,
     actionMetadata: {
-      type: metaType,
+      type: action.type,
       multisig: input.multisig,
       transactionIndex: input.transactionIndex,
     },
@@ -138,11 +154,11 @@ export async function buildProposalVote({
 /** Fetch the multisig's next (unused) transaction index. */
 export async function nextTransactionIndex(
   connection: Connection,
-  multisigPda: PublicKey
+  multisigPda: PublicKey,
 ): Promise<bigint> {
   const info = await multisig.accounts.Multisig.fromAccountAddress(
     connection,
-    multisigPda
+    multisigPda,
   );
   return BigInt(info.transactionIndex.toString()) + BigInt(1);
 }
@@ -227,7 +243,7 @@ export async function buildActionProposal({
   multisigPda: PublicKey;
   member: PublicKey;
   buildInstructions: (
-    vault: PublicKey
+    vault: PublicKey,
   ) => Promise<TransactionInstruction[]> | TransactionInstruction[];
   memo?: string;
   insufficientFunds: InsufficientFundsReporter;
@@ -239,7 +255,7 @@ export async function buildActionProposal({
 }> {
   const transactionIndex = await nextTransactionIndex(
     connection,
-    multisigPda
+    multisigPda,
   ).catch(() => {
     throw notFound();
   });

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
@@ -21,7 +21,8 @@ export type InsufficientFundsReporter = (info: {
 
 /**
  * Build an unsigned Squads transaction from a set of instructions, verify the
- * acting member can cover the fee, and return the base64-serialized tx.
+ * acting member can cover the fee, and return the base64-serialized tx plus the
+ * estimated fee in lamports.
  *
  * Passes `addressLookupTableAddresses` through verbatim (default empty) so the
  * common Helium LUT is not auto-attached to these small governance txns; a
@@ -39,7 +40,7 @@ export async function buildSquadsTransaction({
   instructions: TransactionInstruction[];
   addressLookupTableAddresses?: PublicKey[];
   insufficientFunds: InsufficientFundsReporter;
-}): Promise<string> {
+}): Promise<{ serializedTransaction: string; feeLamports: number }> {
   const tx = await buildVersionedTransaction({
     connection,
     draft: { instructions, feePayer: member, addressLookupTableAddresses },
@@ -51,7 +52,10 @@ export async function buildSquadsTransaction({
     throw insufficientFunds({ required, available });
   }
 
-  return serializeTransaction(tx);
+  return {
+    serializedTransaction: serializeTransaction(tx),
+    feeLamports: required,
+  };
 }
 
 type VoteIxBuilder = (args: {
@@ -97,7 +101,7 @@ export async function buildProposalVote({
     memo: input.memo,
   });
 
-  const serializedTransaction = await buildSquadsTransaction({
+  const { serializedTransaction } = await buildSquadsTransaction({
     connection,
     member,
     instructions: [ix],
@@ -198,4 +202,66 @@ export function wrapAsVaultProposal({
   });
 
   return [createIx, proposalIx];
+}
+
+/**
+ * Full "build as proposal" path for an action endpoint: resolve the next
+ * transaction index (mapping a missing multisig to the caller's NOT_FOUND),
+ * build the action instructions with the vault as authority, wrap them into a
+ * proposal, and produce the base64 outer transaction paid for by `member`.
+ *
+ * `buildInstructions` receives the vault pubkey to use as the action's
+ * authority/owner. Returns the serialized proposal transaction and the assigned
+ * transaction index (as a string, for metadata).
+ */
+export async function buildActionProposal({
+  connection,
+  multisigPda,
+  member,
+  buildInstructions,
+  memo,
+  insufficientFunds,
+  notFound,
+}: {
+  connection: Connection;
+  multisigPda: PublicKey;
+  member: PublicKey;
+  buildInstructions: (
+    vault: PublicKey
+  ) => Promise<TransactionInstruction[]> | TransactionInstruction[];
+  memo?: string;
+  insufficientFunds: InsufficientFundsReporter;
+  notFound: () => Error;
+}): Promise<{
+  serializedTransaction: string;
+  transactionIndex: string;
+  feeLamports: number;
+}> {
+  const transactionIndex = await nextTransactionIndex(
+    connection,
+    multisigPda
+  ).catch(() => {
+    throw notFound();
+  });
+  const vault = vaultPda(multisigPda);
+  const instructions = await buildInstructions(vault);
+  const proposalIxs = wrapAsVaultProposal({
+    multisigPda,
+    transactionIndex,
+    member,
+    vault,
+    instructions,
+    memo,
+  });
+  const { serializedTransaction, feeLamports } = await buildSquadsTransaction({
+    connection,
+    member,
+    instructions: proposalIxs,
+    insufficientFunds,
+  });
+  return {
+    serializedTransaction,
+    transactionIndex: transactionIndex.toString(),
+    feeLamports,
+  };
 }

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
@@ -1,4 +1,10 @@
-import { Connection, PublicKey, TransactionInstruction } from "@solana/web3.js";
+import {
+  AddressLookupTableAccount,
+  Connection,
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+} from "@solana/web3.js";
 import * as multisig from "@sqds/multisig";
 import {
   buildVersionedTransaction,
@@ -135,4 +141,61 @@ export async function nextTransactionIndex(
     multisigPda
   );
   return BigInt(info.transactionIndex.toString()) + BigInt(1);
+}
+
+/** Default vault (index 0) of a multisig — the authority for proposed actions. */
+export function vaultPda(multisigPda: PublicKey): PublicKey {
+  return multisig.getVaultPda({ multisigPda, index: 0 })[0];
+}
+
+/**
+ * Wrap action instructions (built with the vault as their authority) into a
+ * Squads v4 vault-transaction proposal: vaultTransactionCreate + proposalCreate,
+ * both created and paid for by `member`. This is the "build as proposal" mode
+ * of the action endpoints, mirroring the wallet's propose_ixs_with_luts.
+ *
+ * Pure/synchronous: resolve `transactionIndex` via nextTransactionIndex first so
+ * a missing multisig maps to NOT_FOUND before any instruction is built.
+ */
+export function wrapAsVaultProposal({
+  multisigPda,
+  transactionIndex,
+  member,
+  vault,
+  instructions,
+  memo,
+  addressLookupTableAccounts = [],
+}: {
+  multisigPda: PublicKey;
+  transactionIndex: bigint;
+  member: PublicKey;
+  vault: PublicKey;
+  instructions: TransactionInstruction[];
+  memo?: string;
+  addressLookupTableAccounts?: AddressLookupTableAccount[];
+}): TransactionInstruction[] {
+  const transactionMessage = new TransactionMessage({
+    payerKey: vault,
+    // Placeholder blockhash: Squads stores the inner message, not a live tx.
+    recentBlockhash: PublicKey.default.toBase58(),
+    instructions,
+  });
+
+  const createIx = multisig.instructions.vaultTransactionCreate({
+    multisigPda,
+    transactionIndex,
+    creator: member,
+    vaultIndex: 0,
+    ephemeralSigners: 0,
+    transactionMessage,
+    addressLookupTableAccounts,
+    memo,
+  });
+  const proposalIx = multisig.instructions.proposalCreate({
+    multisigPda,
+    creator: member,
+    transactionIndex,
+  });
+
+  return [createIx, proposalIx];
 }

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
@@ -24,6 +24,18 @@ export type InsufficientFundsReporter = (info: {
 }) => Error;
 
 /**
+ * The subset of a procedure's typed `errors` builders the squads helpers need.
+ * The full oRPC `errors` object satisfies this structurally.
+ */
+export type ProposalErrors = {
+  INSUFFICIENT_FUNDS: (opts: {
+    message: string;
+    data: { required: number; available: number };
+  }) => Error;
+  NOT_FOUND: (opts: { message: string }) => Error;
+};
+
+/**
  * Build an unsigned Squads transaction from a set of instructions, verify the
  * acting member can cover the fee, and return the base64-serialized tx plus the
  * estimated fee in lamports.
@@ -78,17 +90,31 @@ export type ProposalRef = {
 
 /**
  * Per-vote-action descriptor. `type` is the single transaction type that keys
- * both the tag and the metadata; `verb` is its human-readable label.
+ * both the tag and the metadata; `verb` is its human-readable label; `buildIx`
+ * is the Squads instruction builder for the vote.
  */
 export type ProposalVoteAction = {
   type: TransactionType;
   verb: string;
+  buildIx: VoteIxBuilder;
 };
 
 export const SQUADS_VOTE_ACTIONS = {
-  approve: { type: TRANSACTION_TYPES.SQUADS_PROPOSAL_APPROVE, verb: "Approve" },
-  reject: { type: TRANSACTION_TYPES.SQUADS_PROPOSAL_REJECT, verb: "Reject" },
-  cancel: { type: TRANSACTION_TYPES.SQUADS_PROPOSAL_CANCEL, verb: "Cancel" },
+  approve: {
+    type: TRANSACTION_TYPES.SQUADS_PROPOSAL_APPROVE,
+    verb: "Approve",
+    buildIx: multisig.instructions.proposalApprove,
+  },
+  reject: {
+    type: TRANSACTION_TYPES.SQUADS_PROPOSAL_REJECT,
+    verb: "Reject",
+    buildIx: multisig.instructions.proposalReject,
+  },
+  cancel: {
+    type: TRANSACTION_TYPES.SQUADS_PROPOSAL_CANCEL,
+    verb: "Cancel",
+    buildIx: multisig.instructions.proposalCancel,
+  },
 } as const satisfies Record<string, ProposalVoteAction>;
 
 /**
@@ -98,20 +124,18 @@ export const SQUADS_VOTE_ACTIONS = {
 export async function buildProposalVote({
   input,
   connection,
-  buildIx,
   action,
-  insufficientFunds,
+  errors,
 }: {
   input: ProposalRef & { memo?: string };
   connection: Connection;
-  buildIx: VoteIxBuilder;
   action: ProposalVoteAction;
-  insufficientFunds: InsufficientFundsReporter;
+  errors: ProposalErrors;
 }) {
   const member = new PublicKey(input.member);
   const multisigPda = new PublicKey(input.multisig);
 
-  const ix = buildIx({
+  const ix = action.buildIx({
     multisigPda,
     transactionIndex: BigInt(input.transactionIndex),
     member,
@@ -122,7 +146,11 @@ export async function buildProposalVote({
     connection,
     member,
     instructions: [ix],
-    insufficientFunds,
+    insufficientFunds: ({ required, available }) =>
+      errors.INSUFFICIENT_FUNDS({
+        message: `Insufficient SOL balance to ${action.verb.toLowerCase()} the proposal`,
+        data: { required, available },
+      }),
   });
 
   const tag = generateTransactionTag({
@@ -166,7 +194,7 @@ export function proposalTransactionData({
   multisig,
   transactionIndex,
   metadata = {},
-  actionMetadata = {},
+  actionMetadata = metadata,
 }: {
   serializedTransaction: string;
   type: TransactionType;
@@ -193,11 +221,11 @@ export function proposalTransactionData({
 /** Fetch the multisig's next (unused) transaction index. */
 export async function nextTransactionIndex(
   connection: Connection,
-  multisigPda: PublicKey,
+  multisigPda: PublicKey
 ): Promise<bigint> {
   const info = await multisig.accounts.Multisig.fromAccountAddress(
     connection,
-    multisigPda,
+    multisigPda
   );
   return BigInt(info.transactionIndex.toString()) + BigInt(1);
 }
@@ -275,18 +303,19 @@ export async function buildActionProposal({
   member,
   buildInstructions,
   memo,
-  insufficientFunds,
-  notFound,
+  errors,
+  action,
 }: {
   connection: Connection;
   multisigPda: PublicKey;
   member: PublicKey;
   buildInstructions: (
-    vault: PublicKey,
+    vault: PublicKey
   ) => Promise<TransactionInstruction[]> | TransactionInstruction[];
   memo?: string;
-  insufficientFunds: InsufficientFundsReporter;
-  notFound: () => Error;
+  errors: ProposalErrors;
+  /** Noun for the insufficient-funds message: "create the ${action} proposal". */
+  action: string;
 }): Promise<{
   serializedTransaction: string;
   transactionIndex: string;
@@ -294,9 +323,11 @@ export async function buildActionProposal({
 }> {
   const transactionIndex = await nextTransactionIndex(
     connection,
-    multisigPda,
+    multisigPda
   ).catch(() => {
-    throw notFound();
+    throw errors.NOT_FOUND({
+      message: `Multisig ${multisigPda.toBase58()} not found`,
+    });
   });
   const vault = vaultPda(multisigPda);
   const instructions = await buildInstructions(vault);
@@ -312,7 +343,11 @@ export async function buildActionProposal({
     connection,
     member,
     instructions: proposalIxs,
-    insufficientFunds,
+    insufficientFunds: ({ required, available }) =>
+      errors.INSUFFICIENT_FUNDS({
+        message: `Insufficient SOL balance to create the ${action} proposal`,
+        data: { required, available },
+      }),
   });
   return {
     serializedTransaction,

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
@@ -1,0 +1,138 @@
+import { Connection, PublicKey, TransactionInstruction } from "@solana/web3.js";
+import * as multisig from "@sqds/multisig";
+import {
+  buildVersionedTransaction,
+  serializeTransaction,
+} from "@/lib/utils/build-transaction";
+import { getTransactionFee } from "@/lib/utils/balance-validation";
+import { generateTransactionTag } from "@/lib/utils/transaction-tags";
+
+/** Fee-shortfall reporter, wired to a procedure's typed INSUFFICIENT_FUNDS error. */
+export type InsufficientFundsReporter = (info: {
+  required: number;
+  available: number;
+}) => Error;
+
+/**
+ * Build an unsigned Squads transaction from a set of instructions, verify the
+ * acting member can cover the fee, and return the base64-serialized tx.
+ *
+ * Passes `addressLookupTableAddresses` through verbatim (default empty) so the
+ * common Helium LUT is not auto-attached to these small governance txns; a
+ * vault execute supplies the inner message's own lookup tables here.
+ */
+export async function buildSquadsTransaction({
+  connection,
+  member,
+  instructions,
+  addressLookupTableAddresses = [],
+  insufficientFunds,
+}: {
+  connection: Connection;
+  member: PublicKey;
+  instructions: TransactionInstruction[];
+  addressLookupTableAddresses?: PublicKey[];
+  insufficientFunds: InsufficientFundsReporter;
+}): Promise<string> {
+  const tx = await buildVersionedTransaction({
+    connection,
+    draft: { instructions, feePayer: member, addressLookupTableAddresses },
+  });
+
+  const required = getTransactionFee(tx);
+  const available = await connection.getBalance(member);
+  if (available < required) {
+    throw insufficientFunds({ required, available });
+  }
+
+  return serializeTransaction(tx);
+}
+
+type VoteIxBuilder = (args: {
+  multisigPda: PublicKey;
+  transactionIndex: bigint;
+  member: PublicKey;
+  memo?: string;
+}) => TransactionInstruction;
+
+/**
+ * Shared body for the approve / reject / cancel proposal endpoints, which
+ * differ only in the Squads instruction they build and their labels.
+ */
+export async function buildProposalVote({
+  input,
+  connection,
+  buildIx,
+  tagType,
+  metaType,
+  verb,
+  insufficientFunds,
+}: {
+  input: {
+    member: string;
+    multisig: string;
+    transactionIndex: string;
+    memo?: string;
+  };
+  connection: Connection;
+  buildIx: VoteIxBuilder;
+  tagType: string;
+  metaType: string;
+  verb: string;
+  insufficientFunds: InsufficientFundsReporter;
+}) {
+  const member = new PublicKey(input.member);
+  const multisigPda = new PublicKey(input.multisig);
+
+  const ix = buildIx({
+    multisigPda,
+    transactionIndex: BigInt(input.transactionIndex),
+    member,
+    memo: input.memo,
+  });
+
+  const serializedTransaction = await buildSquadsTransaction({
+    connection,
+    member,
+    instructions: [ix],
+    insufficientFunds,
+  });
+
+  const tag = generateTransactionTag({
+    type: tagType,
+    member: input.member,
+    multisig: input.multisig,
+    transactionIndex: input.transactionIndex,
+  });
+
+  return {
+    transactions: [
+      {
+        serializedTransaction,
+        metadata: {
+          type: metaType,
+          description: `${verb} proposal #${input.transactionIndex}`,
+        },
+      },
+    ],
+    parallel: false,
+    tag,
+    actionMetadata: {
+      type: metaType,
+      multisig: input.multisig,
+      transactionIndex: input.transactionIndex,
+    },
+  };
+}
+
+/** Fetch the multisig's next (unused) transaction index. */
+export async function nextTransactionIndex(
+  connection: Connection,
+  multisigPda: PublicKey
+): Promise<bigint> {
+  const info = await multisig.accounts.Multisig.fromAccountAddress(
+    connection,
+    multisigPda
+  );
+  return BigInt(info.transactionIndex.toString()) + BigInt(1);
+}

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
@@ -14,6 +14,7 @@ import { getTransactionFee } from "@/lib/utils/balance-validation";
 import {
   generateTransactionTag,
   TRANSACTION_TYPES,
+  TransactionType,
 } from "@/lib/utils/transaction-tags";
 
 /** Fee-shortfall reporter, wired to a procedure's typed INSUFFICIENT_FUNDS error. */
@@ -80,7 +81,7 @@ export type ProposalRef = {
  * both the tag and the metadata; `verb` is its human-readable label.
  */
 export type ProposalVoteAction = {
-  type: string;
+  type: TransactionType;
   verb: string;
 };
 
@@ -148,6 +149,44 @@ export async function buildProposalVote({
       multisig: input.multisig,
       transactionIndex: input.transactionIndex,
     },
+  };
+}
+
+/**
+ * The shared response envelope for an action endpoint's propose mode: one
+ * serialized proposal transaction, display metadata, and actionMetadata keyed
+ * by the proposal's transaction type. `metadata` / `actionMetadata` carry the
+ * endpoint-specific extra fields for each record.
+ */
+export function proposalTransactionData({
+  serializedTransaction,
+  type,
+  description,
+  tag,
+  multisig,
+  transactionIndex,
+  metadata = {},
+  actionMetadata = {},
+}: {
+  serializedTransaction: string;
+  type: TransactionType;
+  description: string;
+  tag: string;
+  multisig: string;
+  transactionIndex: string;
+  metadata?: Record<string, unknown>;
+  actionMetadata?: Record<string, unknown>;
+}) {
+  return {
+    transactions: [
+      {
+        serializedTransaction,
+        metadata: { type, description, ...metadata },
+      },
+    ],
+    parallel: false,
+    tag,
+    actionMetadata: { type, multisig, transactionIndex, ...actionMetadata },
   };
 }
 

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/proposeConfigChange.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/proposeConfigChange.ts
@@ -1,0 +1,117 @@
+import { publicProcedure } from "../../../procedures";
+import { PublicKey } from "@solana/web3.js";
+import * as multisig from "@sqds/multisig";
+import { createSolanaConnection } from "@/lib/solana";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "@/lib/utils/transaction-tags";
+import { buildSquadsTransaction, nextTransactionIndex } from "./helpers";
+
+type ConfigActionInput =
+  | { type: "addMember"; newMember: string; permissions?: string[] }
+  | { type: "removeMember"; oldMember: string }
+  | { type: "changeThreshold"; newThreshold: number };
+
+const PERMISSION_BIT: Record<string, multisig.types.Permission> = {
+  initiate: multisig.types.Permission.Initiate,
+  vote: multisig.types.Permission.Vote,
+  execute: multisig.types.Permission.Execute,
+};
+
+function toConfigAction(
+  action: ConfigActionInput
+): multisig.types.ConfigAction {
+  switch (action.type) {
+    case "addMember":
+      return {
+        __kind: "AddMember",
+        newMember: {
+          key: new PublicKey(action.newMember),
+          permissions: action.permissions
+            ? multisig.types.Permissions.fromPermissions(
+                action.permissions.map((p) => PERMISSION_BIT[p])
+              )
+            : multisig.types.Permissions.all(),
+        },
+      };
+    case "removeMember":
+      return {
+        __kind: "RemoveMember",
+        oldMember: new PublicKey(action.oldMember),
+      };
+    case "changeThreshold":
+      return { __kind: "ChangeThreshold", newThreshold: action.newThreshold };
+  }
+}
+
+export const proposeConfigChange =
+  publicProcedure.squads.proposeConfigChange.handler(
+    async ({ input, errors }) => {
+      const { member, multisig: multisigAddress, actions, memo } = input;
+      const memberKey = new PublicKey(member);
+      const multisigPda = new PublicKey(multisigAddress);
+      const { connection } = createSolanaConnection(member);
+
+      const transactionIndex = await nextTransactionIndex(
+        connection,
+        multisigPda
+      ).catch(() => {
+        throw errors.NOT_FOUND({
+          message: `Multisig ${multisigAddress} not found`,
+        });
+      });
+
+      const createIx = multisig.instructions.configTransactionCreate({
+        multisigPda,
+        creator: memberKey,
+        transactionIndex,
+        actions: actions.map(toConfigAction),
+        memo,
+      });
+      const proposalIx = multisig.instructions.proposalCreate({
+        multisigPda,
+        creator: memberKey,
+        transactionIndex,
+      });
+
+      const serializedTransaction = await buildSquadsTransaction({
+        connection,
+        member: memberKey,
+        instructions: [createIx, proposalIx],
+        insufficientFunds: ({ required, available }) =>
+          errors.INSUFFICIENT_FUNDS({
+            message: "Insufficient SOL balance to propose the config change",
+            data: { required, available },
+          }),
+      });
+
+      const indexStr = transactionIndex.toString();
+      const tag = generateTransactionTag({
+        type: TRANSACTION_TYPES.SQUADS_CONFIG_CHANGE,
+        member,
+        multisig: multisigAddress,
+        transactionIndex: indexStr,
+        actions: actions.map((a) => a.type),
+      });
+
+      return {
+        transactions: [
+          {
+            serializedTransaction,
+            metadata: {
+              type: "squads_config_change",
+              description: `Propose config change #${indexStr}`,
+            },
+          },
+        ],
+        parallel: false,
+        tag,
+        actionMetadata: {
+          type: "squads_config_change",
+          multisig: multisigAddress,
+          transactionIndex: indexStr,
+        },
+      };
+    }
+  );

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/proposeConfigChange.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/proposeConfigChange.ts
@@ -75,7 +75,7 @@ export const proposeConfigChange =
         transactionIndex,
       });
 
-      const serializedTransaction = await buildSquadsTransaction({
+      const { serializedTransaction } = await buildSquadsTransaction({
         connection,
         member: memberKey,
         instructions: [createIx, proposalIx],

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/reject.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/reject.ts
@@ -1,0 +1,24 @@
+import { publicProcedure } from "../../../procedures";
+import * as multisig from "@sqds/multisig";
+import { createSolanaConnection } from "@/lib/solana";
+import { TRANSACTION_TYPES } from "@/lib/utils/transaction-tags";
+import { buildProposalVote } from "./helpers";
+
+export const rejectProposal = publicProcedure.squads.rejectProposal.handler(
+  async ({ input, errors }) => {
+    const { connection } = createSolanaConnection(input.member);
+    return buildProposalVote({
+      input,
+      connection,
+      buildIx: multisig.instructions.proposalReject,
+      tagType: TRANSACTION_TYPES.SQUADS_PROPOSAL_REJECT,
+      metaType: "squads_proposal_reject",
+      verb: "Reject",
+      insufficientFunds: ({ required, available }) =>
+        errors.INSUFFICIENT_FUNDS({
+          message: "Insufficient SOL balance to reject the proposal",
+          data: { required, available },
+        }),
+    });
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/reject.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/reject.ts
@@ -1,8 +1,7 @@
 import { publicProcedure } from "../../../procedures";
 import * as multisig from "@sqds/multisig";
 import { createSolanaConnection } from "@/lib/solana";
-import { TRANSACTION_TYPES } from "@/lib/utils/transaction-tags";
-import { buildProposalVote } from "./helpers";
+import { buildProposalVote, SQUADS_VOTE_ACTIONS } from "./helpers";
 
 export const rejectProposal = publicProcedure.squads.rejectProposal.handler(
   async ({ input, errors }) => {
@@ -11,14 +10,12 @@ export const rejectProposal = publicProcedure.squads.rejectProposal.handler(
       input,
       connection,
       buildIx: multisig.instructions.proposalReject,
-      tagType: TRANSACTION_TYPES.SQUADS_PROPOSAL_REJECT,
-      metaType: "squads_proposal_reject",
-      verb: "Reject",
+      action: SQUADS_VOTE_ACTIONS.reject,
       insufficientFunds: ({ required, available }) =>
         errors.INSUFFICIENT_FUNDS({
           message: "Insufficient SOL balance to reject the proposal",
           data: { required, available },
         }),
     });
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/reject.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/reject.ts
@@ -1,5 +1,4 @@
 import { publicProcedure } from "../../../procedures";
-import * as multisig from "@sqds/multisig";
 import { createSolanaConnection } from "@/lib/solana";
 import { buildProposalVote, SQUADS_VOTE_ACTIONS } from "./helpers";
 
@@ -9,13 +8,8 @@ export const rejectProposal = publicProcedure.squads.rejectProposal.handler(
     return buildProposalVote({
       input,
       connection,
-      buildIx: multisig.instructions.proposalReject,
       action: SQUADS_VOTE_ACTIONS.reject,
-      insufficientFunds: ({ required, available }) =>
-        errors.INSUFFICIENT_FUNDS({
-          message: "Insufficient SOL balance to reject the proposal",
-          data: { required, available },
-        }),
+      errors,
     });
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/squads/router.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/router.ts
@@ -1,0 +1,15 @@
+import { approveProposal } from "./procedures/approve";
+import { rejectProposal } from "./procedures/reject";
+import { cancelProposal } from "./procedures/cancel";
+import { executeProposal } from "./procedures/execute";
+import { proposeConfigChange } from "./procedures/proposeConfigChange";
+import { squadsContract } from "@helium/blockchain-api/contracts";
+import { implement } from "@orpc/server";
+
+export const squadsRouter = implement(squadsContract).router({
+  approveProposal,
+  rejectProposal,
+  cancelProposal,
+  executeProposal,
+  proposeConfigChange,
+});

--- a/packages/blockchain-api/src/server/api/routers/swap/procedures/getQuote.ts
+++ b/packages/blockchain-api/src/server/api/routers/swap/procedures/getQuote.ts
@@ -26,6 +26,11 @@ export const getQuote = publicProcedure.swap.getQuote.handler(
       quoteUrl.searchParams.set("amount", amount);
       quoteUrl.searchParams.set("swapMode", swapMode);
       quoteUrl.searchParams.set("slippageBps", slippageBps.toString());
+      // Exclude RFQ (JupiterZ) routes: those return maker-co-signed transactions
+      // the requesting wallet cannot sign on its own, so a self-signed swap can't
+      // be completed. The paid api-key host respects `excludeRouters=jupiterz` but
+      // ignores `excludeRfq` (only the keyless lite-api host respects the latter).
+      quoteUrl.searchParams.set("excludeRouters", "jupiterz");
 
       const quoteResponse = await fetch(quoteUrl.toString(), {
         headers: {

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/burn.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/burn.ts
@@ -1,5 +1,5 @@
 import { publicProcedure } from "../../../procedures";
-import { PublicKey, Connection } from "@solana/web3.js";
+import { PublicKey, Connection, TransactionInstruction } from "@solana/web3.js";
 import {
   createBurnCheckedInstruction,
   getAssociatedTokenAddressSync,
@@ -20,7 +20,27 @@ import {
   calculateRequiredBalance,
 } from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import { buildActionProposal } from "../../squads/procedures/helpers";
 import BN from "bn.js";
+
+/** Burn `rawAmount` of `mint` from `authority`'s associated token account. */
+async function buildBurnInstruction(
+  connection: Connection,
+  authority: PublicKey,
+  mint: string,
+  rawAmount: bigint
+): Promise<TransactionInstruction> {
+  const mintKey = new PublicKey(mint);
+  const senderAta = getAssociatedTokenAddressSync(mintKey, authority, true);
+  const mintInfo = await getMint(connection, mintKey);
+  return createBurnCheckedInstruction(
+    senderAta,
+    mintKey,
+    authority,
+    rawAmount,
+    mintInfo.decimals
+  );
+}
 
 export const burn = publicProcedure.tokens.burn.handler(
   async ({ input, errors }) => {
@@ -48,17 +68,85 @@ export const burn = publicProcedure.tokens.burn.handler(
       throw errors.BAD_REQUEST({ message: "Cannot burn native SOL" });
     }
 
-    const mintKey = new PublicKey(tokenAmount.mint);
-    const senderAta = getAssociatedTokenAddressSync(mintKey, feePayer, true);
-    const mintInfo = await getMint(connection, mintKey);
+    const burnTokenAmount = await toTokenAmountOutput(
+      new BN(tokenAmount.amount),
+      tokenAmount.mint
+    );
+    const tokenName = TOKEN_NAMES[tokenAmount.mint];
 
+    // ---- Squads propose mode: burn from the vault, wrapped as a proposal ----
+    if (input.multisig) {
+      const multisigPda = new PublicKey(input.multisig);
+      const { serializedTransaction, transactionIndex, feeLamports } =
+        await buildActionProposal({
+          connection,
+          multisigPda,
+          member: feePayer,
+          memo: input.memo,
+          buildInstructions: async (vault) => [
+            await buildBurnInstruction(
+              connection,
+              vault,
+              tokenAmount.mint,
+              rawAmount
+            ),
+          ],
+          insufficientFunds: ({ required, available }) =>
+            errors.INSUFFICIENT_FUNDS({
+              message: "Insufficient SOL balance to create the burn proposal",
+              data: { required, available },
+            }),
+          notFound: () =>
+            errors.NOT_FOUND({
+              message: `Multisig ${input.multisig} not found`,
+            }),
+        });
+
+      const tag = generateTransactionTag({
+        type: TRANSACTION_TYPES.TOKEN_BURN,
+        walletAddress,
+        mint: tokenAmount.mint,
+        amount: tokenAmount.amount,
+        multisig: input.multisig,
+      });
+
+      return {
+        transactionData: {
+          transactions: [
+            {
+              serializedTransaction,
+              metadata: {
+                type: "token_burn_proposal",
+                description: `Propose burn of ${tokenName ?? "Token"}`,
+                tokenAmount: burnTokenAmount,
+                tokenName,
+              },
+            },
+          ],
+          parallel: false,
+          tag,
+          actionMetadata: {
+            type: "token_burn_proposal",
+            multisig: input.multisig,
+            transactionIndex,
+            tokenAmount: burnTokenAmount,
+            tokenName,
+          },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(calculateRequiredBalance(feeLamports, 0)),
+          NATIVE_MINT.toBase58()
+        ),
+      };
+    }
+
+    // ---- Direct burn from the wallet ----
     const instructions = [
-      createBurnCheckedInstruction(
-        senderAta,
-        mintKey,
+      await buildBurnInstruction(
+        connection,
         feePayer,
-        rawAmount,
-        mintInfo.decimals
+        tokenAmount.mint,
+        rawAmount
       ),
     ];
 
@@ -85,12 +173,6 @@ export const burn = publicProcedure.tokens.burn.handler(
         data: { required: estimatedSolFeeLamports, available: walletBalance },
       });
     }
-
-    const burnTokenAmount = await toTokenAmountOutput(
-      new BN(tokenAmount.amount),
-      tokenAmount.mint
-    );
-    const tokenName = TOKEN_NAMES[tokenAmount.mint];
 
     return {
       transactionData: {

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/burn.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/burn.ts
@@ -1,0 +1,122 @@
+import { publicProcedure } from "../../../procedures";
+import { PublicKey, Connection } from "@solana/web3.js";
+import {
+  createBurnCheckedInstruction,
+  getAssociatedTokenAddressSync,
+  getMint,
+  NATIVE_MINT,
+} from "@solana/spl-token";
+import {
+  buildVersionedTransaction,
+  serializeTransaction,
+} from "@/lib/utils/build-transaction";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "@/lib/utils/transaction-tags";
+import { TOKEN_MINTS, TOKEN_NAMES } from "@/lib/constants/tokens";
+import {
+  getTransactionFee,
+  calculateRequiredBalance,
+} from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import BN from "bn.js";
+
+export const burn = publicProcedure.tokens.burn.handler(
+  async ({ input, errors }) => {
+    const { walletAddress, tokenAmount } = input;
+
+    const feePayer = new PublicKey(walletAddress);
+    const connection = new Connection(process.env.SOLANA_RPC_URL!);
+
+    let rawAmount: bigint;
+    try {
+      rawAmount = BigInt(tokenAmount.amount);
+    } catch (e) {
+      throw errors.BAD_REQUEST({
+        message: `Invalid amount: ${
+          e instanceof Error ? e.message : "could not parse amount"
+        }`,
+      });
+    }
+    if (rawAmount <= BigInt(0)) {
+      throw errors.BAD_REQUEST({ message: "Amount must be greater than 0" });
+    }
+    // Burning native SOL is not a token burn; use a transfer to an incinerator
+    // if that is ever needed.
+    if (tokenAmount.mint === TOKEN_MINTS.WSOL) {
+      throw errors.BAD_REQUEST({ message: "Cannot burn native SOL" });
+    }
+
+    const mintKey = new PublicKey(tokenAmount.mint);
+    const senderAta = getAssociatedTokenAddressSync(mintKey, feePayer, true);
+    const mintInfo = await getMint(connection, mintKey);
+
+    const instructions = [
+      createBurnCheckedInstruction(
+        senderAta,
+        mintKey,
+        feePayer,
+        rawAmount,
+        mintInfo.decimals
+      ),
+    ];
+
+    const tx = await buildVersionedTransaction({
+      connection,
+      draft: { instructions, feePayer, addressLookupTableAddresses: [] },
+    });
+
+    const tag = generateTransactionTag({
+      type: TRANSACTION_TYPES.TOKEN_BURN,
+      walletAddress,
+      mint: tokenAmount.mint,
+      amount: tokenAmount.amount,
+    });
+
+    const estimatedSolFeeLamports = calculateRequiredBalance(
+      getTransactionFee(tx),
+      0
+    );
+    const walletBalance = await connection.getBalance(feePayer);
+    if (walletBalance < estimatedSolFeeLamports) {
+      throw errors.INSUFFICIENT_FUNDS({
+        message: "Insufficient SOL balance for transaction fees",
+        data: { required: estimatedSolFeeLamports, available: walletBalance },
+      });
+    }
+
+    const burnTokenAmount = await toTokenAmountOutput(
+      new BN(tokenAmount.amount),
+      tokenAmount.mint
+    );
+    const tokenName = TOKEN_NAMES[tokenAmount.mint];
+
+    return {
+      transactionData: {
+        transactions: [
+          {
+            serializedTransaction: serializeTransaction(tx),
+            metadata: {
+              type: "token_burn",
+              description: `Burn ${tokenName ?? "Token"}`,
+              tokenAmount: burnTokenAmount,
+              tokenName,
+            },
+          },
+        ],
+        parallel: false,
+        tag,
+        actionMetadata: {
+          type: "token_burn",
+          tokenAmount: burnTokenAmount,
+          tokenName,
+        },
+      },
+      estimatedSolFee: await toTokenAmountOutput(
+        new BN(estimatedSolFeeLamports),
+        NATIVE_MINT.toBase58()
+      ),
+    };
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/burn.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/burn.ts
@@ -1,24 +1,21 @@
 import { publicProcedure } from "../../../procedures";
-import { PublicKey, Connection, TransactionInstruction } from "@solana/web3.js";
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
 import {
   createBurnCheckedInstruction,
   getAssociatedTokenAddressSync,
-  getMint,
   NATIVE_MINT,
 } from "@solana/spl-token";
-import {
-  buildVersionedTransaction,
-  serializeTransaction,
-} from "@/lib/utils/build-transaction";
+import { buildSingleTransactionResponse } from "@/lib/utils/build-transaction";
 import {
   generateTransactionTag,
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
-import { TOKEN_MINTS, TOKEN_NAMES } from "@/lib/constants/tokens";
 import {
-  getTransactionFee,
-  calculateRequiredBalance,
-} from "@/lib/utils/balance-validation";
+  TOKEN_MINTS,
+  TOKEN_NAMES,
+  getTokenDecimals,
+} from "@/lib/constants/tokens";
+import { calculateRequiredBalance } from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
 import {
   buildActionProposal,
@@ -29,20 +26,19 @@ import BN from "bn.js";
 
 /** Burn `rawAmount` of `mint` from `authority`'s associated token account. */
 async function buildBurnInstruction(
-  connection: Connection,
   authority: PublicKey,
   mint: string,
-  rawAmount: bigint,
+  rawAmount: bigint
 ): Promise<TransactionInstruction> {
   const mintKey = new PublicKey(mint);
   const senderAta = getAssociatedTokenAddressSync(mintKey, authority, true);
-  const mintInfo = await getMint(connection, mintKey);
+  const decimals = await getTokenDecimals(mint);
   return createBurnCheckedInstruction(
     senderAta,
     mintKey,
     authority,
     rawAmount,
-    mintInfo.decimals,
+    decimals
   );
 }
 
@@ -74,7 +70,7 @@ export const burn = publicProcedure.tokens.burn.handler(
 
     const burnTokenAmount = await toTokenAmountOutput(
       new BN(tokenAmount.amount),
-      tokenAmount.mint,
+      tokenAmount.mint
     );
     const tokenName = TOKEN_NAMES[tokenAmount.mint];
 
@@ -88,22 +84,10 @@ export const burn = publicProcedure.tokens.burn.handler(
           member: feePayer,
           memo: input.memo,
           buildInstructions: async (vault) => [
-            await buildBurnInstruction(
-              connection,
-              vault,
-              tokenAmount.mint,
-              rawAmount,
-            ),
+            await buildBurnInstruction(vault, tokenAmount.mint, rawAmount),
           ],
-          insufficientFunds: ({ required, available }) =>
-            errors.INSUFFICIENT_FUNDS({
-              message: "Insufficient SOL balance to create the burn proposal",
-              data: { required, available },
-            }),
-          notFound: () =>
-            errors.NOT_FOUND({
-              message: `Multisig ${input.multisig} not found`,
-            }),
+          errors,
+          action: "burn",
         });
 
       const tag = generateTransactionTag({
@@ -123,29 +107,18 @@ export const burn = publicProcedure.tokens.burn.handler(
           multisig: input.multisig,
           transactionIndex,
           metadata: { tokenAmount: burnTokenAmount, tokenName },
-          actionMetadata: { tokenAmount: burnTokenAmount, tokenName },
         }),
         estimatedSolFee: await toTokenAmountOutput(
           new BN(calculateRequiredBalance(feeLamports, 0)),
-          NATIVE_MINT.toBase58(),
+          NATIVE_MINT.toBase58()
         ),
       };
     }
 
     // ---- Direct burn from the wallet ----
     const instructions = [
-      await buildBurnInstruction(
-        connection,
-        feePayer,
-        tokenAmount.mint,
-        rawAmount,
-      ),
+      await buildBurnInstruction(feePayer, tokenAmount.mint, rawAmount),
     ];
-
-    const tx = await buildVersionedTransaction({
-      connection,
-      draft: { instructions, feePayer, addressLookupTableAddresses: [] },
-    });
 
     const tag = generateTransactionTag({
       type: TRANSACTION_TYPES.TOKEN_BURN,
@@ -154,43 +127,25 @@ export const burn = publicProcedure.tokens.burn.handler(
       amount: tokenAmount.amount,
     });
 
-    const estimatedSolFeeLamports = calculateRequiredBalance(
-      getTransactionFee(tx),
-      0,
-    );
-    const walletBalance = await connection.getBalance(feePayer);
-    if (walletBalance < estimatedSolFeeLamports) {
-      throw errors.INSUFFICIENT_FUNDS({
-        message: "Insufficient SOL balance for transaction fees",
-        data: { required: estimatedSolFeeLamports, available: walletBalance },
-      });
-    }
-
-    return {
-      transactionData: {
-        transactions: [
-          {
-            serializedTransaction: serializeTransaction(tx),
-            metadata: {
-              type: "token_burn",
-              description: `Burn ${tokenName ?? "Token"}`,
-              tokenAmount: burnTokenAmount,
-              tokenName,
-            },
-          },
-        ],
-        parallel: false,
-        tag,
-        actionMetadata: {
-          type: "token_burn",
-          tokenAmount: burnTokenAmount,
-          tokenName,
-        },
+    return buildSingleTransactionResponse({
+      connection,
+      instructions,
+      feePayer,
+      addressLookupTableAddresses: [],
+      insufficientFundsMessage: "Insufficient SOL balance for transaction fees",
+      errors,
+      tag,
+      transactionMetadata: {
+        type: "token_burn",
+        description: `Burn ${tokenName ?? "Token"}`,
+        tokenAmount: burnTokenAmount,
+        tokenName,
       },
-      estimatedSolFee: await toTokenAmountOutput(
-        new BN(estimatedSolFeeLamports),
-        NATIVE_MINT.toBase58(),
-      ),
-    };
-  },
+      actionMetadata: {
+        type: "token_burn",
+        tokenAmount: burnTokenAmount,
+        tokenName,
+      },
+    });
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/burn.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/burn.ts
@@ -20,7 +20,11 @@ import {
   calculateRequiredBalance,
 } from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
-import { buildActionProposal } from "../../squads/procedures/helpers";
+import {
+  buildActionProposal,
+  proposalTransactionData,
+} from "../../squads/procedures/helpers";
+import { createSolanaConnection } from "@/lib/solana";
 import BN from "bn.js";
 
 /** Burn `rawAmount` of `mint` from `authority`'s associated token account. */
@@ -28,7 +32,7 @@ async function buildBurnInstruction(
   connection: Connection,
   authority: PublicKey,
   mint: string,
-  rawAmount: bigint
+  rawAmount: bigint,
 ): Promise<TransactionInstruction> {
   const mintKey = new PublicKey(mint);
   const senderAta = getAssociatedTokenAddressSync(mintKey, authority, true);
@@ -38,7 +42,7 @@ async function buildBurnInstruction(
     mintKey,
     authority,
     rawAmount,
-    mintInfo.decimals
+    mintInfo.decimals,
   );
 }
 
@@ -47,7 +51,7 @@ export const burn = publicProcedure.tokens.burn.handler(
     const { walletAddress, tokenAmount } = input;
 
     const feePayer = new PublicKey(walletAddress);
-    const connection = new Connection(process.env.SOLANA_RPC_URL!);
+    const { connection } = createSolanaConnection(walletAddress);
 
     let rawAmount: bigint;
     try {
@@ -70,7 +74,7 @@ export const burn = publicProcedure.tokens.burn.handler(
 
     const burnTokenAmount = await toTokenAmountOutput(
       new BN(tokenAmount.amount),
-      tokenAmount.mint
+      tokenAmount.mint,
     );
     const tokenName = TOKEN_NAMES[tokenAmount.mint];
 
@@ -88,7 +92,7 @@ export const burn = publicProcedure.tokens.burn.handler(
               connection,
               vault,
               tokenAmount.mint,
-              rawAmount
+              rawAmount,
             ),
           ],
           insufficientFunds: ({ required, available }) =>
@@ -111,31 +115,19 @@ export const burn = publicProcedure.tokens.burn.handler(
       });
 
       return {
-        transactionData: {
-          transactions: [
-            {
-              serializedTransaction,
-              metadata: {
-                type: "token_burn_proposal",
-                description: `Propose burn of ${tokenName ?? "Token"}`,
-                tokenAmount: burnTokenAmount,
-                tokenName,
-              },
-            },
-          ],
-          parallel: false,
+        transactionData: proposalTransactionData({
+          serializedTransaction,
+          type: TRANSACTION_TYPES.TOKEN_BURN_PROPOSAL,
+          description: `Propose burn of ${tokenName ?? "Token"}`,
           tag,
-          actionMetadata: {
-            type: "token_burn_proposal",
-            multisig: input.multisig,
-            transactionIndex,
-            tokenAmount: burnTokenAmount,
-            tokenName,
-          },
-        },
+          multisig: input.multisig,
+          transactionIndex,
+          metadata: { tokenAmount: burnTokenAmount, tokenName },
+          actionMetadata: { tokenAmount: burnTokenAmount, tokenName },
+        }),
         estimatedSolFee: await toTokenAmountOutput(
           new BN(calculateRequiredBalance(feeLamports, 0)),
-          NATIVE_MINT.toBase58()
+          NATIVE_MINT.toBase58(),
         ),
       };
     }
@@ -146,7 +138,7 @@ export const burn = publicProcedure.tokens.burn.handler(
         connection,
         feePayer,
         tokenAmount.mint,
-        rawAmount
+        rawAmount,
       ),
     ];
 
@@ -164,7 +156,7 @@ export const burn = publicProcedure.tokens.burn.handler(
 
     const estimatedSolFeeLamports = calculateRequiredBalance(
       getTransactionFee(tx),
-      0
+      0,
     );
     const walletBalance = await connection.getBalance(feePayer);
     if (walletBalance < estimatedSolFeeLamports) {
@@ -197,8 +189,8 @@ export const burn = publicProcedure.tokens.burn.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(estimatedSolFeeLamports),
-        NATIVE_MINT.toBase58()
+        NATIVE_MINT.toBase58(),
       ),
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/memo.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/memo.ts
@@ -1,5 +1,6 @@
 import { publicProcedure } from "../../../procedures";
-import { PublicKey, Connection } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
+import { createSolanaConnection } from "@/lib/solana";
 import { createMemoInstruction } from "@solana/spl-memo";
 import { NATIVE_MINT } from "@solana/spl-token";
 import {
@@ -22,7 +23,7 @@ export const memo = publicProcedure.tokens.memo.handler(
     const { walletAddress, memo: memoText } = input;
 
     const feePayer = new PublicKey(walletAddress);
-    const connection = new Connection(process.env.SOLANA_RPC_URL!);
+    const { connection } = createSolanaConnection(walletAddress);
 
     const instructions = [createMemoInstruction(memoText, [feePayer])];
 
@@ -39,7 +40,7 @@ export const memo = publicProcedure.tokens.memo.handler(
 
     const estimatedSolFeeLamports = calculateRequiredBalance(
       getTransactionFee(tx),
-      0
+      0,
     );
     const walletBalance = await connection.getBalance(feePayer);
     if (walletBalance < estimatedSolFeeLamports) {
@@ -68,8 +69,8 @@ export const memo = publicProcedure.tokens.memo.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(estimatedSolFeeLamports),
-        NATIVE_MINT.toBase58()
+        NATIVE_MINT.toBase58(),
       ),
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/memo.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/memo.ts
@@ -1,0 +1,75 @@
+import { publicProcedure } from "../../../procedures";
+import { PublicKey, Connection } from "@solana/web3.js";
+import { createMemoInstruction } from "@solana/spl-memo";
+import { NATIVE_MINT } from "@solana/spl-token";
+import {
+  buildVersionedTransaction,
+  serializeTransaction,
+} from "@/lib/utils/build-transaction";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "@/lib/utils/transaction-tags";
+import {
+  getTransactionFee,
+  calculateRequiredBalance,
+} from "@/lib/utils/balance-validation";
+import { toTokenAmountOutput } from "@/lib/utils/token-math";
+import BN from "bn.js";
+
+export const memo = publicProcedure.tokens.memo.handler(
+  async ({ input, errors }) => {
+    const { walletAddress, memo: memoText } = input;
+
+    const feePayer = new PublicKey(walletAddress);
+    const connection = new Connection(process.env.SOLANA_RPC_URL!);
+
+    const instructions = [createMemoInstruction(memoText, [feePayer])];
+
+    const tx = await buildVersionedTransaction({
+      connection,
+      draft: { instructions, feePayer, addressLookupTableAddresses: [] },
+    });
+
+    const tag = generateTransactionTag({
+      type: TRANSACTION_TYPES.MEMO,
+      walletAddress,
+      memo: memoText,
+    });
+
+    const estimatedSolFeeLamports = calculateRequiredBalance(
+      getTransactionFee(tx),
+      0
+    );
+    const walletBalance = await connection.getBalance(feePayer);
+    if (walletBalance < estimatedSolFeeLamports) {
+      throw errors.INSUFFICIENT_FUNDS({
+        message: "Insufficient SOL balance for transaction fees",
+        data: { required: estimatedSolFeeLamports, available: walletBalance },
+      });
+    }
+
+    return {
+      transactionData: {
+        transactions: [
+          {
+            serializedTransaction: serializeTransaction(tx),
+            metadata: {
+              type: "memo",
+              description: "Memo",
+            },
+          },
+        ],
+        parallel: false,
+        tag,
+        actionMetadata: {
+          type: "memo",
+        },
+      },
+      estimatedSolFee: await toTokenAmountOutput(
+        new BN(estimatedSolFeeLamports),
+        NATIVE_MINT.toBase58()
+      ),
+    };
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/memo.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/memo.ts
@@ -2,21 +2,11 @@ import { publicProcedure } from "../../../procedures";
 import { PublicKey } from "@solana/web3.js";
 import { createSolanaConnection } from "@/lib/solana";
 import { createMemoInstruction } from "@solana/spl-memo";
-import { NATIVE_MINT } from "@solana/spl-token";
-import {
-  buildVersionedTransaction,
-  serializeTransaction,
-} from "@/lib/utils/build-transaction";
+import { buildSingleTransactionResponse } from "@/lib/utils/build-transaction";
 import {
   generateTransactionTag,
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
-import {
-  getTransactionFee,
-  calculateRequiredBalance,
-} from "@/lib/utils/balance-validation";
-import { toTokenAmountOutput } from "@/lib/utils/token-math";
-import BN from "bn.js";
 
 export const memo = publicProcedure.tokens.memo.handler(
   async ({ input, errors }) => {
@@ -27,50 +17,22 @@ export const memo = publicProcedure.tokens.memo.handler(
 
     const instructions = [createMemoInstruction(memoText, [feePayer])];
 
-    const tx = await buildVersionedTransaction({
-      connection,
-      draft: { instructions, feePayer, addressLookupTableAddresses: [] },
-    });
-
     const tag = generateTransactionTag({
       type: TRANSACTION_TYPES.MEMO,
       walletAddress,
       memo: memoText,
     });
 
-    const estimatedSolFeeLamports = calculateRequiredBalance(
-      getTransactionFee(tx),
-      0,
-    );
-    const walletBalance = await connection.getBalance(feePayer);
-    if (walletBalance < estimatedSolFeeLamports) {
-      throw errors.INSUFFICIENT_FUNDS({
-        message: "Insufficient SOL balance for transaction fees",
-        data: { required: estimatedSolFeeLamports, available: walletBalance },
-      });
-    }
-
-    return {
-      transactionData: {
-        transactions: [
-          {
-            serializedTransaction: serializeTransaction(tx),
-            metadata: {
-              type: "memo",
-              description: "Memo",
-            },
-          },
-        ],
-        parallel: false,
-        tag,
-        actionMetadata: {
-          type: "memo",
-        },
-      },
-      estimatedSolFee: await toTokenAmountOutput(
-        new BN(estimatedSolFeeLamports),
-        NATIVE_MINT.toBase58(),
-      ),
-    };
-  },
+    return buildSingleTransactionResponse({
+      connection,
+      instructions,
+      feePayer,
+      addressLookupTableAddresses: [],
+      insufficientFundsMessage: "Insufficient SOL balance for transaction fees",
+      errors,
+      tag,
+      transactionMetadata: { type: "memo", description: "Memo" },
+      actionMetadata: { type: "memo" },
+    });
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
@@ -1,5 +1,10 @@
 import { publicProcedure } from "../../../procedures";
-import { PublicKey, SystemProgram, Connection } from "@solana/web3.js";
+import {
+  PublicKey,
+  SystemProgram,
+  Connection,
+  TransactionInstruction,
+} from "@solana/web3.js";
 import {
   createAssociatedTokenAccountIdempotentInstruction,
   createTransferCheckedInstruction,
@@ -15,10 +20,80 @@ import {
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
 import { TOKEN_MINTS, TOKEN_NAMES } from "@/lib/constants/tokens";
-import { getTransactionFee, calculateRequiredBalance, RENT_COSTS } from "@/lib/utils/balance-validation";
+import {
+  getTransactionFee,
+  calculateRequiredBalance,
+  RENT_COSTS,
+} from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
 import { NATIVE_MINT } from "@solana/spl-token";
+import {
+  nextTransactionIndex,
+  vaultPda,
+  wrapAsVaultProposal,
+} from "../../squads/procedures/helpers";
 import BN from "bn.js";
+
+/**
+ * Build the raw transfer instructions with `authority` as the source owner and
+ * fee payer for any created associated token account. Shared by the direct
+ * transfer path (authority = wallet) and the Squads propose path (authority =
+ * vault).
+ */
+async function buildTransferInstructions({
+  connection,
+  authority,
+  destination,
+  mint,
+  rawAmount,
+  isSol,
+}: {
+  connection: Connection;
+  authority: PublicKey;
+  destination: PublicKey;
+  mint: string;
+  rawAmount: bigint;
+  isSol: boolean;
+}): Promise<{ instructions: TransactionInstruction[]; needsAta: boolean }> {
+  if (isSol) {
+    return {
+      instructions: [
+        SystemProgram.transfer({
+          fromPubkey: authority,
+          toPubkey: destination,
+          lamports: rawAmount,
+        }),
+      ],
+      needsAta: false,
+    };
+  }
+
+  const mintKey = new PublicKey(mint);
+  const senderAta = getAssociatedTokenAddressSync(mintKey, authority, true);
+  const destAta = getAssociatedTokenAddressSync(mintKey, destination, true);
+  const needsAta = !(await connection.getAccountInfo(destAta));
+  const mintInfo = await getMint(connection, mintKey);
+
+  return {
+    instructions: [
+      createAssociatedTokenAccountIdempotentInstruction(
+        authority,
+        destAta,
+        destination,
+        mintKey
+      ),
+      createTransferCheckedInstruction(
+        senderAta,
+        mintKey,
+        destAta,
+        authority,
+        rawAmount,
+        mintInfo.decimals
+      ),
+    ],
+    needsAta,
+  };
+}
 
 export const transfer = publicProcedure.tokens.transfer.handler(
   async ({ input, errors }) => {
@@ -29,7 +104,6 @@ export const transfer = publicProcedure.tokens.transfer.handler(
     const connection = new Connection(process.env.SOLANA_RPC_URL!);
 
     let rawAmount: bigint;
-
     try {
       rawAmount = BigInt(tokenAmount.amount);
     } catch (e) {
@@ -45,55 +119,112 @@ export const transfer = publicProcedure.tokens.transfer.handler(
     }
 
     const isSol = tokenAmount.mint === TOKEN_MINTS.WSOL;
+    const transferTokenAmount = await toTokenAmountOutput(
+      new BN(tokenAmount.amount),
+      tokenAmount.mint
+    );
+    const tokenName = TOKEN_NAMES[tokenAmount.mint];
 
-    const instructions: (
-      | ReturnType<typeof SystemProgram.transfer>
-      | ReturnType<typeof createAssociatedTokenAccountIdempotentInstruction>
-      | ReturnType<typeof createTransferCheckedInstruction>
-    )[] = [];
+    // ---- Squads propose mode: build the transfer from the vault, wrap it ----
+    if (input.multisig) {
+      const multisigPda = new PublicKey(input.multisig);
+      const transactionIndex = await nextTransactionIndex(
+        connection,
+        multisigPda
+      ).catch(() => {
+        throw errors.NOT_FOUND({
+          message: `Multisig ${input.multisig} not found`,
+        });
+      });
+      const vault = vaultPda(multisigPda);
 
-    let needsAta = false;
+      const { instructions: actionIxs } = await buildTransferInstructions({
+        connection,
+        authority: vault,
+        destination: destKey,
+        mint: tokenAmount.mint,
+        rawAmount,
+        isSol,
+      });
 
-    if (isSol) {
-      const lamports = rawAmount;
+      const proposalIxs = wrapAsVaultProposal({
+        multisigPda,
+        transactionIndex,
+        member: feePayer,
+        vault,
+        instructions: actionIxs,
+        memo: input.memo,
+      });
 
-      instructions.push(
-        SystemProgram.transfer({
-          fromPubkey: feePayer,
-          toPubkey: destKey,
-          lamports,
-        }),
-      );
-    } else {
-      const mintKey = new PublicKey(tokenAmount.mint);
-      const senderAta = getAssociatedTokenAddressSync(mintKey, feePayer, true);
-      const destAta = getAssociatedTokenAddressSync(mintKey, destKey, true);
-
-      const destAtaInfo = await connection.getAccountInfo(destAta);
-      needsAta = !destAtaInfo;
-
-      const mintInfo = await getMint(connection, mintKey);
-
-      instructions.push(
-        createAssociatedTokenAccountIdempotentInstruction(
+      const tx = await buildVersionedTransaction({
+        connection,
+        draft: {
+          instructions: proposalIxs,
           feePayer,
-          destAta,
-          destKey,
-          mintKey,
-        ),
-      );
+          addressLookupTableAddresses: [],
+        },
+      });
 
-      instructions.push(
-        createTransferCheckedInstruction(
-          senderAta,
-          mintKey,
-          destAta,
-          feePayer,
-          rawAmount,
-          mintInfo.decimals,
+      const txFee = getTransactionFee(tx);
+      const walletBalance = await connection.getBalance(feePayer);
+      if (walletBalance < txFee) {
+        throw errors.INSUFFICIENT_FUNDS({
+          message: "Insufficient SOL balance to create the transfer proposal",
+          data: { required: txFee, available: walletBalance },
+        });
+      }
+
+      const indexStr = transactionIndex.toString();
+      const tag = generateTransactionTag({
+        type: TRANSACTION_TYPES.TOKEN_TRANSFER,
+        walletAddress,
+        destination,
+        mint: tokenAmount.mint,
+        amount: tokenAmount.amount,
+        multisig: input.multisig,
+      });
+
+      return {
+        transactionData: {
+          transactions: [
+            {
+              serializedTransaction: serializeTransaction(tx),
+              metadata: {
+                type: "token_transfer_proposal",
+                description: `Propose transfer of ${tokenName ?? "Token"}`,
+                tokenAmount: transferTokenAmount,
+                tokenName,
+                recipient: destination,
+              },
+            },
+          ],
+          parallel: false,
+          tag,
+          actionMetadata: {
+            type: "token_transfer_proposal",
+            multisig: input.multisig,
+            transactionIndex: indexStr,
+            tokenAmount: transferTokenAmount,
+            tokenName,
+            recipient: destination,
+          },
+        },
+        estimatedSolFee: await toTokenAmountOutput(
+          new BN(calculateRequiredBalance(txFee, 0)),
+          NATIVE_MINT.toBase58()
         ),
-      );
+      };
     }
+
+    // ---- Direct transfer from the wallet ----
+    const { instructions, needsAta } = await buildTransferInstructions({
+      connection,
+      authority: feePayer,
+      destination: destKey,
+      mint: tokenAmount.mint,
+      rawAmount,
+      isSol,
+    });
 
     const tx = await buildVersionedTransaction({
       connection,
@@ -126,12 +257,6 @@ export const transfer = publicProcedure.tokens.transfer.handler(
       });
     }
 
-    const transferTokenAmount = await toTokenAmountOutput(
-      new BN(tokenAmount.amount),
-      tokenAmount.mint,
-    );
-    const tokenName = TOKEN_NAMES[tokenAmount.mint];
-
     return {
       transactionData: {
         transactions: [
@@ -157,8 +282,8 @@ export const transfer = publicProcedure.tokens.transfer.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(estimatedSolFeeLamports),
-        NATIVE_MINT.toBase58(),
+        NATIVE_MINT.toBase58()
       ),
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
@@ -9,7 +9,6 @@ import {
   createAssociatedTokenAccountIdempotentInstruction,
   createTransferCheckedInstruction,
   getAssociatedTokenAddressSync,
-  getMint,
 } from "@solana/spl-token";
 import {
   buildVersionedTransaction,
@@ -19,7 +18,11 @@ import {
   generateTransactionTag,
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
-import { TOKEN_MINTS, TOKEN_NAMES } from "@/lib/constants/tokens";
+import {
+  TOKEN_MINTS,
+  TOKEN_NAMES,
+  getTokenDecimals,
+} from "@/lib/constants/tokens";
 import {
   getTransactionFee,
   calculateRequiredBalance,
@@ -70,8 +73,11 @@ async function buildTransferInstructions({
   const mintKey = new PublicKey(mint);
   const senderAta = getAssociatedTokenAddressSync(mintKey, authority, true);
   const destAta = getAssociatedTokenAddressSync(mintKey, destination, true);
-  const needsAta = !(await connection.getAccountInfo(destAta));
-  const mintInfo = await getMint(connection, mintKey);
+  const [destAtaInfo, decimals] = await Promise.all([
+    connection.getAccountInfo(destAta),
+    getTokenDecimals(mint),
+  ]);
+  const needsAta = !destAtaInfo;
 
   return {
     instructions: [
@@ -79,7 +85,7 @@ async function buildTransferInstructions({
         authority,
         destAta,
         destination,
-        mintKey,
+        mintKey
       ),
       createTransferCheckedInstruction(
         senderAta,
@@ -87,7 +93,7 @@ async function buildTransferInstructions({
         destAta,
         authority,
         rawAmount,
-        mintInfo.decimals,
+        decimals
       ),
     ],
     needsAta,
@@ -120,7 +126,7 @@ export const transfer = publicProcedure.tokens.transfer.handler(
     const isSol = tokenAmount.mint === TOKEN_MINTS.WSOL;
     const transferTokenAmount = await toTokenAmountOutput(
       new BN(tokenAmount.amount),
-      tokenAmount.mint,
+      tokenAmount.mint
     );
     const tokenName = TOKEN_NAMES[tokenAmount.mint];
 
@@ -144,16 +150,8 @@ export const transfer = publicProcedure.tokens.transfer.handler(
                 isSol,
               })
             ).instructions,
-          insufficientFunds: ({ required, available }) =>
-            errors.INSUFFICIENT_FUNDS({
-              message:
-                "Insufficient SOL balance to create the transfer proposal",
-              data: { required, available },
-            }),
-          notFound: () =>
-            errors.NOT_FOUND({
-              message: `Multisig ${input.multisig} not found`,
-            }),
+          errors,
+          action: "transfer",
         });
 
       const tag = generateTransactionTag({
@@ -178,15 +176,10 @@ export const transfer = publicProcedure.tokens.transfer.handler(
             tokenName,
             recipient: destination,
           },
-          actionMetadata: {
-            tokenAmount: transferTokenAmount,
-            tokenName,
-            recipient: destination,
-          },
         }),
         estimatedSolFee: await toTokenAmountOutput(
           new BN(calculateRequiredBalance(feeLamports, 0)),
-          NATIVE_MINT.toBase58(),
+          NATIVE_MINT.toBase58()
         ),
       };
     }
@@ -257,8 +250,8 @@ export const transfer = publicProcedure.tokens.transfer.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(estimatedSolFeeLamports),
-        NATIVE_MINT.toBase58(),
+        NATIVE_MINT.toBase58()
       ),
     };
-  },
+  }
 );

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
@@ -27,11 +27,7 @@ import {
 } from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
 import { NATIVE_MINT } from "@solana/spl-token";
-import {
-  nextTransactionIndex,
-  vaultPda,
-  wrapAsVaultProposal,
-} from "../../squads/procedures/helpers";
+import { buildActionProposal } from "../../squads/procedures/helpers";
 import BN from "bn.js";
 
 /**
@@ -128,53 +124,35 @@ export const transfer = publicProcedure.tokens.transfer.handler(
     // ---- Squads propose mode: build the transfer from the vault, wrap it ----
     if (input.multisig) {
       const multisigPda = new PublicKey(input.multisig);
-      const transactionIndex = await nextTransactionIndex(
-        connection,
-        multisigPda
-      ).catch(() => {
-        throw errors.NOT_FOUND({
-          message: `Multisig ${input.multisig} not found`,
+      const { serializedTransaction, transactionIndex, feeLamports } =
+        await buildActionProposal({
+          connection,
+          multisigPda,
+          member: feePayer,
+          memo: input.memo,
+          buildInstructions: async (vault) =>
+            (
+              await buildTransferInstructions({
+                connection,
+                authority: vault,
+                destination: destKey,
+                mint: tokenAmount.mint,
+                rawAmount,
+                isSol,
+              })
+            ).instructions,
+          insufficientFunds: ({ required, available }) =>
+            errors.INSUFFICIENT_FUNDS({
+              message:
+                "Insufficient SOL balance to create the transfer proposal",
+              data: { required, available },
+            }),
+          notFound: () =>
+            errors.NOT_FOUND({
+              message: `Multisig ${input.multisig} not found`,
+            }),
         });
-      });
-      const vault = vaultPda(multisigPda);
 
-      const { instructions: actionIxs } = await buildTransferInstructions({
-        connection,
-        authority: vault,
-        destination: destKey,
-        mint: tokenAmount.mint,
-        rawAmount,
-        isSol,
-      });
-
-      const proposalIxs = wrapAsVaultProposal({
-        multisigPda,
-        transactionIndex,
-        member: feePayer,
-        vault,
-        instructions: actionIxs,
-        memo: input.memo,
-      });
-
-      const tx = await buildVersionedTransaction({
-        connection,
-        draft: {
-          instructions: proposalIxs,
-          feePayer,
-          addressLookupTableAddresses: [],
-        },
-      });
-
-      const txFee = getTransactionFee(tx);
-      const walletBalance = await connection.getBalance(feePayer);
-      if (walletBalance < txFee) {
-        throw errors.INSUFFICIENT_FUNDS({
-          message: "Insufficient SOL balance to create the transfer proposal",
-          data: { required: txFee, available: walletBalance },
-        });
-      }
-
-      const indexStr = transactionIndex.toString();
       const tag = generateTransactionTag({
         type: TRANSACTION_TYPES.TOKEN_TRANSFER,
         walletAddress,
@@ -188,7 +166,7 @@ export const transfer = publicProcedure.tokens.transfer.handler(
         transactionData: {
           transactions: [
             {
-              serializedTransaction: serializeTransaction(tx),
+              serializedTransaction,
               metadata: {
                 type: "token_transfer_proposal",
                 description: `Propose transfer of ${tokenName ?? "Token"}`,
@@ -203,14 +181,14 @@ export const transfer = publicProcedure.tokens.transfer.handler(
           actionMetadata: {
             type: "token_transfer_proposal",
             multisig: input.multisig,
-            transactionIndex: indexStr,
+            transactionIndex,
             tokenAmount: transferTokenAmount,
             tokenName,
             recipient: destination,
           },
         },
         estimatedSolFee: await toTokenAmountOutput(
-          new BN(calculateRequiredBalance(txFee, 0)),
+          new BN(calculateRequiredBalance(feeLamports, 0)),
           NATIVE_MINT.toBase58()
         ),
       };

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
@@ -27,7 +27,10 @@ import {
 } from "@/lib/utils/balance-validation";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
 import { NATIVE_MINT } from "@solana/spl-token";
-import { buildActionProposal } from "../../squads/procedures/helpers";
+import {
+  buildActionProposal,
+  proposalTransactionData,
+} from "../../squads/procedures/helpers";
 import BN from "bn.js";
 
 /**
@@ -76,7 +79,7 @@ async function buildTransferInstructions({
         authority,
         destAta,
         destination,
-        mintKey
+        mintKey,
       ),
       createTransferCheckedInstruction(
         senderAta,
@@ -84,7 +87,7 @@ async function buildTransferInstructions({
         destAta,
         authority,
         rawAmount,
-        mintInfo.decimals
+        mintInfo.decimals,
       ),
     ],
     needsAta,
@@ -117,7 +120,7 @@ export const transfer = publicProcedure.tokens.transfer.handler(
     const isSol = tokenAmount.mint === TOKEN_MINTS.WSOL;
     const transferTokenAmount = await toTokenAmountOutput(
       new BN(tokenAmount.amount),
-      tokenAmount.mint
+      tokenAmount.mint,
     );
     const tokenName = TOKEN_NAMES[tokenAmount.mint];
 
@@ -163,33 +166,27 @@ export const transfer = publicProcedure.tokens.transfer.handler(
       });
 
       return {
-        transactionData: {
-          transactions: [
-            {
-              serializedTransaction,
-              metadata: {
-                type: "token_transfer_proposal",
-                description: `Propose transfer of ${tokenName ?? "Token"}`,
-                tokenAmount: transferTokenAmount,
-                tokenName,
-                recipient: destination,
-              },
-            },
-          ],
-          parallel: false,
+        transactionData: proposalTransactionData({
+          serializedTransaction,
+          type: TRANSACTION_TYPES.TOKEN_TRANSFER_PROPOSAL,
+          description: `Propose transfer of ${tokenName ?? "Token"}`,
           tag,
-          actionMetadata: {
-            type: "token_transfer_proposal",
-            multisig: input.multisig,
-            transactionIndex,
+          multisig: input.multisig,
+          transactionIndex,
+          metadata: {
             tokenAmount: transferTokenAmount,
             tokenName,
             recipient: destination,
           },
-        },
+          actionMetadata: {
+            tokenAmount: transferTokenAmount,
+            tokenName,
+            recipient: destination,
+          },
+        }),
         estimatedSolFee: await toTokenAmountOutput(
           new BN(calculateRequiredBalance(feeLamports, 0)),
-          NATIVE_MINT.toBase58()
+          NATIVE_MINT.toBase58(),
         ),
       };
     }
@@ -260,8 +257,8 @@ export const transfer = publicProcedure.tokens.transfer.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(estimatedSolFeeLamports),
-        NATIVE_MINT.toBase58()
+        NATIVE_MINT.toBase58(),
       ),
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/tokens/router.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/router.ts
@@ -1,6 +1,8 @@
 import { getBalances } from "./procedures/getBalances";
 import { transfer } from "./procedures/transfer";
 import { multiTransfer } from "./procedures/multiTransfer";
+import { burn } from "./procedures/burn";
+import { memo } from "./procedures/memo";
 import { createHntAccount } from "./procedures/createHntAccount";
 import { tokensContract } from "@helium/blockchain-api/contracts";
 import { implement } from "@orpc/server";
@@ -15,6 +17,10 @@ export const tokensRouter = implement(tokensContract).router({
   transfer,
   /** Create transactions to transfer the same mint to multiple recipients */
   multiTransfer,
+  /** Create a transaction to burn tokens */
+  burn,
+  /** Create a memo transaction */
+  memo,
   /** Create an HNT token account for a wallet */
   createHntAccount,
 });

--- a/packages/blockchain-api/tests/e2e/automation.test.ts
+++ b/packages/blockchain-api/tests/e2e/automation.test.ts
@@ -146,7 +146,6 @@ describe("automation endpoints", () => {
 
   describe("lifecycle", () => {
     let walletAddress: string;
-    let totalHotspots: number;
     let firstEntityKey: string | undefined;
     const duration = 5;
 
@@ -154,17 +153,15 @@ describe("automation endpoints", () => {
       walletAddress = payer.publicKey.toBase58();
       await closeIfExists(walletAddress);
 
-      totalHotspots = 1;
       try {
         const hotspotsResult = await client.hotspots.getHotspots({
           walletAddress,
           page: 1,
           limit: 5,
         });
-        totalHotspots = hotspotsResult.total || 1;
         firstEntityKey = hotspotsResult.hotspots[0]?.entityKey;
       } catch {
-        console.log("getHotspots failed, using default totalHotspots=1");
+        console.log("getHotspots failed; skipping the per-hotspot add case");
       }
 
       // Create the cron itself (init-only, raw cron, pre-funded for `duration`).
@@ -172,7 +169,6 @@ describe("automation endpoints", () => {
         walletAddress,
         cronSchedule: DAILY_CRON,
         duration,
-        totalHotspots,
       });
 
       expect(result.transactionData.tag).to.equal(
@@ -353,7 +349,6 @@ describe("automation endpoints", () => {
           walletAddress,
           cronSchedule: "",
           duration: 5,
-          totalHotspots: 1,
         });
         expect.fail("Should have thrown a validation error");
       } catch (error: any) {

--- a/packages/blockchain-api/tests/e2e/automation.test.ts
+++ b/packages/blockchain-api/tests/e2e/automation.test.ts
@@ -167,7 +167,7 @@ describe("automation endpoints", () => {
       // Create the cron itself (init-only, raw cron, pre-funded for `duration`).
       const result = await client.hotspots.createAutomation({
         walletAddress,
-        cronSchedule: DAILY_CRON,
+        schedule: DAILY_CRON,
         duration,
       });
 
@@ -342,12 +342,12 @@ describe("automation endpoints", () => {
   });
 
   describe("validation", () => {
-    it("rejects an empty cron schedule", async () => {
+    it("rejects an empty schedule", async () => {
       const walletAddress = payer.publicKey.toBase58();
       try {
         await (client.hotspots.createAutomation as any)({
           walletAddress,
-          cronSchedule: "",
+          schedule: "",
           duration: 5,
         });
         expect.fail("Should have thrown a validation error");

--- a/packages/blockchain-api/tests/e2e/automation.test.ts
+++ b/packages/blockchain-api/tests/e2e/automation.test.ts
@@ -1,14 +1,13 @@
-import {
-  Connection,
-  Keypair,
-  LAMPORTS_PER_SOL,
-  PublicKey,
-} from "@solana/web3.js";
+import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { expect } from "chai";
 import { after, before, describe, it } from "mocha";
 import { applyMinimalServerEnv } from "./helpers/env";
 import { ensureNextServer, stopNextServer } from "./helpers/next";
-import { ensureSurfpool, getSurfpoolRpcUrl, stopSurfpool } from "./helpers/surfpool";
+import {
+  ensureSurfpool,
+  getSurfpoolRpcUrl,
+  stopSurfpool,
+} from "./helpers/surfpool";
 import { ensureFunds, loadKeypairFromEnv } from "./helpers/wallet";
 import { signAndSubmitTransactionData } from "./helpers/tx";
 import { createORPCClient } from "@orpc/client";
@@ -16,15 +15,36 @@ import { RPCLink } from "@orpc/client/fetch";
 import type { appRouter } from "@/server/api";
 import type { RouterClient } from "@orpc/server";
 import { ORPCError } from "@orpc/server";
+
 // Import constants directly to avoid path alias issues in tests
 const BASE_AUTOMATION_RENT = 0.02098095;
 const TASK_RETURN_ACCOUNT_SIZE = 0.01;
-const RECIPIENT_RENT = 0.00242208;
+
+// Raw crontab string (6-field clockwork format: sec min hour dom month dow).
+const DAILY_CRON = "0 0 0 * * *";
 
 describe("automation endpoints", () => {
   let payer: Keypair;
   let connection: Connection;
   let client: RouterClient<typeof appRouter>;
+
+  // Submit an action's transactions and wait for finalization.
+  async function submit(transactionData: any) {
+    const signatures = await signAndSubmitTransactionData(
+      connection,
+      transactionData,
+      payer
+    );
+    const { blockhash, lastValidBlockHeight } =
+      await connection.getLatestBlockhash("finalized");
+    for (const sig of signatures) {
+      await connection.confirmTransaction(
+        { signature: sig, blockhash, lastValidBlockHeight },
+        "finalized"
+      );
+    }
+    return signatures;
+  }
 
   before(async () => {
     if (!process.env.ASSET_ENDPOINT) {
@@ -37,12 +57,9 @@ describe("automation endpoints", () => {
     await ensureNextServer();
     payer = loadKeypairFromEnv();
     connection = new Connection(getSurfpoolRpcUrl(), "confirmed");
-    await ensureFunds(payer.publicKey, 0.1 * LAMPORTS_PER_SOL);
+    await ensureFunds(payer.publicKey, 0.5 * LAMPORTS_PER_SOL);
 
-    // Create ORPC client pointing to the test server
-    const link = new RPCLink({
-      url: "http://127.0.0.1:3000/rpc",
-    });
+    const link = new RPCLink({ url: "http://127.0.0.1:3000/rpc" });
     client = createORPCClient(link);
   });
 
@@ -51,28 +68,25 @@ describe("automation endpoints", () => {
     await stopSurfpool();
   });
 
-  describe("without automation", () => {
-    before(async () => {
-      const walletAddress = payer.publicKey.toBase58();
-      const status = await client.hotspots.getAutomationStatus({
+  // Make sure no cron exists for a wallet before a test.
+  async function closeIfExists(walletAddress: string) {
+    const status = await client.hotspots.getAutomationStatus({ walletAddress });
+    if (status.hasExistingAutomation || status.isOutOfSol) {
+      const closeResult = await client.hotspots.closeAutomation({
         walletAddress,
       });
-      if (status.hasExistingAutomation) {
-        const closeResult = await client.hotspots.closeAutomation({
-          walletAddress,
-        });
-        await signAndSubmitTransactionData(
-          connection,
-          closeResult.transactionData,
-          payer,
-        );
-        await new Promise((resolve) => setTimeout(resolve, 2000));
-      }
+      await submit(closeResult.transactionData);
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+
+  describe("without automation", () => {
+    before(async () => {
+      await closeIfExists(payer.publicKey.toBase58());
     });
 
-    it("gets automation status for wallet without automation", async () => {
+    it("gets automation status for a wallet without automation", async () => {
       const walletAddress = payer.publicKey.toBase58();
-
       const result = await client.hotspots.getAutomationStatus({
         walletAddress,
       });
@@ -80,25 +94,19 @@ describe("automation endpoints", () => {
       expect(result.hasExistingAutomation).to.equal(false);
       expect(result.isOutOfSol).to.equal(false);
       expect(result.currentSchedule).to.be.undefined;
-      // Rent fee should be BASE_AUTOMATION_RENT + TASK_RETURN_ACCOUNT_SIZE when no automation exists
       expect(result.rentFee).to.equal(
         BASE_AUTOMATION_RENT + TASK_RETURN_ACCOUNT_SIZE
       );
-      // Fees should be valid numbers
-      expect(result.recipientFee).to.be.a("number");
-      expect(result.operationalSol).to.be.a("number");
-      expect(result.recipientFee).to.be.at.least(0);
-      expect(result.operationalSol).to.be.at.least(0);
-      // Balances should be strings representing lamports
+      expect(result.recipientFee).to.be.a("number").and.to.be.at.least(0);
+      expect(result.operationalSol).to.be.a("number").and.to.be.at.least(0);
       expect(result.cronJobBalance).to.equal("0");
-      // PDA balance should be a valid number (parseInt will return NaN if invalid)
-      const pdaBalance = parseInt(result.pdaWalletBalance, 10);
-      expect(Number.isNaN(pdaBalance)).to.equal(false);
+      expect(Number.isNaN(parseInt(result.pdaWalletBalance, 10))).to.equal(
+        false
+      );
     });
 
-    it("returns NOT_FOUND error when trying to fund non-existent automation", async () => {
+    it("returns NOT_FOUND when funding a non-existent automation", async () => {
       const walletAddress = payer.publicKey.toBase58();
-
       try {
         await client.hotspots.fundAutomation({
           walletAddress,
@@ -112,9 +120,8 @@ describe("automation endpoints", () => {
       }
     });
 
-    it("returns NOT_FOUND error when trying to close non-existent automation", async () => {
+    it("returns NOT_FOUND when closing a non-existent automation", async () => {
       const walletAddress = payer.publicKey.toBase58();
-
       try {
         await client.hotspots.closeAutomation({ walletAddress });
         expect.fail("Should have thrown NOT_FOUND error");
@@ -124,382 +131,240 @@ describe("automation endpoints", () => {
         expect(error.message).to.include("Automation not found");
       }
     });
+
+    it("returns NOT_FOUND when adding a wallet claim to a non-existent automation", async () => {
+      const walletAddress = payer.publicKey.toBase58();
+      try {
+        await client.hotspots.addWalletToAutomation({ walletAddress });
+        expect.fail("Should have thrown NOT_FOUND error");
+      } catch (error: any) {
+        expect(error).to.be.instanceOf(ORPCError);
+        expect(error.code).to.equal("NOT_FOUND");
+      }
+    });
   });
 
-  describe("with automation", () => {
+  describe("lifecycle", () => {
     let walletAddress: string;
     let totalHotspots: number;
-    const schedule = "daily";
+    let firstEntityKey: string | undefined;
     const duration = 5;
 
     before(async () => {
       walletAddress = payer.publicKey.toBase58();
-      // Get hotspot count first using the API
-      // Note: getHotspots may fail validation in test environment, so we use a default
+      await closeIfExists(walletAddress);
+
       totalHotspots = 1;
       try {
         const hotspotsResult = await client.hotspots.getHotspots({
           walletAddress,
           page: 1,
-          limit: 1,
+          limit: 5,
         });
-        totalHotspots = hotspotsResult.total;
-      } catch (error) {
-        // If getHotspots fails (e.g., validation error), use default of 1 for testing
-        console.log(
-          "getHotspots failed, using default totalHotspots=1 for test"
-        );
+        totalHotspots = hotspotsResult.total || 1;
+        firstEntityKey = hotspotsResult.hotspots[0]?.entityKey;
+      } catch {
+        console.log("getHotspots failed, using default totalHotspots=1");
       }
 
-      if (totalHotspots === 0) {
-        throw new Error(
-          "Cannot set up automation test - no hotspots found for wallet"
-        );
-      }
-
-      // Set up automation
+      // Create the cron itself (init-only, raw cron, pre-funded for `duration`).
       const result = await client.hotspots.createAutomation({
         walletAddress,
-        schedule,
+        cronSchedule: DAILY_CRON,
         duration,
         totalHotspots,
       });
 
-      // Verify transaction was created
-      expect(result.transactionData.transactions.length).to.equal(1);
       expect(result.transactionData.tag).to.equal(
         `setup_automation:${walletAddress}`
       );
-      expect(result.transactionData.parallel).to.equal(false);
-
-      // Verify transaction metadata
       const txData = result.transactionData.transactions[0];
       expect(txData.metadata?.type).to.equal("setup_automation");
-      expect(txData.metadata?.description).to.equal(
-        "Set up hotspot claim automation"
-      );
-      expect(txData.metadata?.schedule).to.equal(schedule);
-      expect(txData.metadata?.duration).to.equal(duration);
-      expect(txData.serializedTransaction.length).to.be.greaterThan(100);
-
-      // Verify batch-level actionMetadata
+      expect(txData.metadata?.cronSchedule).to.equal(DAILY_CRON);
       expect(result.transactionData.actionMetadata).to.deep.include({
         type: "setup_automation",
+        cronSchedule: DAILY_CRON,
       });
 
-      // Submit transaction
-      const signatures = await signAndSubmitTransactionData(
-        connection,
-        result.transactionData,
-        payer
-      );
+      await submit(result.transactionData);
 
-      // Wait for transactions to be finalized
-      const { blockhash, lastValidBlockHeight } =
-        await connection.getLatestBlockhash("finalized");
-      for (const sig of signatures) {
-        await connection.confirmTransaction(
-          { signature: sig, blockhash, lastValidBlockHeight },
-          "finalized"
-        );
-      }
-
-      // Verify automation was created - retry a few times if needed
+      // Wait for the cron to be visible.
       let status = await client.hotspots.getAutomationStatus({ walletAddress });
       let retries = 0;
-      const maxRetries = 10;
-      while (!status.hasExistingAutomation && retries < maxRetries) {
+      while (!status.hasExistingAutomation && retries < 10) {
         await new Promise((resolve) => setTimeout(resolve, 2000));
         status = await client.hotspots.getAutomationStatus({ walletAddress });
         retries++;
       }
-
       if (!status.hasExistingAutomation) {
         throw new Error(
-          `Automation setup failed after ${retries} retries. Status: ${JSON.stringify(
-            status,
-            null,
-            2
-          )}`
+          `Automation setup failed: ${JSON.stringify(status, null, 2)}`
         );
       }
     });
 
-    it("gets automation status showing automation exists", async () => {
+    it("reports the raw cron schedule on status", async () => {
       const result = await client.hotspots.getAutomationStatus({
         walletAddress,
       });
-
       expect(result.hasExistingAutomation).to.equal(true);
       expect(result.isOutOfSol).to.equal(false);
-      expect(result.currentSchedule).to.not.be.undefined;
+      expect(result.currentSchedule?.cron).to.equal(DAILY_CRON);
+      // Best-effort classification of the raw cron for display.
       expect(result.currentSchedule?.schedule).to.equal("daily");
-      expect(result.currentSchedule?.time).to.match(/^\d{1,2}:\d{2}\s(AM|PM)$/);
-      const nextRunDate = new Date(result.currentSchedule!.nextRun);
-      expect(nextRunDate.getTime()).to.be.greaterThan(Date.now());
       expect(result.rentFee).to.equal(0);
-      expect(result.recipientFee).to.be.closeTo(0.00726624, 0.00000001);
-      expect(result.operationalSol).to.equal(0);
-      expect(result.remainingClaims).to.equal(22);
-      expect(result.fundingPeriodInfo?.periodLength).to.equal("daily");
-      expect(result.fundingPeriodInfo?.periodsRemaining).to.equal(22);
-      expect(result.fundingPeriodInfo?.cronJobPeriodsRemaining).to.equal(1035);
-      expect(result.fundingPeriodInfo?.pdaWalletPeriodsRemaining).to.equal(22);
-      expect(result.pdaWalletBalance).to.equal("10850880");
+      expect(result.cronJobBalance).to.match(/^\d+$/);
+      expect(result.pdaWalletBalance).to.match(/^\d+$/);
     });
 
-    it("funds existing automation with additional duration", async () => {
-      const initialStatus = await client.hotspots.getAutomationStatus({
+    it("adds a whole-wallet claim to the cron", async () => {
+      const result = await client.hotspots.addWalletToAutomation({
         walletAddress,
       });
-      const beforeBalance = parseInt(initialStatus.cronJobBalance, 10);
+      expect(result.transactionData.tag).to.equal(
+        `add_wallet_to_automation:${walletAddress}`
+      );
+      expect(result.transactionData.transactions[0].metadata?.type).to.equal(
+        "add_wallet_to_automation"
+      );
+      await submit(result.transactionData);
+    });
 
-      console.log("initialStatus", initialStatus);
+    it("funds existing automation by duration and increases both pools' runway", async () => {
+      const before = await client.hotspots.getAutomationStatus({
+        walletAddress,
+      });
+      const beforeCron = parseInt(before.cronJobBalance, 10);
+      const beforePda = parseInt(before.pdaWalletBalance, 10);
 
       const additionalDuration = 3;
       const result = await client.hotspots.fundAutomation({
         walletAddress,
         additionalDuration,
       });
-
       expect(result.transactionData.tag).to.equal(
         `fund_automation:${walletAddress}`
       );
-      expect(result.transactionData.parallel).to.equal(false);
-
-      // fundAutomation should always return transactions when automation exists
-      expect(result.transactionData.transactions.length).to.equal(1);
       expect(
-        result.transactionData.transactions[0].serializedTransaction.length
-      ).to.be.greaterThan(100);
-
-      // Verify transaction metadata
-      const txData = result.transactionData.transactions[0];
-      expect(txData.metadata?.type).to.equal("fund_automation");
-      expect(txData.metadata?.description).to.equal(
-        "Fund hotspot claim automation"
-      );
-      expect(txData.metadata?.additionalDuration).to.equal(additionalDuration);
-
-      // Submit transaction
-      await signAndSubmitTransactionData(
-        connection,
-        result.transactionData,
-        payer
-      );
-
-      // Wait a bit for transaction to settle
+        result.transactionData.transactions[0].metadata?.additionalDuration
+      ).to.equal(additionalDuration);
+      await submit(result.transactionData);
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
-      // Verify balance increased and pools are balanced
-      const afterStatus = await client.hotspots.getAutomationStatus({
+      const after = await client.hotspots.getAutomationStatus({
         walletAddress,
       });
-      console.log("afterStatus", afterStatus);
-      const beforePdaBalance = parseInt(initialStatus.pdaWalletBalance, 10);
-      const afterCronBalance = parseInt(afterStatus.cronJobBalance, 10);
-      const afterPdaBalance = parseInt(afterStatus.pdaWalletBalance, 10);
-      const cronBalanceIncrease = afterCronBalance - beforeBalance;
-      const pdaBalanceIncrease = afterPdaBalance - beforePdaBalance;
-      // At least one pool should have increased (the one that needed funding)
-      expect(cronBalanceIncrease + pdaBalanceIncrease).to.be.greaterThan(0);
+      const cronIncrease = parseInt(after.cronJobBalance, 10) - beforeCron;
+      const pdaIncrease = parseInt(after.pdaWalletBalance, 10) - beforePda;
+      expect(cronIncrease + pdaIncrease).to.be.greaterThan(0);
+    });
 
-      // Verify that periods remaining increased by the additional duration
-      // Note: We fund each pool independently to reach the target, so pools may not be equal
-      // if one pool already has more periods than the target
-      if (afterStatus.fundingPeriodInfo) {
-        const initialPeriods =
-          initialStatus.fundingPeriodInfo?.periodsRemaining || 0;
-        const afterPeriods = afterStatus.fundingPeriodInfo.periodsRemaining;
-        // Periods should have increased by at least the additional duration
-        // (may be more if one pool was already above the target)
-        expect(afterPeriods).to.be.at.least(
-          initialPeriods + additionalDuration
-        );
-        // The effective periods remaining should be the minimum of both pools
-        expect(afterStatus.fundingPeriodInfo.periodsRemaining).to.equal(
-          Math.min(
-            afterStatus.fundingPeriodInfo.cronJobPeriodsRemaining,
-            afterStatus.fundingPeriodInfo.pdaWalletPeriodsRemaining
-          )
-        );
+    it("adds a single hotspot claim to the cron", async function () {
+      if (!firstEntityKey) {
+        this.skip();
       }
-    });
-
-    it("gets funding estimate for automation", async () => {
-      const duration = 5;
-      const result = await client.hotspots.getFundingEstimate({
+      const result = await client.hotspots.addEntityToAutomation({
         walletAddress,
-        duration,
+        entityKey: firstEntityKey!,
       });
-
-      // Verify funding amounts are calculated correctly (use closeTo for floating point precision)
-      // When automation exists, rentFee should be 0
-      expect(result.rentFee).to.equal(0);
-      // Recipient fee should be 0 because recipient rent was already paid when automation was created
-      expect(result.recipientFee).to.equal(0);
-      // operationalSol should be the sum of cronJobFunding and pdaWalletFunding
-      const calculatedOperationalSol =
-        result.cronJobFunding + result.pdaWalletFunding;
-      expect(result.operationalSol).to.be.closeTo(calculatedOperationalSol, 0.00000001);
-      // totalSolNeeded should be rentFee + operationalSol + recipientFee
-      const calculatedTotalSolNeeded =
-        result.rentFee + result.operationalSol + result.recipientFee;
-      expect(result.totalSolNeeded).to.be.closeTo(
-        calculatedTotalSolNeeded,
-        0.00000001
+      expect(result.transactionData.tag).to.equal(
+        `add_entity_to_automation:${walletAddress}`
       );
-      const cronBalance = parseInt(result.currentCronJobBalance, 10);
-      const pdaBalance = parseInt(result.currentPdaWalletBalance, 10);
-      expect(Number.isNaN(cronBalance)).to.equal(false);
-      expect(Number.isNaN(pdaBalance)).to.equal(false);
+      const meta = result.transactionData.transactions[0].metadata;
+      expect(meta?.type).to.equal("add_entity_to_automation");
+      expect(meta?.entityKey).to.equal(firstEntityKey);
+      await submit(result.transactionData);
     });
 
-    it("returns funding estimate with rentFee when automation does not exist", async () => {
-      // Use a different wallet that doesn't have automation
-      const testWallet = Keypair.generate();
-      await ensureFunds(testWallet.publicKey, 0.01 * LAMPORTS_PER_SOL);
-      const testWalletAddress = testWallet.publicKey.toBase58();
-
-      const result = await client.hotspots.getFundingEstimate({
-        walletAddress: testWalletAddress,
-        duration: 1,
+    it("removes a claim entry by index", async () => {
+      // The whole-wallet claim added first sits at index 0.
+      const result = await client.hotspots.removeEntityFromAutomation({
+        walletAddress,
+        index: 0,
       });
-
-      // When automation doesn't exist, rentFee should include initial setup rent
-      expect(result.rentFee).to.equal(
-        BASE_AUTOMATION_RENT + TASK_RETURN_ACCOUNT_SIZE
+      expect(result.transactionData.tag).to.equal(
+        `remove_entity_from_automation:${walletAddress}`
       );
-      // operationalSol should be the sum of cronJobFunding and pdaWalletFunding
-      const calculatedOperationalSol =
-        result.cronJobFunding + result.pdaWalletFunding;
-      expect(result.operationalSol).to.be.closeTo(calculatedOperationalSol, 0.00000001);
-      // totalSolNeeded should be rentFee + operationalSol + recipientFee
-      const calculatedTotalSolNeeded =
-        result.rentFee + result.operationalSol + result.recipientFee;
-      expect(result.totalSolNeeded).to.be.closeTo(
-        calculatedTotalSolNeeded,
-        0.00000001
+      expect(result.transactionData.transactions[0].metadata?.index).to.equal(
+        0
       );
-      // Balances should be 0 when automation doesn't exist
-      expect(result.currentCronJobBalance).to.equal("0");
-      expect(result.currentPdaWalletBalance).to.equal("0");
+      await submit(result.transactionData);
     });
 
-    it("returns INSUFFICIENT_FUNDS error when wallet doesn't have enough SOL to fund absurdly long duration", async () => {
-      // Use the main wallet which has automation set up
-      // Try to fund with an absurdly long duration that requires more SOL than the wallet has
-      const absurdDuration = 1_000_000_000_000;
-
+    it("rejects removing an out-of-range claim index", async () => {
       try {
-        await client.hotspots.fundAutomation({
+        await client.hotspots.removeEntityFromAutomation({
           walletAddress,
-          additionalDuration: absurdDuration,
+          index: 9999,
         });
-        expect.fail("Should have thrown INSUFFICIENT_FUNDS error");
+        expect.fail("Should have thrown NOT_FOUND error");
       } catch (error: any) {
         expect(error).to.be.instanceOf(ORPCError);
-        expect(error.code).to.equal("INSUFFICIENT_FUNDS");
-        expect(error.message).to.include("Insufficient SOL balance");
-        expect(error.data?.required).to.be.greaterThan(0);
-        expect(error.data?.available).to.be.greaterThan(0);
-        expect(error.data?.required).to.be.greaterThan(error.data?.available);
+        expect(error.code).to.equal("NOT_FOUND");
       }
     });
 
-    it("closes automation and verifies it was removed", async () => {
+    it("closes automation and verifies removal", async () => {
       const result = await client.hotspots.closeAutomation({ walletAddress });
-
-      // Should have at least one transaction (remove entities + close)
-      expect(result.transactionData.transactions.length).to.be.greaterThan(0);
       expect(result.transactionData.tag).to.equal(
         `close_automation:${walletAddress}`
       );
-      expect(result.transactionData.parallel).to.equal(false);
-      expect(
-        result.transactionData.transactions[0].serializedTransaction.length
-      ).to.be.greaterThan(100);
-
-      // Verify transaction metadata
-      const txData = result.transactionData.transactions[0];
-      expect(txData.metadata?.type).to.equal("close_automation");
-      expect(txData.metadata?.description).to.equal(
-        "Close hotspot claim automation"
-      );
-
-      // Submit transaction
-      await signAndSubmitTransactionData(
-        connection,
-        result.transactionData,
-        payer
-      );
-
-      // Wait a bit for transaction to settle
+      await submit(result.transactionData);
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
-      // Verify automation was closed
       const status = await client.hotspots.getAutomationStatus({
         walletAddress,
       });
       expect(status.hasExistingAutomation).to.equal(false);
-      expect(status.isOutOfSol).to.equal(false);
       expect(status.currentSchedule).to.be.undefined;
-      // Rent fee should be back to initial setup cost
-      expect(status.rentFee).to.equal(
-        BASE_AUTOMATION_RENT + TASK_RETURN_ACCOUNT_SIZE
+    });
+  });
+
+  describe("operator floor top-up", () => {
+    it("builds transfers for pools at or below the floor", async () => {
+      const walletAddress = payer.publicKey.toBase58();
+      // A fresh wallet's pools are empty (balance 0), so both are <= floor.
+      const target = Keypair.generate().publicKey.toBase58();
+      const result = await client.hotspots.topUpAutomation({
+        operatorAddress: walletAddress,
+        floorLamports: 1_000_000,
+        fundLamports: 2_000_000,
+        targets: [target],
+      });
+      expect(result.transactionData.tag).to.equal(
+        `top_up_automation:${walletAddress}`
       );
+      // Both pools (cron + claim) for the empty target need funding.
+      expect(result.transactionData.actionMetadata).to.deep.include({
+        type: "top_up_automation",
+        poolsFunded: 2,
+      });
+      expect(
+        result.transactionData.transactions[0].serializedTransaction.length
+      ).to.be.greaterThan(100);
     });
   });
 
   describe("validation", () => {
-    it("validates schedule parameter must be daily, weekly, or monthly", async () => {
+    it("rejects an empty cron schedule", async () => {
       const walletAddress = payer.publicKey.toBase58();
-
-      // Get hotspot count first using the API
-      // Note: getHotspots may fail validation in test environment, so we use a default
-      let totalHotspots = 1;
-      try {
-        const hotspotsResult = await client.hotspots.getHotspots({
-          walletAddress,
-          page: 1,
-          limit: 1,
-        });
-        totalHotspots = hotspotsResult.total;
-      } catch (error) {
-        // If getHotspots fails (e.g., validation error), use default of 1 for testing
-        console.log(
-          "getHotspots failed, using default totalHotspots=1 for test"
-        );
-      }
-
-      if (totalHotspots === 0) {
-        throw new Error(
-          "Cannot test validation - no hotspots found for wallet"
-        );
-      }
-
       try {
         await (client.hotspots.createAutomation as any)({
           walletAddress,
-          schedule: "invalid",
+          cronSchedule: "",
           duration: 5,
-          totalHotspots,
+          totalHotspots: 1,
         });
         expect.fail("Should have thrown a validation error");
       } catch (error: any) {
         expect(error).to.be.instanceOf(Error);
-        // Validation errors might be ORPCError or ValidationError
         if (error instanceof ORPCError) {
           expect(error.code).to.equal("BAD_REQUEST");
         }
-        // Error should mention validation failure
-        expect(error.message.toLowerCase()).to.match(
-          /invalid|validation|schedule/
-        );
       }
     });
 
-    it("validates wallet address format must be valid base58", async () => {
+    it("rejects an invalid wallet address", async () => {
       try {
         await client.hotspots.getAutomationStatus({
           walletAddress: "invalid-address",
@@ -510,7 +375,6 @@ describe("automation endpoints", () => {
         if (error instanceof ORPCError) {
           expect(error.code).to.equal("BAD_REQUEST");
         }
-        // Error should mention validation failure
         expect(error.message.toLowerCase()).to.match(
           /invalid|validation|address/
         );

--- a/packages/blockchain-api/tests/e2e/claim-hotspot-rewards.test.ts
+++ b/packages/blockchain-api/tests/e2e/claim-hotspot-rewards.test.ts
@@ -1,0 +1,130 @@
+import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { sleep } from "@helium/spl-utils";
+import { expect } from "chai";
+import { after, before, describe, it } from "mocha";
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { appRouter } from "@/server/api";
+import type { RouterClient } from "@orpc/server";
+import { applyMinimalServerEnv } from "./helpers/env";
+import { ensureNextServer, stopNextServer } from "./helpers/next";
+import {
+  ensureSurfpool,
+  getSurfpoolRpcUrl,
+  stopSurfpool,
+} from "./helpers/surfpool";
+import {
+  ensureFunds,
+  loadKeypair2FromEnv,
+  loadKeypairFromEnv,
+} from "./helpers/wallet";
+import { signAndSubmitTransactionData } from "./helpers/tx";
+
+const NETWORKS = ["mobile", "iot", "hnt"] as const;
+
+// A real claim can't be synthesized (rewards are oracle-signed for a real,
+// DAS-indexed hotspot), so this uses the real test wallets + ASSET_ENDPOINT.
+// It discovers a hotspot that currently has claimable rewards rather than
+// hardcoding one, since a fixed hotspot may already be drained on mainnet.
+describe("single-hotspot claim rewards", () => {
+  let wallets: Keypair[];
+  let connection: Connection;
+  let client: RouterClient<typeof appRouter>;
+
+  before(async () => {
+    if (!process.env.ASSET_ENDPOINT) {
+      throw new Error("ASSET_ENDPOINT is required for the claim test");
+    }
+    applyMinimalServerEnv();
+    await ensureSurfpool();
+    await ensureNextServer();
+
+    wallets = [loadKeypairFromEnv(), loadKeypair2FromEnv()];
+    connection = new Connection(getSurfpoolRpcUrl(), "confirmed");
+    for (const w of wallets) {
+      await ensureFunds(w.publicKey, 0.05 * LAMPORTS_PER_SOL);
+    }
+
+    const link = new RPCLink({ url: "http://127.0.0.1:3000/rpc" });
+    client = createORPCClient(link);
+  });
+
+  after(async () => {
+    await stopNextServer();
+    await stopSurfpool();
+  });
+
+  const claimableFor = async (
+    walletAddress: string,
+    network: (typeof NETWORKS)[number],
+    entityPubKey: string
+  ): Promise<bigint> => {
+    const pending = await client.hotspots.getPendingRewards({
+      walletAddress,
+      network,
+    });
+    const hotspot = pending.byHotspot.find(
+      (h) => h.hotspotPubKey === entityPubKey
+    );
+    return BigInt(hotspot?.pending.claimable.amount || "0");
+  };
+
+  it("claims the full pending rewards for one hotspot", async () => {
+    // Find a (wallet, network, hotspot) that currently has claimable rewards.
+    let target:
+      | {
+          payer: Keypair;
+          network: (typeof NETWORKS)[number];
+          entityPubKey: string;
+        }
+      | undefined;
+    for (const payer of wallets) {
+      const walletAddress = payer.publicKey.toBase58();
+      for (const network of NETWORKS) {
+        const pending = await client.hotspots.getPendingRewards({
+          walletAddress,
+          network,
+        });
+        const hotspot = pending.byHotspot.find(
+          (h) => BigInt(h.pending.claimable.amount) > 0n
+        );
+        if (hotspot) {
+          target = { payer, network, entityPubKey: hotspot.hotspotPubKey };
+          break;
+        }
+      }
+      if (target) break;
+    }
+
+    expect(
+      target,
+      "no test wallet has a hotspot with claimable rewards on the current fork"
+    ).to.not.be.undefined;
+    const { payer, network, entityPubKey } = target!;
+    const walletAddress = payer.publicKey.toBase58();
+
+    const before = await claimableFor(walletAddress, network, entityPubKey);
+    expect(before).to.be.greaterThan(0n);
+
+    const result = await client.hotspots.claimHotspotRewards({
+      entityPubKey,
+      walletAddress,
+      network,
+    });
+    expect(result.transactionData.transactions.length).to.be.greaterThan(0);
+    expect(
+      result.transactionData.transactions[0].serializedTransaction
+    ).to.be.a("string");
+
+    await signAndSubmitTransactionData(
+      connection,
+      result.transactionData,
+      payer
+    );
+    await sleep(2000);
+
+    // After claiming, the hotspot's claimable rewards should have dropped.
+    const remaining = await claimableFor(walletAddress, network, entityPubKey);
+    expect(remaining).to.be.lessThan(before);
+  });
+});

--- a/packages/blockchain-api/tests/e2e/data-credits-burn.test.ts
+++ b/packages/blockchain-api/tests/e2e/data-credits-burn.test.ts
@@ -1,0 +1,66 @@
+import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { DC_MINT } from "@helium/spl-utils";
+import { expect } from "chai";
+import { after, before, describe, it } from "mocha";
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { appRouter } from "@/server/api";
+import type { RouterClient } from "@orpc/server";
+import { applyMinimalServerEnv } from "./helpers/env";
+import { ensureNextServer, stopNextServer } from "./helpers/next";
+import {
+  ensureSurfpool,
+  getSurfpoolRpcUrl,
+  stopSurfpool,
+} from "./helpers/surfpool";
+import { ensureFunds, ensureTokenBalance } from "./helpers/wallet";
+import { signAndSubmitTransactionData } from "./helpers/tx";
+
+// Direct DC burn needs no real wallet or ASSET_ENDPOINT: the DC balance is
+// synthesized on the surfpool fork via the surfnet_setTokenAccount cheat, so a
+// freshly-generated keypair suffices.
+describe("data-credits burn", () => {
+  let payer: Keypair;
+  let connection: Connection;
+  let client: RouterClient<typeof appRouter>;
+
+  before(async () => {
+    // ASSET_ENDPOINT is unused by the burn path but some server env checks
+    // expect it set; point it at the fork so boot never blocks on it.
+    process.env.ASSET_ENDPOINT ||= getSurfpoolRpcUrl();
+    applyMinimalServerEnv();
+    await ensureSurfpool();
+    await ensureNextServer();
+
+    payer = Keypair.generate();
+    connection = new Connection(getSurfpoolRpcUrl(), "confirmed");
+    await ensureFunds(payer.publicKey, 0.05 * LAMPORTS_PER_SOL);
+    await ensureTokenBalance(payer.publicKey, DC_MINT, 1000); // DC has 0 decimals
+
+    const link = new RPCLink({ url: "http://127.0.0.1:3000/rpc" });
+    client = createORPCClient(link);
+  });
+
+  after(async () => {
+    await stopNextServer();
+    await stopSurfpool();
+  });
+
+  it("burns data credits and reduces the DC balance", async () => {
+    const owner = payer.publicKey.toBase58();
+    const dcAta = getAssociatedTokenAddressSync(DC_MINT, payer.publicKey, true);
+
+    const before = (await connection.getTokenAccountBalance(dcAta)).value
+      .amount;
+    expect(Number(before)).to.equal(1000);
+
+    const txData = await client.dataCredits.burn({ owner, amount: "400" });
+    expect(txData.transactions.length).to.be.greaterThan(0);
+
+    await signAndSubmitTransactionData(connection, txData, payer);
+
+    const after = (await connection.getTokenAccountBalance(dcAta)).value.amount;
+    expect(Number(after)).to.equal(600);
+  });
+});

--- a/packages/blockchain-api/tests/e2e/helpers/squads.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/squads.ts
@@ -1,0 +1,51 @@
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import * as multisig from "@sqds/multisig";
+import assert from "assert";
+
+/**
+ * Create a fresh Squads v4 multisig on the fork and wait for it to be indexed,
+ * returning its PDA. Threshold and members are caller-specified so each test can
+ * shape its own approve/reject/cancel cutoffs.
+ */
+export async function createTestMultisig(params: {
+  connection: Connection;
+  creator: Keypair;
+  threshold: number;
+  members: multisig.types.Member[];
+}): Promise<PublicKey> {
+  const { connection, creator, threshold, members } = params;
+
+  const createKey = Keypair.generate();
+  const [multisigPda] = multisig.getMultisigPda({
+    createKey: createKey.publicKey,
+  });
+  const [programConfigPda] = multisig.getProgramConfigPda({});
+  const programConfig =
+    await multisig.accounts.ProgramConfig.fromAccountAddress(
+      connection,
+      programConfigPda
+    );
+
+  await multisig.rpc.multisigCreateV2({
+    connection,
+    treasury: programConfig.treasury,
+    createKey,
+    creator,
+    multisigPda,
+    configAuthority: null,
+    threshold,
+    members,
+    timeLock: 0,
+    rentCollector: null,
+    sendOptions: { skipPreflight: false },
+  });
+
+  let created = false;
+  for (let i = 0; i < 30 && !created; i++) {
+    created = (await connection.getAccountInfo(multisigPda)) !== null;
+    if (!created) await new Promise((r) => setTimeout(r, 1000));
+  }
+  assert.ok(created, "multisig account was not created on the fork");
+
+  return multisigPda;
+}

--- a/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
@@ -27,6 +27,14 @@ export function getSurfpoolRpcUrl(): string {
   return process.env.SURFPOOL_RPC_URL || "http://127.0.0.1:8899";
 }
 
+// Per-request timeout for health probes. Without this the fetch has no timeout,
+// so a surfpool RPC that accepts the connection but never responds hangs the
+// await forever, blocking the health-wait loop below and defeating its
+// healthTimeoutMs deadline (the loop only re-checks between iterations) — the
+// difference between a clean "did not become healthy in time" failure and a job
+// that hangs until the CI timeout.
+const HEALTH_REQUEST_TIMEOUT_MS = 5000;
+
 async function jsonRpc<T = unknown>(
   method: string,
   params?: unknown,
@@ -36,6 +44,7 @@ async function jsonRpc<T = unknown>(
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    signal: AbortSignal.timeout(HEALTH_REQUEST_TIMEOUT_MS),
   });
   return res.json() as Promise<JsonRpcResponse<T>>;
 }

--- a/packages/blockchain-api/tests/e2e/hotspot-burn.test.ts
+++ b/packages/blockchain-api/tests/e2e/hotspot-burn.test.ts
@@ -1,0 +1,85 @@
+import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { expect } from "chai";
+import { after, before, describe, it } from "mocha";
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { appRouter } from "@/server/api";
+import type { RouterClient } from "@orpc/server";
+import { applyMinimalServerEnv } from "./helpers/env";
+import { ensureNextServer, stopNextServer } from "./helpers/next";
+import {
+  ensureSurfpool,
+  getSurfpoolRpcUrl,
+  stopSurfpool,
+} from "./helpers/surfpool";
+import { ensureFunds, loadKeypairFromEnv } from "./helpers/wallet";
+import { signAndSubmitTransactionData } from "./helpers/tx";
+import { TEST_HOTSPOT_ENTITY_KEY } from "./helpers/constants";
+
+// Burning is destructive, so this runs strictly against the surfpool fork:
+// the burn tx is submitted to 127.0.0.1:8899 and thrown away on teardown — the
+// real hotspot on mainnet is never touched. TEST_HOTSPOT is owned by the test
+// wallet on the freshly-forked mainnet state.
+describe("hotspot burn (fork-only)", () => {
+  let payer: Keypair;
+  let connection: Connection;
+  let client: RouterClient<typeof appRouter>;
+
+  before(async () => {
+    if (!process.env.ASSET_ENDPOINT) {
+      throw new Error("ASSET_ENDPOINT is required for the burn test");
+    }
+    applyMinimalServerEnv();
+    await ensureSurfpool();
+    await ensureNextServer();
+
+    payer = loadKeypairFromEnv();
+    connection = new Connection(getSurfpoolRpcUrl(), "confirmed");
+    await ensureFunds(payer.publicKey, 0.05 * LAMPORTS_PER_SOL);
+
+    const link = new RPCLink({ url: "http://127.0.0.1:3000/rpc" });
+    client = createORPCClient(link);
+  });
+
+  after(async () => {
+    await stopNextServer();
+    await stopSurfpool();
+  });
+
+  it("burns a hotspot on the fork (and a repeat burn fails)", async () => {
+    const walletAddress = payer.publicKey.toBase58();
+
+    // First burn: builds a valid bubblegum burn that confirms on the fork.
+    const result = await client.hotspots.burnHotspot({
+      walletAddress,
+      hotspotPubkey: TEST_HOTSPOT_ENTITY_KEY,
+    });
+    expect(result.transactionData.transactions.length).to.be.greaterThan(0);
+    const sigs = await signAndSubmitTransactionData(
+      connection,
+      result.transactionData,
+      payer
+    );
+    expect(sigs.length).to.equal(1);
+
+    // Second burn of the same hotspot must fail to submit: the fork's merkle
+    // tree changed, so the (mainnet-sourced) proof no longer validates. This
+    // proves the first burn actually mutated on-chain state.
+    const repeat = await client.hotspots.burnHotspot({
+      walletAddress,
+      hotspotPubkey: TEST_HOTSPOT_ENTITY_KEY,
+    });
+    let threw = false;
+    try {
+      await signAndSubmitTransactionData(
+        connection,
+        repeat.transactionData,
+        payer
+      );
+    } catch {
+      threw = true;
+    }
+    expect(threw, "expected a repeat burn to fail after the leaf was burned").to
+      .be.true;
+  });
+});

--- a/packages/blockchain-api/tests/e2e/squads-lifecycle.test.ts
+++ b/packages/blockchain-api/tests/e2e/squads-lifecycle.test.ts
@@ -4,6 +4,8 @@ import assert from "assert";
 import { setupTestCtx, TestCtx } from "./helpers/context";
 import { ensureFunds, loadKeypair2FromEnv } from "./helpers/wallet";
 import { signAndSubmitTransactionData } from "./helpers/tx";
+import { stopNextServer } from "./helpers/next";
+import { stopSurfpool } from "./helpers/surfpool";
 
 /**
  * Drives the Squads v4 proposal lifecycle endpoints against a freshly created
@@ -119,6 +121,11 @@ describe("squads v4 proposal lifecycle", function () {
       2,
       "multisig should start at 2-of-2"
     );
+  });
+
+  after(async () => {
+    await stopNextServer();
+    await stopSurfpool();
   });
 
   it("proposes a config change and rejects it", async () => {

--- a/packages/blockchain-api/tests/e2e/squads-lifecycle.test.ts
+++ b/packages/blockchain-api/tests/e2e/squads-lifecycle.test.ts
@@ -1,0 +1,179 @@
+import { Keypair, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import * as multisig from "@sqds/multisig";
+import assert from "assert";
+import { setupTestCtx, TestCtx } from "./helpers/context";
+import { ensureFunds, loadKeypair2FromEnv } from "./helpers/wallet";
+import { signAndSubmitTransactionData } from "./helpers/tx";
+
+/**
+ * Drives the Squads v4 proposal lifecycle endpoints against a freshly created
+ * multisig on the mainnet fork:
+ *
+ *   proposeConfigChange -> rejectProposal              (proposal ends Rejected)
+ *   proposeConfigChange -> approve x2 -> executeProposal (threshold actually changes)
+ *   proposeConfigChange -> approve   -> cancelProposal   (proposal ends Cancelled)
+ *
+ * The multisig has two members (the two test wallets) so approve/reject/cancel
+ * cutoffs can be reached deterministically. The vault-transaction execute path
+ * is exercised once proposal-mode lands on the action endpoints; here execute
+ * covers the config-transaction path.
+ */
+describe("squads v4 proposal lifecycle", function () {
+  this.timeout(300_000);
+
+  let ctx: TestCtx;
+  let member2: Keypair;
+  let multisigPda: PublicKey;
+
+  const base58 = (k: PublicKey) => k.toBase58();
+
+  async function proposalStatus(index: string): Promise<string> {
+    const [proposalPda] = multisig.getProposalPda({
+      multisigPda,
+      transactionIndex: BigInt(index),
+    });
+    const proposal = await multisig.accounts.Proposal.fromAccountAddress(
+      ctx.connection,
+      proposalPda
+    );
+    return proposal.status.__kind;
+  }
+
+  async function currentThreshold(): Promise<number> {
+    const ms = await multisig.accounts.Multisig.fromAccountAddress(
+      ctx.connection,
+      multisigPda
+    );
+    return ms.threshold;
+  }
+
+  async function proposeChangeThreshold(newThreshold: number): Promise<string> {
+    const res = await ctx.client.squads.proposeConfigChange({
+      member: base58(ctx.payer.publicKey),
+      multisig: base58(multisigPda),
+      actions: [{ type: "changeThreshold", newThreshold }],
+    });
+    await signAndSubmitTransactionData(ctx.connection, res, ctx.payer);
+    return String(
+      (res.actionMetadata as Record<string, unknown>).transactionIndex
+    );
+  }
+
+  async function approve(index: string, signer: Keypair): Promise<void> {
+    const res = await ctx.client.squads.approveProposal({
+      member: base58(signer.publicKey),
+      multisig: base58(multisigPda),
+      transactionIndex: index,
+    });
+    await signAndSubmitTransactionData(ctx.connection, res, signer);
+  }
+
+  before(async () => {
+    ctx = await setupTestCtx();
+    member2 = loadKeypair2FromEnv();
+    await ensureFunds(ctx.payer.publicKey, 0.2 * LAMPORTS_PER_SOL);
+    await ensureFunds(member2.publicKey, 0.1 * LAMPORTS_PER_SOL);
+
+    // Create a fresh 2-of-2 multisig on the fork so proposal cutoffs are
+    // deterministic and we never touch a real mainnet multisig.
+    const createKey = Keypair.generate();
+    [multisigPda] = multisig.getMultisigPda({ createKey: createKey.publicKey });
+    const [programConfigPda] = multisig.getProgramConfigPda({});
+    const programConfig =
+      await multisig.accounts.ProgramConfig.fromAccountAddress(
+        ctx.connection,
+        programConfigPda
+      );
+
+    await multisig.rpc.multisigCreateV2({
+      connection: ctx.connection,
+      treasury: programConfig.treasury,
+      createKey,
+      creator: ctx.payer,
+      multisigPda,
+      configAuthority: null,
+      threshold: 2,
+      members: [
+        {
+          key: ctx.payer.publicKey,
+          permissions: multisig.types.Permissions.all(),
+        },
+        {
+          key: member2.publicKey,
+          permissions: multisig.types.Permissions.all(),
+        },
+      ],
+      timeLock: 0,
+      rentCollector: null,
+      sendOptions: { skipPreflight: false },
+    });
+
+    let created = false;
+    for (let i = 0; i < 30 && !created; i++) {
+      created = (await ctx.connection.getAccountInfo(multisigPda)) !== null;
+      if (!created) await new Promise((r) => setTimeout(r, 1000));
+    }
+    assert.ok(created, "multisig account was not created on the fork");
+    assert.equal(
+      await currentThreshold(),
+      2,
+      "multisig should start at 2-of-2"
+    );
+  });
+
+  it("proposes a config change and rejects it", async () => {
+    // 2-of-2: rejection cutoff is members - threshold + 1 = 1, so one reject
+    // moves the proposal to Rejected.
+    const index = await proposeChangeThreshold(1);
+
+    const res = await ctx.client.squads.rejectProposal({
+      member: base58(ctx.payer.publicKey),
+      multisig: base58(multisigPda),
+      transactionIndex: index,
+    });
+    await signAndSubmitTransactionData(ctx.connection, res, ctx.payer);
+
+    assert.equal(await proposalStatus(index), "Rejected");
+  });
+
+  it("proposes, approves, and executes a config change", async () => {
+    const index = await proposeChangeThreshold(1);
+
+    await approve(index, ctx.payer);
+    await approve(index, member2);
+    assert.equal(await proposalStatus(index), "Approved");
+
+    const res = await ctx.client.squads.executeProposal({
+      member: base58(ctx.payer.publicKey),
+      multisig: base58(multisigPda),
+      transactionIndex: index,
+    });
+    assert.equal(
+      (res.actionMetadata as Record<string, unknown>).kind,
+      "config",
+      "execute should detect a config transaction"
+    );
+    await signAndSubmitTransactionData(ctx.connection, res, ctx.payer);
+
+    assert.equal(await proposalStatus(index), "Executed");
+    assert.equal(await currentThreshold(), 1, "threshold should now be 1-of-2");
+  });
+
+  it("cancels an approved proposal", async () => {
+    // threshold is now 1: one approve moves the proposal to Approved, and the
+    // cancel cutoff (= threshold) is likewise 1.
+    const index = await proposeChangeThreshold(2);
+
+    await approve(index, ctx.payer);
+    assert.equal(await proposalStatus(index), "Approved");
+
+    const res = await ctx.client.squads.cancelProposal({
+      member: base58(ctx.payer.publicKey),
+      multisig: base58(multisigPda),
+      transactionIndex: index,
+    });
+    await signAndSubmitTransactionData(ctx.connection, res, ctx.payer);
+
+    assert.equal(await proposalStatus(index), "Cancelled");
+  });
+});

--- a/packages/blockchain-api/tests/e2e/squads-lifecycle.test.ts
+++ b/packages/blockchain-api/tests/e2e/squads-lifecycle.test.ts
@@ -4,6 +4,7 @@ import assert from "assert";
 import { setupTestCtx, TestCtx } from "./helpers/context";
 import { ensureFunds, loadKeypair2FromEnv } from "./helpers/wallet";
 import { signAndSubmitTransactionData } from "./helpers/tx";
+import { createTestMultisig } from "./helpers/squads";
 import { stopNextServer } from "./helpers/next";
 import { stopSurfpool } from "./helpers/surfpool";
 
@@ -78,22 +79,9 @@ describe("squads v4 proposal lifecycle", function () {
 
     // Create a fresh 2-of-2 multisig on the fork so proposal cutoffs are
     // deterministic and we never touch a real mainnet multisig.
-    const createKey = Keypair.generate();
-    [multisigPda] = multisig.getMultisigPda({ createKey: createKey.publicKey });
-    const [programConfigPda] = multisig.getProgramConfigPda({});
-    const programConfig =
-      await multisig.accounts.ProgramConfig.fromAccountAddress(
-        ctx.connection,
-        programConfigPda
-      );
-
-    await multisig.rpc.multisigCreateV2({
+    multisigPda = await createTestMultisig({
       connection: ctx.connection,
-      treasury: programConfig.treasury,
-      createKey,
       creator: ctx.payer,
-      multisigPda,
-      configAuthority: null,
       threshold: 2,
       members: [
         {
@@ -105,17 +93,7 @@ describe("squads v4 proposal lifecycle", function () {
           permissions: multisig.types.Permissions.all(),
         },
       ],
-      timeLock: 0,
-      rentCollector: null,
-      sendOptions: { skipPreflight: false },
     });
-
-    let created = false;
-    for (let i = 0; i < 30 && !created; i++) {
-      created = (await ctx.connection.getAccountInfo(multisigPda)) !== null;
-      if (!created) await new Promise((r) => setTimeout(r, 1000));
-    }
-    assert.ok(created, "multisig account was not created on the fork");
     assert.equal(
       await currentThreshold(),
       2,

--- a/packages/blockchain-api/tests/e2e/squads-propose.test.ts
+++ b/packages/blockchain-api/tests/e2e/squads-propose.test.ts
@@ -10,6 +10,7 @@ import {
   loadKeypair2FromEnv,
 } from "./helpers/wallet";
 import { signAndSubmitTransactionData } from "./helpers/tx";
+import { createTestMultisig } from "./helpers/squads";
 import { TEST_HOTSPOT_ENTITY_KEY } from "./helpers/constants";
 import { stopNextServer } from "./helpers/next";
 import { stopSurfpool } from "./helpers/surfpool";
@@ -86,21 +87,9 @@ describe("squads v4 propose-mode (token transfer)", function () {
     recipient = loadKeypair2FromEnv();
     await ensureFunds(ctx.payer.publicKey, 0.2 * LAMPORTS_PER_SOL);
 
-    const createKey = Keypair.generate();
-    [multisigPda] = multisig.getMultisigPda({ createKey: createKey.publicKey });
-    const [programConfigPda] = multisig.getProgramConfigPda({});
-    const programConfig =
-      await multisig.accounts.ProgramConfig.fromAccountAddress(
-        ctx.connection,
-        programConfigPda
-      );
-    await multisig.rpc.multisigCreateV2({
+    multisigPda = await createTestMultisig({
       connection: ctx.connection,
-      treasury: programConfig.treasury,
-      createKey,
       creator: ctx.payer,
-      multisigPda,
-      configAuthority: null,
       threshold: 1,
       members: [
         {
@@ -108,17 +97,7 @@ describe("squads v4 propose-mode (token transfer)", function () {
           permissions: multisig.types.Permissions.all(),
         },
       ],
-      timeLock: 0,
-      rentCollector: null,
-      sendOptions: { skipPreflight: false },
     });
-
-    let created = false;
-    for (let i = 0; i < 30 && !created; i++) {
-      created = (await ctx.connection.getAccountInfo(multisigPda)) !== null;
-      if (!created) await new Promise((r) => setTimeout(r, 1000));
-    }
-    assert.ok(created, "multisig account was not created on the fork");
 
     vault = multisig.getVaultPda({ multisigPda, index: 0 })[0];
     // Fund the vault with HNT (+ a little SOL), and pre-create the recipient's

--- a/packages/blockchain-api/tests/e2e/squads-propose.test.ts
+++ b/packages/blockchain-api/tests/e2e/squads-propose.test.ts
@@ -1,6 +1,6 @@
 import { Keypair, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
-import { DC_MINT, HNT_MINT } from "@helium/spl-utils";
+import { DC_MINT, HNT_MINT, IOT_MINT } from "@helium/spl-utils";
 import * as multisig from "@sqds/multisig";
 import assert from "assert";
 import { setupTestCtx, TestCtx } from "./helpers/context";
@@ -241,6 +241,30 @@ describe("squads v4 propose-mode (token transfer)", function () {
       (before - (await tokenBalance(vault, DC_MINT))).toString(),
       amount,
       "vault DC should be reduced by the burned amount"
+    );
+  });
+
+  it("proposes, approves, and executes a DC delegation from the vault", async () => {
+    await ensureTokenBalance(vault, DC_MINT, 100);
+    const dcBefore = await tokenBalance(vault, DC_MINT);
+    const delegateAmount = "5";
+
+    const propose = await ctx.client.dataCredits.delegate({
+      owner: base58(ctx.payer.publicKey),
+      routerKey: "test-router-squads",
+      amount: delegateAmount,
+      mint: base58(IOT_MINT),
+      multisig: base58(multisigPda),
+    });
+    const meta = propose.actionMetadata as Record<string, unknown>;
+    assert.equal(meta.type, "delegate_data_credits_proposal");
+    await signAndSubmitTransactionData(ctx.connection, propose, ctx.payer);
+    await approveAndExecute(String(meta.transactionIndex));
+
+    assert.equal(
+      (dcBefore - (await tokenBalance(vault, DC_MINT))).toString(),
+      delegateAmount,
+      "vault DC should be reduced by the delegated amount"
     );
   });
 

--- a/packages/blockchain-api/tests/e2e/squads-propose.test.ts
+++ b/packages/blockchain-api/tests/e2e/squads-propose.test.ts
@@ -11,6 +11,8 @@ import {
 } from "./helpers/wallet";
 import { signAndSubmitTransactionData } from "./helpers/tx";
 import { TEST_HOTSPOT_ENTITY_KEY } from "./helpers/constants";
+import { stopNextServer } from "./helpers/next";
+import { stopSurfpool } from "./helpers/surfpool";
 
 /**
  * Exercises the token-transfer endpoint's Squads propose mode end to end: the
@@ -124,6 +126,11 @@ describe("squads v4 propose-mode (token transfer)", function () {
     await ensureFunds(vault, 0.05 * LAMPORTS_PER_SOL);
     await ensureTokenBalance(vault, HNT_MINT, 5);
     await ensureTokenBalance(recipient.publicKey, HNT_MINT, 1);
+  });
+
+  after(async () => {
+    await stopNextServer();
+    await stopSurfpool();
   });
 
   it("proposes, approves, and executes a transfer from the vault", async () => {

--- a/packages/blockchain-api/tests/e2e/squads-propose.test.ts
+++ b/packages/blockchain-api/tests/e2e/squads-propose.test.ts
@@ -10,6 +10,7 @@ import {
   loadKeypair2FromEnv,
 } from "./helpers/wallet";
 import { signAndSubmitTransactionData } from "./helpers/tx";
+import { TEST_HOTSPOT_ENTITY_KEY } from "./helpers/constants";
 
 /**
  * Exercises the token-transfer endpoint's Squads propose mode end to end: the
@@ -240,6 +241,24 @@ describe("squads v4 propose-mode (token transfer)", function () {
       (before - (await tokenBalance(vault, DC_MINT))).toString(),
       amount,
       "vault DC should be reduced by the burned amount"
+    );
+  });
+
+  // The cNFT propose happy path can't run on a fork (the vault would have to
+  // actually own the hotspot per the real DAS index, which surfpool can't set
+  // up). This negative case still confirms the propose-mode branch is reached
+  // and the ownership guard compares against the vault rather than walletAddress.
+  it("rejects a hotspot burn proposal when the vault does not own the hotspot", async () => {
+    await assert.rejects(
+      ctx.client.hotspots.burnHotspot({
+        walletAddress: base58(ctx.payer.publicKey),
+        hotspotPubkey: TEST_HOTSPOT_ENTITY_KEY,
+        multisig: base58(multisigPda),
+      }),
+      (err: unknown) => {
+        assert.match(String((err as Error)?.message ?? err), /owner/i);
+        return true;
+      }
     );
   });
 });

--- a/packages/blockchain-api/tests/e2e/squads-propose.test.ts
+++ b/packages/blockchain-api/tests/e2e/squads-propose.test.ts
@@ -1,0 +1,153 @@
+import { Keypair, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { HNT_MINT } from "@helium/spl-utils";
+import * as multisig from "@sqds/multisig";
+import assert from "assert";
+import { setupTestCtx, TestCtx } from "./helpers/context";
+import {
+  ensureFunds,
+  ensureTokenBalance,
+  loadKeypair2FromEnv,
+} from "./helpers/wallet";
+import { signAndSubmitTransactionData } from "./helpers/tx";
+
+/**
+ * Exercises the token-transfer endpoint's Squads propose mode end to end: the
+ * transfer is built with the vault as the source authority, wrapped into a
+ * vaultTransactionCreate + proposalCreate proposal, then approved and executed
+ * so the vault actually pays out. This also covers executeProposal's
+ * vault-transaction path (the config path is covered in squads-lifecycle).
+ *
+ * A 1-of-1 multisig keeps the flow to a single approve + execute by the payer.
+ */
+describe("squads v4 propose-mode (token transfer)", function () {
+  this.timeout(300_000);
+
+  let ctx: TestCtx;
+  let recipient: Keypair;
+  let multisigPda: PublicKey;
+  let vault: PublicKey;
+
+  const base58 = (k: PublicKey) => k.toBase58();
+
+  async function hntBalance(owner: PublicKey): Promise<bigint> {
+    const ata = getAssociatedTokenAddressSync(HNT_MINT, owner, true);
+    const res = await ctx.connection
+      .getTokenAccountBalance(ata)
+      .catch(() => null);
+    return res ? BigInt(res.value.amount) : BigInt(0);
+  }
+
+  before(async () => {
+    ctx = await setupTestCtx();
+    recipient = loadKeypair2FromEnv();
+    await ensureFunds(ctx.payer.publicKey, 0.2 * LAMPORTS_PER_SOL);
+
+    const createKey = Keypair.generate();
+    [multisigPda] = multisig.getMultisigPda({ createKey: createKey.publicKey });
+    const [programConfigPda] = multisig.getProgramConfigPda({});
+    const programConfig =
+      await multisig.accounts.ProgramConfig.fromAccountAddress(
+        ctx.connection,
+        programConfigPda
+      );
+    await multisig.rpc.multisigCreateV2({
+      connection: ctx.connection,
+      treasury: programConfig.treasury,
+      createKey,
+      creator: ctx.payer,
+      multisigPda,
+      configAuthority: null,
+      threshold: 1,
+      members: [
+        {
+          key: ctx.payer.publicKey,
+          permissions: multisig.types.Permissions.all(),
+        },
+      ],
+      timeLock: 0,
+      rentCollector: null,
+      sendOptions: { skipPreflight: false },
+    });
+
+    let created = false;
+    for (let i = 0; i < 30 && !created; i++) {
+      created = (await ctx.connection.getAccountInfo(multisigPda)) !== null;
+      if (!created) await new Promise((r) => setTimeout(r, 1000));
+    }
+    assert.ok(created, "multisig account was not created on the fork");
+
+    vault = multisig.getVaultPda({ multisigPda, index: 0 })[0];
+    // Fund the vault with HNT (+ a little SOL), and pre-create the recipient's
+    // HNT ATA so the transfer needs no rent at execution time.
+    await ensureFunds(vault, 0.05 * LAMPORTS_PER_SOL);
+    await ensureTokenBalance(vault, HNT_MINT, 5);
+    await ensureTokenBalance(recipient.publicKey, HNT_MINT, 1);
+  });
+
+  it("proposes, approves, and executes a transfer from the vault", async () => {
+    const amount = "200000000"; // 2 HNT (8 decimals)
+    const vaultBefore = await hntBalance(vault);
+    const recipientBefore = await hntBalance(recipient.publicKey);
+
+    const propose = await ctx.client.tokens.transfer({
+      walletAddress: base58(ctx.payer.publicKey),
+      destination: base58(recipient.publicKey),
+      tokenAmount: { amount, mint: base58(HNT_MINT) },
+      multisig: base58(multisigPda),
+    });
+    const meta = propose.transactionData.actionMetadata as Record<
+      string,
+      unknown
+    >;
+    assert.equal(meta.type, "token_transfer_proposal");
+    await signAndSubmitTransactionData(
+      ctx.connection,
+      propose.transactionData,
+      ctx.payer
+    );
+    const index = String(meta.transactionIndex);
+
+    const approve = await ctx.client.squads.approveProposal({
+      member: base58(ctx.payer.publicKey),
+      multisig: base58(multisigPda),
+      transactionIndex: index,
+    });
+    await signAndSubmitTransactionData(ctx.connection, approve, ctx.payer);
+
+    const execute = await ctx.client.squads.executeProposal({
+      member: base58(ctx.payer.publicKey),
+      multisig: base58(multisigPda),
+      transactionIndex: index,
+    });
+    assert.equal(
+      (execute.actionMetadata as Record<string, unknown>).kind,
+      "vault",
+      "execute should detect a vault transaction"
+    );
+    await signAndSubmitTransactionData(ctx.connection, execute, ctx.payer);
+
+    const [proposalPda] = multisig.getProposalPda({
+      multisigPda,
+      transactionIndex: BigInt(index),
+    });
+    const proposal = await multisig.accounts.Proposal.fromAccountAddress(
+      ctx.connection,
+      proposalPda
+    );
+    assert.equal(proposal.status.__kind, "Executed");
+
+    const vaultAfter = await hntBalance(vault);
+    const recipientAfter = await hntBalance(recipient.publicKey);
+    assert.equal(
+      (recipientAfter - recipientBefore).toString(),
+      amount,
+      "recipient should receive 2 HNT"
+    );
+    assert.equal(
+      (vaultBefore - vaultAfter).toString(),
+      amount,
+      "vault should be debited 2 HNT"
+    );
+  });
+});

--- a/packages/blockchain-api/tests/e2e/squads-propose.test.ts
+++ b/packages/blockchain-api/tests/e2e/squads-propose.test.ts
@@ -1,6 +1,6 @@
 import { Keypair, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
-import { HNT_MINT } from "@helium/spl-utils";
+import { DC_MINT, HNT_MINT } from "@helium/spl-utils";
 import * as multisig from "@sqds/multisig";
 import assert from "assert";
 import { setupTestCtx, TestCtx } from "./helpers/context";
@@ -30,12 +30,52 @@ describe("squads v4 propose-mode (token transfer)", function () {
 
   const base58 = (k: PublicKey) => k.toBase58();
 
-  async function hntBalance(owner: PublicKey): Promise<bigint> {
-    const ata = getAssociatedTokenAddressSync(HNT_MINT, owner, true);
+  async function tokenBalance(
+    owner: PublicKey,
+    mint: PublicKey
+  ): Promise<bigint> {
+    const ata = getAssociatedTokenAddressSync(mint, owner, true);
     const res = await ctx.connection
       .getTokenAccountBalance(ata)
       .catch(() => null);
     return res ? BigInt(res.value.amount) : BigInt(0);
+  }
+
+  const hntBalance = (owner: PublicKey) => tokenBalance(owner, HNT_MINT);
+
+  /**
+   * Sign+submit the proposal, then approve and execute it as the sole member
+   * (1-of-1), asserting the proposal ends Executed. Returns nothing.
+   */
+  async function approveAndExecute(index: string): Promise<void> {
+    const approve = await ctx.client.squads.approveProposal({
+      member: base58(ctx.payer.publicKey),
+      multisig: base58(multisigPda),
+      transactionIndex: index,
+    });
+    await signAndSubmitTransactionData(ctx.connection, approve, ctx.payer);
+
+    const execute = await ctx.client.squads.executeProposal({
+      member: base58(ctx.payer.publicKey),
+      multisig: base58(multisigPda),
+      transactionIndex: index,
+    });
+    assert.equal(
+      (execute.actionMetadata as Record<string, unknown>).kind,
+      "vault",
+      "execute should detect a vault transaction"
+    );
+    await signAndSubmitTransactionData(ctx.connection, execute, ctx.payer);
+
+    const [proposalPda] = multisig.getProposalPda({
+      multisigPda,
+      transactionIndex: BigInt(index),
+    });
+    const proposal = await multisig.accounts.Proposal.fromAccountAddress(
+      ctx.connection,
+      proposalPda
+    );
+    assert.equal(proposal.status.__kind, "Executed");
   }
 
   before(async () => {
@@ -148,6 +188,58 @@ describe("squads v4 propose-mode (token transfer)", function () {
       (vaultBefore - vaultAfter).toString(),
       amount,
       "vault should be debited 2 HNT"
+    );
+  });
+
+  it("proposes, approves, and executes a token burn from the vault", async () => {
+    const amount = "100000000"; // 1 HNT
+    const before = await hntBalance(vault);
+
+    const propose = await ctx.client.tokens.burn({
+      walletAddress: base58(ctx.payer.publicKey),
+      tokenAmount: { amount, mint: base58(HNT_MINT) },
+      multisig: base58(multisigPda),
+    });
+    const meta = propose.transactionData.actionMetadata as Record<
+      string,
+      unknown
+    >;
+    assert.equal(meta.type, "token_burn_proposal");
+    await signAndSubmitTransactionData(
+      ctx.connection,
+      propose.transactionData,
+      ctx.payer
+    );
+    await approveAndExecute(String(meta.transactionIndex));
+
+    assert.equal(
+      (before - (await hntBalance(vault))).toString(),
+      amount,
+      "vault HNT should be reduced by the burned amount"
+    );
+  });
+
+  it("proposes, approves, and executes a DC burn from the vault", async () => {
+    await ensureFunds(vault, 0.05 * LAMPORTS_PER_SOL);
+    await ensureTokenBalance(vault, DC_MINT, 100); // DC has 0 decimals
+    const amount = "10";
+    const before = await tokenBalance(vault, DC_MINT);
+
+    // dataCredits/burn returns the bare TransactionData (no envelope).
+    const propose = await ctx.client.dataCredits.burn({
+      owner: base58(ctx.payer.publicKey),
+      amount,
+      multisig: base58(multisigPda),
+    });
+    const meta = propose.actionMetadata as Record<string, unknown>;
+    assert.equal(meta.type, "burn_data_credits_proposal");
+    await signAndSubmitTransactionData(ctx.connection, propose, ctx.payer);
+    await approveAndExecute(String(meta.transactionIndex));
+
+    assert.equal(
+      (before - (await tokenBalance(vault, DC_MINT))).toString(),
+      amount,
+      "vault DC should be reduced by the burned amount"
     );
   });
 });

--- a/packages/blockchain-api/tests/e2e/token-burn-memo.test.ts
+++ b/packages/blockchain-api/tests/e2e/token-burn-memo.test.ts
@@ -1,0 +1,91 @@
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+} from "@solana/web3.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { expect } from "chai";
+import { after, before, describe, it } from "mocha";
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { appRouter } from "@/server/api";
+import type { RouterClient } from "@orpc/server";
+import { TOKEN_MINTS } from "../../src/lib/constants/tokens";
+import { applyMinimalServerEnv } from "./helpers/env";
+import { ensureNextServer, stopNextServer } from "./helpers/next";
+import {
+  ensureSurfpool,
+  getSurfpoolRpcUrl,
+  stopSurfpool,
+} from "./helpers/surfpool";
+import { ensureFunds, ensureTokenBalance } from "./helpers/wallet";
+import { signAndSubmitTransactionData } from "./helpers/tx";
+
+// Token burn and memo need no real wallet or ASSET_ENDPOINT: burn synthesizes
+// the SPL balance on the surfpool fork via surfnet_setTokenAccount, and memo
+// only needs SOL (airdropped). A freshly-generated keypair suffices.
+describe("token burn and memo", () => {
+  let payer: Keypair;
+  let connection: Connection;
+  let client: RouterClient<typeof appRouter>;
+
+  before(async () => {
+    process.env.ASSET_ENDPOINT ||= getSurfpoolRpcUrl();
+    applyMinimalServerEnv();
+    await ensureSurfpool();
+    await ensureNextServer();
+
+    payer = Keypair.generate();
+    connection = new Connection(getSurfpoolRpcUrl(), "confirmed");
+    await ensureFunds(payer.publicKey, 0.05 * LAMPORTS_PER_SOL);
+
+    const link = new RPCLink({ url: "http://127.0.0.1:3000/rpc" });
+    client = createORPCClient(link);
+  });
+
+  after(async () => {
+    await stopNextServer();
+    await stopSurfpool();
+  });
+
+  it("burns SPL tokens and reduces the balance", async () => {
+    const hntMint = new PublicKey(TOKEN_MINTS.HNT);
+    await ensureTokenBalance(payer.publicKey, hntMint, 5); // 5 HNT (8 decimals)
+    const ata = getAssociatedTokenAddressSync(hntMint, payer.publicKey, true);
+
+    const before = (await connection.getTokenAccountBalance(ata)).value.amount;
+    expect(Number(before)).to.equal(500_000_000);
+
+    const txData = await client.tokens.burn({
+      walletAddress: payer.publicKey.toBase58(),
+      tokenAmount: { amount: "100000000", mint: TOKEN_MINTS.HNT }, // burn 1 HNT
+    });
+    expect(txData.transactionData.transactions.length).to.be.greaterThan(0);
+
+    await signAndSubmitTransactionData(
+      connection,
+      txData.transactionData,
+      payer
+    );
+
+    const after = (await connection.getTokenAccountBalance(ata)).value.amount;
+    expect(Number(after)).to.equal(400_000_000);
+  });
+
+  it("emits a memo transaction that confirms", async () => {
+    const txData = await client.tokens.memo({
+      walletAddress: payer.publicKey.toBase58(),
+      memo: "helium-wallet e2e memo",
+    });
+    expect(txData.transactionData.transactions.length).to.equal(1);
+
+    // signAndSubmitTransactionData throws if the tx fails to confirm.
+    const sigs = await signAndSubmitTransactionData(
+      connection,
+      txData.transactionData,
+      payer
+    );
+    expect(sigs.length).to.equal(1);
+  });
+});

--- a/packages/blockchain-api/tests/unit/automation-helpers.test.ts
+++ b/packages/blockchain-api/tests/unit/automation-helpers.test.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { resolveScheduleToCron } from "../../src/lib/utils/automation-helpers";
+
+describe("resolveScheduleToCron", () => {
+  it("passes a raw crontab string through unchanged", () => {
+    const raw = "0 30 14 * * 1";
+    expect(resolveScheduleToCron(raw)).to.equal(raw);
+  });
+
+  it("resolves each preset to a 6-field crontab (not the preset literal)", () => {
+    for (const preset of ["daily", "weekly", "monthly"]) {
+      const cron = resolveScheduleToCron(preset);
+      expect(cron).to.not.equal(preset);
+      // sec min hour dom month dow
+      expect(cron.split(" ")).to.have.lengthOf(6);
+    }
+  });
+
+  it("maps daily to an every-day crontab (wildcard dom/month/dow)", () => {
+    const [, , , dom, month, dow] = resolveScheduleToCron("daily").split(" ");
+    expect([dom, month, dow]).to.deep.equal(["*", "*", "*"]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,7 +171,7 @@ importers:
     dependencies:
       '@solana/web3.js':
         specifier: 1.98.2
-        version: 1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
     devDependencies:
       git-format-staged:
         specifier: ^2.1.3
@@ -657,19 +657,19 @@ importers:
         version: 1.13.6(@opentelemetry/api@1.9.0)
       '@orpc/json-schema':
         specifier: 1.13.6
-        version: 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+        version: 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))
       '@orpc/openapi':
         specifier: 1.13.6
-        version: 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+        version: 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))
       '@orpc/server':
         specifier: 1.13.6
-        version: 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+        version: 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))
       '@orpc/tanstack-query':
         specifier: 1.13.6
         version: 1.13.6(@opentelemetry/api@1.9.0)(@orpc/client@1.13.6(@opentelemetry/api@1.9.0))(@tanstack/query-core@5.90.20)
       '@orpc/zod':
         specifier: 1.13.6
-        version: 1.13.6(@opentelemetry/api@1.9.0)(@orpc/contract@1.13.6(@opentelemetry/api@1.9.0))(@orpc/server@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10)))(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))(zod@4.3.6)
+        version: 1.13.6(@opentelemetry/api@1.9.0)(@orpc/contract@1.13.6(@opentelemetry/api@1.9.0))(@orpc/server@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10)))(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))(zod@4.3.6)
       '@privy-io/react-auth':
         specifier: ^2.20.0
         version: 2.25.0(@react-native-async-storage/async-storage@1.19.3(react-native@0.72.17(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(bufferutil@4.0.7)(encoding@0.1.13)(react@19.2.6)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.0.7)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/spl-token@0.4.14(@solana/web3.js@1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.0.7)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.0.7)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -709,6 +709,9 @@ importers:
       '@solana/web3.js':
         specifier: 1.98.2
         version: 1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@sqds/multisig':
+        specifier: ^2.1.4
+        version: 2.1.4(bufferutil@4.0.7)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@t3-oss/env-nextjs':
         specifier: ^0.13.8
         version: 0.13.10(typescript@5.9.3)(zod@4.3.6)
@@ -6933,6 +6936,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -7693,6 +7697,7 @@ packages:
 
   '@sqds/sdk@2.0.4':
     resolution: {integrity: sha512-SmwqL55GW9teIPRqYBVUp1tNp3Tfd8olPShas/+5L48XaUHBDEFNuDA9E8KKbIZoB34WSLdgyq0tIJLlhMMHnA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
@@ -8408,6 +8413,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -10735,16 +10741,16 @@ packages:
 
   glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -18471,12 +18477,12 @@ snapshots:
 
   '@orpc/interop@1.13.6': {}
 
-  '@orpc/json-schema@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))':
+  '@orpc/json-schema@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))':
     dependencies:
       '@orpc/contract': 1.13.6(@opentelemetry/api@1.9.0)
       '@orpc/interop': 1.13.6
-      '@orpc/openapi': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
-      '@orpc/server': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+      '@orpc/openapi': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+      '@orpc/server': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))
       '@orpc/shared': 1.13.6(@opentelemetry/api@1.9.0)
       json-schema-typed: 8.0.2
     transitivePeerDependencies:
@@ -18494,13 +18500,13 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/openapi@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))':
+  '@orpc/openapi@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))':
     dependencies:
       '@orpc/client': 1.13.6(@opentelemetry/api@1.9.0)
       '@orpc/contract': 1.13.6(@opentelemetry/api@1.9.0)
       '@orpc/interop': 1.13.6
       '@orpc/openapi-client': 1.13.6(@opentelemetry/api@1.9.0)
-      '@orpc/server': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+      '@orpc/server': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))
       '@orpc/shared': 1.13.6(@opentelemetry/api@1.9.0)
       '@orpc/standard-server': 1.13.6(@opentelemetry/api@1.9.0)
       json-schema-typed: 8.0.2
@@ -18511,7 +18517,7 @@ snapshots:
       - fastify
       - ws
 
-  '@orpc/server@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))':
+  '@orpc/server@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))':
     dependencies:
       '@orpc/client': 1.13.6(@opentelemetry/api@1.9.0)
       '@orpc/contract': 1.13.6(@opentelemetry/api@1.9.0)
@@ -18526,7 +18532,7 @@ snapshots:
       cookie: 1.1.1
     optionalDependencies:
       crossws: 0.3.5
-      ws: 7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+      ws: 8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - fastify
@@ -18591,12 +18597,12 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/zod@1.13.6(@opentelemetry/api@1.9.0)(@orpc/contract@1.13.6(@opentelemetry/api@1.9.0))(@orpc/server@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10)))(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))(zod@4.3.6)':
+  '@orpc/zod@1.13.6(@opentelemetry/api@1.9.0)(@orpc/contract@1.13.6(@opentelemetry/api@1.9.0))(@orpc/server@1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10)))(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))(zod@4.3.6)':
     dependencies:
       '@orpc/contract': 1.13.6(@opentelemetry/api@1.9.0)
-      '@orpc/json-schema': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
-      '@orpc/openapi': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
-      '@orpc/server': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+      '@orpc/json-schema': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+      '@orpc/openapi': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+      '@orpc/server': 1.13.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10))
       '@orpc/shared': 1.13.6(@opentelemetry/api@1.9.0)
       escape-string-regexp: 5.0.0
       wildcard-match: 5.1.4
@@ -21709,6 +21715,29 @@ snapshots:
       buffer: 6.0.3
       fast-stable-stringify: 1.0.0
       jayson: 4.1.3(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+      node-fetch: 2.7.0(encoding@0.1.13)
+      rpc-websockets: 9.3.7
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@solana/web3.js@1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@solana/buffer-layout': 4.0.1
+      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
+      agentkeepalive: 4.6.0
+      bn.js: 5.2.3
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.3
+      fast-stable-stringify: 1.0.0
+      jayson: 4.1.3(bufferutil@4.0.7)(utf-8-validate@6.0.6)
       node-fetch: 2.7.0(encoding@0.1.13)
       rpc-websockets: 9.3.7
       superstruct: 2.0.2
@@ -26413,6 +26442,10 @@ snapshots:
     dependencies:
       ws: 7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10)
 
+  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 7.5.10(bufferutil@4.0.7)(utf-8-validate@6.0.6)
+
   isows@1.0.6(ws@8.18.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)):
     dependencies:
       ws: 8.18.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -26458,6 +26491,24 @@ snapshots:
       json-stringify-safe: 5.0.1
       uuid: 8.3.2
       ws: 7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  jayson@4.1.3(bufferutil@4.0.7)(utf-8-validate@6.0.6):
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 12.20.55
+      '@types/ws': 7.4.7
+      JSONStream: 1.3.5
+      commander: 2.20.3
+      delay: 5.0.0
+      es6-promisify: 5.0.0
+      eyes: 0.1.8
+      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@6.0.6))
+      json-stringify-safe: 5.0.1
+      uuid: 8.3.2
+      ws: 7.5.10(bufferutil@4.0.7)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -30485,6 +30536,11 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.7
       utf-8-validate: 5.0.10
+
+  ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.0.7
+      utf-8-validate: 6.0.6
 
   ws@8.18.0(bufferutil@4.0.7)(utf-8-validate@5.0.10):
     optionalDependencies:


### PR DESCRIPTION
Adds the blockchain-api endpoints that let the `helium-wallet` CLI build all of its Solana transactions server-side and sign + submit locally. This is the API counterpart to helium-wallet-rs#560; together they move transaction construction out of the wallet SDK and behind the API.

## Endpoint groups
- **Tokens**: transfer, multi-transfer, burn, memo.
- **Data credits**: burn, mint, delegate.
- **Hotspots**: single-hotspot claim, whole-wallet claim, burn, transfer, update/assert.
- **Claim automation (tuktuk)**: single-cron lifecycle with granular claim entries, funding/top-up, requeue, and close.
- **Squads v4**: proposal lifecycle (approve / reject / cancel / execute / propose-config-change) plus an optional propose mode on the action endpoints (token and DC transfer/burn, DC delegate, hotspot burn/transfer) that builds the action as a vault proposal instead of a direct transaction.
- **Data-only hotspots**: issue and onboard (IoT and mobile).

## Notable points
- Data-only issue/onboard are built on-chain through the data-only escrow, with the issue transaction co-signed by the ECC verifier. They do not go through the maker onboarding server, which requires a pre-registered maker record and cannot self-serve a data-only hotspot. The issue endpoint verifies the verifier returned the same message it submitted (only a signature added) before relaying it, and requires an https verifier URL.
- Swap quotes exclude RFQ (JupiterZ) routes, which return maker-co-signed transactions a self-signing wallet cannot complete, while keeping the getQuote/getTokens rate-limit cache from develop.
- Action endpoints return a consistent envelope (`transactionData` + `estimatedSolFee`) so the wallet can decode, display, and sign every command uniformly.

## Verification
E2E on a surfpool mainnet fork (automation lifecycle, squads propose/execute, token and DC burns) and against devnet: a token transfer and a data-only mobile issue + onboard both land and finalize on-chain, with only the ECC verifier as an external dependency.
