### PR TITLE
fix: preserve mobile hotspot serial on location re-assert

### DIFF
--- a/programs/helium-entity-manager/src/instructions/update_mobile_info_v0.rs
+++ b/programs/helium-entity-manager/src/instructions/update_mobile_info_v0.rs
@@ -155,7 +155,11 @@ pub fn handler<'info>(
     }
   }
 
-  if let Some(deployment_info) = args.deployment_info {
+  if let Some(mut deployment_info) = args.deployment_info {
+    preserve_wifi_serial(
+      &mut deployment_info,
+      &ctx.accounts.mobile_info.deployment_info,
+    );
     ctx.accounts.mobile_info.deployment_info = Some(deployment_info);
   }
 
@@ -166,4 +170,103 @@ pub fn handler<'info>(
   )?;
 
   Ok(())
+}
+
+/// A location re-assert ships a fresh `WifiInfoV0` that often omits the serial
+/// (`serial: None`). This instruction replaces `deployment_info` wholesale, so
+/// without this the re-assert would wipe a serial that was set at onboard time.
+/// Carry the existing on-chain serial forward whenever the incoming update
+/// doesn't provide one. Non-wifi deployment info is left untouched.
+fn preserve_wifi_serial(
+  incoming: &mut MobileDeploymentInfoV0,
+  existing: &Option<MobileDeploymentInfoV0>,
+) {
+  let MobileDeploymentInfoV0::WifiInfoV0 { serial, .. } = incoming else {
+    return;
+  };
+  // Treat both an omitted (`None`) and an empty-string serial as "not provided",
+  // so a re-assert that ships either form can't wipe a real serial.
+  if serial.as_deref().is_some_and(|s| !s.is_empty()) {
+    return;
+  }
+  if let Some(MobileDeploymentInfoV0::WifiInfoV0 {
+    serial: existing_serial,
+    ..
+  }) = existing
+  {
+    *serial = existing_serial.clone();
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn wifi(serial: Option<&str>) -> MobileDeploymentInfoV0 {
+    MobileDeploymentInfoV0::WifiInfoV0 {
+      antenna: 1,
+      elevation: 2,
+      azimuth: 3,
+      mechanical_down_tilt: 4,
+      electrical_down_tilt: 5,
+      serial: serial.map(|s| s.to_string()),
+    }
+  }
+
+  fn serial_of(info: &MobileDeploymentInfoV0) -> Option<String> {
+    match info {
+      MobileDeploymentInfoV0::WifiInfoV0 { serial, .. } => serial.clone(),
+      MobileDeploymentInfoV0::CbrsInfoV0 { .. } => None,
+    }
+  }
+
+  #[test]
+  fn preserves_existing_serial_when_update_omits_it() {
+    // The re-assert bug: incoming has no serial, existing on-chain does.
+    let mut incoming = wifi(None);
+    preserve_wifi_serial(&mut incoming, &Some(wifi(Some("SERIAL-123"))));
+    assert_eq!(serial_of(&incoming), Some("SERIAL-123".to_string()));
+  }
+
+  #[test]
+  fn preserves_existing_serial_when_update_sends_empty_string() {
+    // Some clients serialize an omitted serial as "" rather than None.
+    let mut incoming = wifi(Some(""));
+    preserve_wifi_serial(&mut incoming, &Some(wifi(Some("SERIAL-123"))));
+    assert_eq!(serial_of(&incoming), Some("SERIAL-123".to_string()));
+  }
+
+  #[test]
+  fn keeps_incoming_serial_when_provided() {
+    // A caller that does supply a serial is authoritative; don't override it.
+    let mut incoming = wifi(Some("NEW-456"));
+    preserve_wifi_serial(&mut incoming, &Some(wifi(Some("OLD-123"))));
+    assert_eq!(serial_of(&incoming), Some("NEW-456".to_string()));
+  }
+
+  #[test]
+  fn leaves_serial_none_when_no_existing_serial() {
+    let mut incoming = wifi(None);
+    preserve_wifi_serial(&mut incoming, &Some(wifi(None)));
+    assert_eq!(serial_of(&incoming), None);
+  }
+
+  #[test]
+  fn no_existing_deployment_info_leaves_incoming_untouched() {
+    let mut incoming = wifi(None);
+    preserve_wifi_serial(&mut incoming, &None);
+    assert_eq!(serial_of(&incoming), None);
+  }
+
+  #[test]
+  fn cbrs_incoming_is_untouched() {
+    let mut incoming = MobileDeploymentInfoV0::CbrsInfoV0 {
+      radio_infos: vec![],
+    };
+    preserve_wifi_serial(&mut incoming, &Some(wifi(Some("SERIAL-123"))));
+    assert!(matches!(
+      incoming,
+      MobileDeploymentInfoV0::CbrsInfoV0 { .. }
+    ));
+  }
 }

--- a/tests/helium-entity-manager.ts
+++ b/tests/helium-entity-manager.ts
@@ -1042,6 +1042,64 @@ describe("helium-entity-manager", () => {
         expect(storageAcc.deploymentInfo?.wifiInfoV0).to.deep.equal(wifiInfo);
       });
 
+      it("preserves the existing serial when a re-assert omits it", async () => {
+        // First set a serial, as happens at onboard time.
+        const withSerial = {
+          antenna: 1,
+          elevation: 2,
+          azimuth: 3,
+          mechanicalDownTilt: 4,
+          electricalDownTilt: 5,
+          serial: "SERIAL-PRESERVE-123",
+        };
+        const setMethod = (
+          await updateMobileMetadata({
+            program: hemProgram,
+            assetId: hotspot,
+            rewardableEntityConfig,
+            location: new BN(1000),
+            getAssetFn,
+            getAssetProofFn,
+            deploymentInfo: { wifiInfoV0: withSerial },
+          })
+        ).signers([hotspotOwner]);
+        const info = (await setMethod.pubkeys()).mobileInfo!;
+        await setMethod.rpc({ skipPreflight: true });
+
+        // A location re-assert ships a fresh WifiInfoV0 with no serial.
+        const withoutSerial = {
+          antenna: 10,
+          elevation: 20,
+          azimuth: 30,
+          mechanicalDownTilt: 40,
+          electricalDownTilt: 50,
+          serial: null,
+        };
+        const reassert = (
+          await updateMobileMetadata({
+            program: hemProgram,
+            assetId: hotspot,
+            rewardableEntityConfig,
+            location: new BN(2000),
+            getAssetFn,
+            getAssetProofFn,
+            deploymentInfo: { wifiInfoV0: withoutSerial },
+          })
+        ).signers([hotspotOwner]);
+        await reassert.rpc({ skipPreflight: true });
+
+        const storageAcc = await hemProgram.account.mobileHotspotInfoV0.fetch(
+          info!
+        );
+        // The re-assert's other fields are applied...
+        expect(storageAcc.deploymentInfo?.wifiInfoV0?.antenna).to.eq(10);
+        expect(storageAcc.deploymentInfo?.wifiInfoV0?.elevation).to.eq(20);
+        // ...but the previously-set serial is preserved, not wiped to null.
+        expect(storageAcc.deploymentInfo?.wifiInfoV0?.serial).to.eq(
+          "SERIAL-PRESERVE-123"
+        );
+      });
+
       it("oracle can update active status", async () => {
         await hemProgram.methods
           .setEntityActiveV0({


### PR DESCRIPTION
Mobile WiFi hotspots were losing their on-chain `serial` whenever their location was re-asserted.

## Root cause

`update_mobile_info_v0` replaced `deployment_info` wholesale. A location re-assert ships a fresh `WifiInfoV0` that omits the serial (`serial: None`), so the previously-onboarded serial got overwritten to null. On-chain history confirms it: affected hotspots go from serial-present to null in the exact record where `asserted_hex` changes. The result is 500+ mobile WiFi hotspots with a serial in IMS but null on chain (`network.chain.mobile_hotspot_inventory.serial_number` null while the IMS `hotspots.serial` is set; `hotspot_details.serial = coalesce(onchain, ims)` masks the gap).

Only `blockchain-api`'s `/update-info` guarded against this (via `mergeDeploymentInfo`). The builder-app location-assert path goes through the onboarding server, which forwards `deploymentInfo` verbatim with no merge, so it bypassed that guard.

## Fix

Preserve the existing on-chain serial in the program itself, in `update_mobile_info_v0`. Every caller funnels through this instruction, so fixing it here closes the hole regardless of client or SDK version. When an update omits the serial (`None` or empty string), the existing value is carried forward; a caller that supplies a serial stays authoritative.

## Scope

Serial is the only `WifiInfoV0` field that can be preserved safely in-program — it has an `Option` sentinel. The down-tilt fields (`mechanical_down_tilt`, `electrical_down_tilt`) are also overwritten wholesale on re-assert, but they are non-optional `u16`, so an omitted value is indistinguishable from a deliberate `0`; preserving them needs a client-side merge (onboarding server) or a schema change, tracked as a follow-up. Clearing a serial is intentionally not supported — a hotspot always has one, and every observed wipe was accidental.

## Tests

- Rust unit tests over the merge branches (preserve-on-omit, empty-string, keep-when-provided, no-existing, no-deployment-info, cbrs-untouched).
- TS integration test that sets a serial, re-asserts with a serial-less `WifiInfoV0`, and asserts the serial survives while the other fields update.

## Follow-ups (not in this PR)

- Onboarding-server side `mergeDeploymentInfo` (defense in depth; also addresses down-tilts).
- One-time IMS to chain backfill of the affected hotspots, run after this lands.
