### PR TITLE
HIP 149 backstop: security-review hardening

### DIFF
--- a/programs/helium-sub-daos/src/backstop.rs
+++ b/programs/helium-sub-daos/src/backstop.rs
@@ -30,6 +30,19 @@ use anchor_lang::prelude::*;
 /// The backstop keys off the Mobile sub-DAO's `dc_burned` and percent share.
 pub const MOBILE_SUB_DAO: Pubkey = pubkey!("Gm9xDCJawDEKDrrQW6haw94gABaYzQwCq4ZQU8h8bd22");
 
+/// The canonical mainnet HNT/USD Pyth push account (shard 0 for `HNT_PRICE_FEED_ID`),
+/// kept continuously fresh on-chain and mirrored in `spl-utils`' `HNT_PYTH_PRICE_FEED`.
+/// `calculate_utility_score_v0` pins the supplied price account to this key so a caller
+/// cannot substitute a different (stale-but-valid) HNT price update to steer the backstop.
+///
+/// Operational constraint: this constant and the account the end-epoch cron forwards must
+/// move together. A closed or stale canonical account fails safe (the content checks in
+/// `read_hnt_price` make the epoch dormant, issuance continues). But repointing the cron
+/// at a *different* account without also upgrading this constant hard-fails the pin
+/// (`InvalidPriceOracle`) and halts issuance. To rotate the Pyth feed account, upgrade this
+/// constant and update the cron in the same rollout.
+pub const HNT_PYTH_PRICE_FEED: Pubkey = pubkey!("4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33");
+
 /// Mobile data bucket fraction (HIP 149 Decision 3), as a percentage. Hardcoded.
 pub const MOBILE_DATA_BUCKET_PERCENT: u128 = 70;
 
@@ -49,9 +62,17 @@ pub struct BackstopInput {
   /// `10^(hnt_decimals - pyth_exponent - 5)`, the DC->HNT scale factor (mirrors
   /// `mint_data_credits_v0`). With 8 HNT decimals and a -8 exponent this is `10^11`.
   pub decimals_factor: u128,
-  /// Confidence-adjusted Pyth HNT price (`ema_price - 2 * ema_conf`), guaranteed `> 0`
-  /// by the caller. Same convention as `mint_data_credits_v0`.
-  pub hnt_price_with_conf: u64,
+  /// Lower-bound Pyth HNT price (`ema_price - 2 * ema_conf`), guaranteed `> 0` by the
+  /// caller. Used for the floor/top-up: a lower price converts the USD target into more
+  /// HNT, which is the conservative direction for a minimum. Same convention as
+  /// `mint_data_credits_v0`.
+  pub hnt_price_floor: u64,
+  /// EMA (point-estimate) Pyth HNT price, no confidence adjustment. Used for the earnings
+  /// cap so it binds at exactly `3.0 x carrier_paid_USD` at the point price. The floor uses
+  /// the lower bound (never underpay a minimum); the cap uses the point price (land on the
+  /// HIP's 3.0x rather than biasing the ceiling in either direction with the confidence
+  /// width) (I-01).
+  pub hnt_price_cap: u64,
 }
 
 /// Result of the backstop computation for one epoch.
@@ -90,11 +111,12 @@ pub fn compute_backstop(input: &BackstopInput) -> BackstopOutput {
 
   // carrier_paid_USD = dc_burned x 1e-5. The cap is 3.0x of it (dc_burned*3 in DC units);
   // the floor target (0.5x) is computed below, after the share guard, since it's only
-  // used on the top-up path.
+  // used on the top-up path. The cap uses the EMA point price so it binds at exactly 3.0x;
+  // the floor uses the lower (confidence-adjusted) price so a minimum is never underpaid.
   let deployer_cap_hnt = scale_dc_to_hnt(
     (input.mobile_dc_burned as u128).saturating_mul(3),
     input.decimals_factor,
-    input.hnt_price_with_conf,
+    input.hnt_price_cap,
   );
 
   // Total emission unaffected by the backstop: schedule + the existing re-emit.
@@ -115,7 +137,7 @@ pub fn compute_backstop(input: &BackstopInput) -> BackstopOutput {
   let target_hnt = scale_dc_to_hnt(
     (input.mobile_dc_burned / 2) as u128,
     input.decimals_factor,
-    input.hnt_price_with_conf,
+    input.hnt_price_floor,
   );
 
   // deployer_baseline = (emission + existing_re_emit) x mobile_share x 0.70.
@@ -130,13 +152,17 @@ pub fn compute_backstop(input: &BackstopInput) -> BackstopOutput {
   // Reverses the same scale used in deployer_baseline. The alpha division sizes a
   // DAO-level mint so the slice reaching Mobile data deployers equals the shortfall.
   let shortfall = (target_hnt as u128).saturating_sub(deployer_baseline as u128);
+  // If the demand doesn't fit in u64 the inputs are already outside any real range (an
+  // absurdly low price). Fail safe to no top-up for the epoch (I-02) rather than treating
+  // the overflow as "use the whole burn budget"; this matches read_hnt_price, which makes
+  // the backstop dormant on any price that can't be trusted.
   let top_up_demand: u64 = shortfall
     .saturating_mul(u32::MAX as u128)
     .saturating_mul(100)
     .checked_div(share.saturating_mul(MOBILE_DATA_BUCKET_PERCENT))
     .unwrap_or(0)
     .try_into()
-    .unwrap_or(u64::MAX);
+    .unwrap_or(0);
 
   // Burn-bounded: the top-up may use only the burn beyond what the existing re-emit
   // already consumes (HIP 149 shared-budget bound). With existing_re_emit =
@@ -201,6 +227,8 @@ mod tests {
   }
 
   fn base_input(price_dollars: f64, smoothed: u64) -> BackstopInput {
+    // Zero-confidence case: floor and cap prices coincide, so the existing worked
+    // examples are unchanged by the floor/cap price split (I-01).
     BackstopInput {
       emission: EMISSION,
       smoothed_hnt_burned: smoothed,
@@ -208,7 +236,8 @@ mod tests {
       mobile_dc_burned: DC_BURNED,
       mobile_share: SHARE_8927,
       decimals_factor: DECIMALS_FACTOR,
-      hnt_price_with_conf: hnt_price(price_dollars),
+      hnt_price_floor: hnt_price(price_dollars),
+      hnt_price_cap: hnt_price(price_dollars),
     }
   }
 
@@ -290,6 +319,23 @@ mod tests {
     assert!(
       (hnt(out.deployer_cap_hnt) - 10_920.0).abs() < 5.0,
       "cap_hnt {} should be ~10,920 HNT",
+      hnt(out.deployer_cap_hnt)
+    );
+  }
+
+  #[test]
+  fn cap_uses_its_own_price_not_the_floor_price() {
+    // I-01: the cap converts its 3.0x USD ceiling at the EMA point price, independent of
+    // the floor's lower (confidence-adjusted) price. EMA $1.00, floor price $0.90. The cap
+    // in HNT is 3 x $9,100 / $1.00 = 27,300 HNT (exactly 3.0x at the point price), not
+    // 3 x $9,100 / $0.90 = 30,333 HNT (what sharing the floor's lower price would give).
+    let mut input = base_input(1.00, NET_CAP);
+    input.hnt_price_floor = hnt_price(0.90);
+    input.hnt_price_cap = hnt_price(1.00);
+    let out = compute_backstop(&input);
+    assert!(
+      (hnt(out.deployer_cap_hnt) - 27_300.0).abs() < 5.0,
+      "cap_hnt {} should use the EMA point price (~27,300 HNT), not the floor's lower price (~30,333)",
       hnt(out.deployer_cap_hnt)
     );
   }

--- a/programs/helium-sub-daos/src/error.rs
+++ b/programs/helium-sub-daos/src/error.rs
@@ -68,7 +68,7 @@ pub enum ErrorCode {
   #[msg("Supplement window is active but no supplement vault was provided")]
   SupplementVaultMissing,
 
-  #[msg("Supplement vault is not owned by the configured supplement vault owner")]
+  #[msg("Supplement vault does not match the configured supplement vault token account")]
   InvalidSupplementVault,
 
   #[msg("Supplement window is active but no Council compensation vault was provided")]
@@ -76,4 +76,13 @@ pub enum ErrorCode {
 
   #[msg("Council compensation vault does not match the configured Council fanout token account")]
   InvalidCouncilVault,
+
+  #[msg("HNT price oracle account is required for the backstop but was not supplied")]
+  PriceOracleMissing,
+
+  #[msg("HNT price oracle account does not match the canonical HNT Pyth price feed")]
+  InvalidPriceOracle,
+
+  #[msg("The Mobile sub-DAO epoch-info accounts required by the backstop were not supplied")]
+  MobileEpochInfoMissing,
 }

--- a/programs/helium-sub-daos/src/instructions/calculate_utility_score_v0.rs
+++ b/programs/helium-sub-daos/src/instructions/calculate_utility_score_v0.rs
@@ -90,12 +90,16 @@ pub struct CalculateUtilityScoreV0<'info> {
   /// CHECK: May not have ever been initialized
   pub not_emitted_counter: UncheckedAccount<'info>,
   pub no_emit_program: Program<'info, NoEmit>,
-  /// CHECK: HIP 149 backstop HNT/USD Pyth price. Optional, and fully validated in the
-  /// handler (feed id, Full verification, staleness, positivity) — any problem makes the
-  /// backstop go dormant for the epoch rather than fail the instruction, so a missing or
-  /// stale price can never halt reward issuance. No declarative constraints for that
-  /// reason; an attacker can at most disable the backstop (same as omitting it), never
-  /// inject a price.
+  /// CHECK: HIP 149 backstop HNT/USD Pyth price. Optional in the account struct (so the
+  /// TESTING dormant-path calls may omit it), but in production the handler requires it to
+  /// be present and pinned to the canonical HNT_PYTH_PRICE_FEED account. Requiring and
+  /// pinning it — rather than treating omission as "go dormant" — is what stops a
+  /// permissionless caller from front-running the cron and suppressing the backstop by
+  /// omitting or substituting the price (M-02/I-04). The price *contents* still fail safe:
+  /// a malformed, unverified, stale, or non-positive price makes the backstop dormant for
+  /// the epoch (handled in read_hnt_price) rather than halting reward issuance. The pinned
+  /// account is maintained continuously on-chain, so its presence is always satisfiable on
+  /// the honest path.
   pub hnt_price_oracle: Option<UncheckedAccount<'info>>,
 }
 
@@ -191,24 +195,45 @@ pub fn handler<'info>(
   // same Mobile signals and compute the same total_rewards, so the result is independent
   // of sub-DAO ordering.
   //
-  // Fail-safe: if the price is missing/stale/malformed or the Mobile epoch-info accounts
-  // aren't supplied, the backstop is dormant for the epoch (baseline emission + existing
-  // re-emit, no top-up, no cap) rather than failing the instruction. A stale price can
-  // never halt reward issuance, and the HIP already treats the target as a best-effort
-  // per-epoch aim, not a hard guarantee.
-  let hnt_price = read_hnt_price(&ctx);
-  let backstop = match (hnt_price, mobile_signals(&ctx, args.epoch)) {
-    (Some((decimals_factor, hnt_price_with_conf)), Some((mobile_dc_burned, mobile_share))) => {
-      compute_backstop(&BackstopInput {
-        emission: emission_ts,
-        smoothed_hnt_burned: smoothed,
-        net_emissions_cap,
-        mobile_dc_burned,
-        mobile_share,
-        decimals_factor,
-        hnt_price_with_conf,
-      })
-    }
+  // The price account and the Mobile epoch-info accounts are mandatory inputs (the price
+  // is pinned above; the Mobile accounts error via mobile_signals if omitted), so a
+  // permissionless caller cannot front-run the cron and suppress the backstop by leaving
+  // them out (M-02). What stays fail-safe is the price *content*: a malformed, unverified,
+  // stale, or non-positive price makes the backstop dormant for the epoch (baseline
+  // emission + existing re-emit, no top-up, no cap) rather than halting reward issuance.
+  // The HIP already treats the target as a best-effort per-epoch aim, not a hard guarantee.
+  //
+  // In production the price account must be present and pinned to the canonical HNT feed;
+  // omission or substitution is rejected here rather than silently going dormant, which is
+  // what closes the permissionless-suppression path (M-02/I-04). Relaxed under TESTING,
+  // where the dormant-path tests intentionally omit the oracle. Rotating the pinned feed
+  // account requires upgrading HNT_PYTH_PRICE_FEED and the cron together — see that
+  // constant's docs for the halt-vs-dormant cases.
+  if !TESTING {
+    let oracle = ctx
+      .accounts
+      .hnt_price_oracle
+      .as_ref()
+      .ok_or_else(|| error!(ErrorCode::PriceOracleMissing))?;
+    require!(
+      oracle.key() == crate::backstop::HNT_PYTH_PRICE_FEED,
+      ErrorCode::InvalidPriceOracle
+    );
+  }
+  let backstop = match (read_hnt_price(&ctx), mobile_signals(&ctx, args.epoch)?) {
+    (
+      Some((decimals_factor, hnt_price_floor, hnt_price_cap)),
+      Some((mobile_dc_burned, mobile_share)),
+    ) => compute_backstop(&BackstopInput {
+      emission: emission_ts,
+      smoothed_hnt_burned: smoothed,
+      net_emissions_cap,
+      mobile_dc_burned,
+      mobile_share,
+      decimals_factor,
+      hnt_price_floor,
+      hnt_price_cap,
+    }),
     _ => {
       let existing_re_emit = std::cmp::min(smoothed, net_emissions_cap);
       crate::backstop::BackstopOutput {
@@ -372,14 +397,16 @@ pub fn handler<'info>(
 /// dormant rather than wrong. Generous under TESTING so posted test prices never expire.
 const PRICE_MAX_AGE_SECS: i64 = 60 * 60;
 
-/// Read the confidence-adjusted HNT price and DC->HNT scale factor from the optional Pyth
-/// account, mirroring `mint_data_credits_v0`'s price math. Returns `None` (backstop
-/// dormant this epoch) for any reason the price can't be trusted: not supplied, wrong
-/// owner/type, wrong feed, not Full-verified, stale, or non-positive. Never errors, so a
-/// bad price can't halt reward issuance.
+/// Read the DC->HNT scale factor and the lower/upper confidence-adjusted HNT prices from
+/// the (pinned, required) Pyth account, mirroring `mint_data_credits_v0`'s price math.
+/// Returns `(decimals_factor, price_floor, price_cap)`, or `None` (backstop dormant this
+/// epoch) for any reason the price *content* can't be trusted: wrong type, wrong feed, not
+/// Full-verified, stale, or non-positive. Never errors, so a bad price can't halt reward
+/// issuance. Account presence and identity are enforced by the caller (required account +
+/// pin), so the only remaining reason to bail here is untrustworthy content.
 fn read_hnt_price<'info>(
   ctx: &Context<'_, '_, '_, 'info, CalculateUtilityScoreV0<'info>>,
-) -> Option<(u128, u64)> {
+) -> Option<(u128, u64, u64)> {
   let oracle = ctx.accounts.hnt_price_oracle.as_ref()?;
   let price_update = try_from!(Account<PriceUpdateV2>, oracle).ok()?;
 
@@ -401,13 +428,16 @@ fn read_hnt_price<'info>(
     return None;
   }
 
-  // Remove the confidence to use the most conservative (lower) price, exactly as
-  // mint_data_credits_v0 does. A lower price yields a larger top-up; the burn bound
-  // still caps total re-emission at recent destruction.
-  let hnt_price_with_conf = message
-    .ema_price
-    .checked_sub(i64::try_from(message.ema_conf.checked_mul(2)?).ok()?)?;
-  if hnt_price_with_conf <= 0 {
+  // Two prices for the two mechanisms. The floor/top-up uses the lower confidence bound
+  // (`ema_price - 2 * ema_conf`), exactly as mint_data_credits_v0 does: a lower price
+  // yields a larger top-up, the conservative direction for a minimum, and the burn bound
+  // still caps total re-emission at recent destruction. The cap uses the EMA point price
+  // (no confidence adjustment) so it binds at exactly 3.0x the payer rate rather than
+  // biasing the ceiling in either direction by the confidence width (I-01).
+  let conf_2 = i64::try_from(message.ema_conf.checked_mul(2)?).ok()?;
+  let price_floor = message.ema_price.checked_sub(conf_2)?;
+  let price_cap = message.ema_price;
+  if price_floor <= 0 || price_cap <= 0 {
     return None;
   }
 
@@ -415,11 +445,21 @@ fn read_hnt_price<'info>(
   let exponent = i32::from(ctx.accounts.hnt_mint.decimals) - message.exponent - 5;
   let decimals_factor = 10_u128.checked_pow(u32::try_from(exponent).ok()?)?;
 
-  Some((decimals_factor, u64::try_from(hnt_price_with_conf).ok()?))
+  Some((
+    decimals_factor,
+    u64::try_from(price_floor).ok()?,
+    u64::try_from(price_cap).ok()?,
+  ))
 }
 
-/// Read the Mobile sub-DAO's per-epoch `dc_burned` and 30-epoch EMA percent share, or
-/// `None` (backstop dormant) if the Mobile epoch-info accounts aren't available.
+/// Read the Mobile sub-DAO's per-epoch `dc_burned` and 30-epoch EMA percent share.
+///
+/// Returns `Err(MobileEpochInfoMissing)` if the caller omitted the Mobile epoch-info
+/// accounts, so a permissionless caller cannot front-run the cron and suppress the
+/// backstop by leaving them out (M-02). The cron and admin end-epoch always forward them,
+/// and they are public PDAs, so requiring their presence never blocks the honest path.
+/// Returns `Ok(None)` (backstop dormant, no halt) when the accounts are present but not
+/// yet initialized (e.g. a zero-burn epoch), and `Ok(Some(..))` when they are readable.
 ///
 /// In production these come from the Mobile sub-DAO's current- and previous-epoch
 /// `SubDaoEpochInfoV0` accounts, located in `remaining_accounts` by their PDAs (pinned to
@@ -429,12 +469,12 @@ fn read_hnt_price<'info>(
 fn mobile_signals<'info>(
   ctx: &Context<'_, '_, 'info, 'info, CalculateUtilityScoreV0<'info>>,
   epoch: u64,
-) -> Option<(u64, u32)> {
+) -> Result<Option<(u64, u32)>> {
   if TESTING {
-    return Some((
+    return Ok(Some((
       ctx.accounts.sub_dao_epoch_info.dc_burned,
       ctx.accounts.prev_sub_dao_epoch_info.previous_percentage,
-    ));
+    )));
   }
 
   let curr_pda = Pubkey::find_program_address(
@@ -459,13 +499,21 @@ fn mobile_signals<'info>(
   let curr_acc = ctx
     .remaining_accounts
     .iter()
-    .find(|acc| acc.key() == curr_pda)?;
+    .find(|acc| acc.key() == curr_pda)
+    .ok_or_else(|| error!(ErrorCode::MobileEpochInfoMissing))?;
   let prev_acc = ctx
     .remaining_accounts
     .iter()
-    .find(|acc| acc.key() == prev_pda)?;
+    .find(|acc| acc.key() == prev_pda)
+    .ok_or_else(|| error!(ErrorCode::MobileEpochInfoMissing))?;
 
-  let curr = Account::<SubDaoEpochInfoV0>::try_from(curr_acc).ok()?;
-  let prev = Account::<SubDaoEpochInfoV0>::try_from(prev_acc).ok()?;
-  Some((curr.dc_burned, prev.previous_percentage))
+  // Present but not yet initialized (e.g. no carrier burn this epoch) -> dormant, not an
+  // error, so a low-activity epoch can never halt reward issuance.
+  match (
+    Account::<SubDaoEpochInfoV0>::try_from(curr_acc).ok(),
+    Account::<SubDaoEpochInfoV0>::try_from(prev_acc).ok(),
+  ) {
+    (Some(curr), Some(prev)) => Ok(Some((curr.dc_burned, prev.previous_percentage))),
+    _ => Ok(None),
+  }
 }

--- a/programs/helium-sub-daos/src/instructions/issue_rewards_v0.rs
+++ b/programs/helium-sub-daos/src/instructions/issue_rewards_v0.rs
@@ -77,8 +77,9 @@ pub struct IssueRewardsV0<'info> {
   pub prev_sub_dao_epoch_info: Box<Account<'info, SubDaoEpochInfoV0>>,
   // HIP 149 Decision 2 supplement vault (the Receiving Entity's Squads vault HNT account).
   // Optional so pre-supplement callers/tests need not pass it; required only when the
-  // supplement window is active (enforced in the handler). Validated there: HNT mint, and
-  // owned by SUPPLEMENT_VAULT_OWNER (relaxed under TESTING).
+  // supplement window is active (enforced in the handler). Validated there: key equals
+  // SUPPLEMENT_VAULT_TOKEN_ACCOUNT (relaxed under TESTING). The HNT mint is enforced by the
+  // mint CPI.
   #[account(mut)]
   pub supplement_vault: Option<Box<Account<'info, TokenAccount>>>,
   // HIP 149 Decision 4 Council-compensation fanout (a mini_fanout PDA-owned HNT account that
@@ -287,7 +288,7 @@ pub fn handler(ctx: Context<IssueRewardsV0>, args: IssueRewardsArgsV0) -> Result
       .as_ref()
       .ok_or_else(|| error!(ErrorCode::SupplementVaultMissing))?;
     require!(
-      TESTING || vault.owner == crate::supplement::SUPPLEMENT_VAULT_OWNER,
+      TESTING || vault.key() == crate::supplement::SUPPLEMENT_VAULT_TOKEN_ACCOUNT,
       ErrorCode::InvalidSupplementVault
     );
     // Council fanout (the 1.25% carve-out). Always required while active, even if the

--- a/programs/helium-sub-daos/src/supplement.rs
+++ b/programs/helium-sub-daos/src/supplement.rs
@@ -41,10 +41,13 @@ pub const INFLATION_FLAT_PER_EPOCH_PER_SUBDAO: u64 = 98_000 * 100_000_000;
 /// then decaying linearly to zero across the taper window.
 pub const INFLATION_TAPER_INITIAL_PER_EPOCH_PER_SUBDAO: u64 = INFLATION_FLAT_PER_EPOCH_PER_SUBDAO;
 
-// PATCH-TIME: the Receiving Entity's Squads vault that receives the supplement. Placeholder
-// (the system program id); set to the real vault before deploy. issue_rewards_v0 checks the
-// supplied supplement token account is owned by this key (relaxed under TESTING).
-pub const SUPPLEMENT_VAULT_OWNER: Pubkey = pubkey!("11111111111111111111111111111111");
+// PATCH-TIME: the Receiving Entity's Squads vault HNT token account that receives the
+// supplement. Placeholder (the system program id); set to the real token account before
+// deploy. issue_rewards_v0 requires the supplied supplement token account to equal this key
+// (relaxed under TESTING), pinned to the exact account — like COUNCIL_FANOUT_TOKEN_ACCOUNT —
+// rather than only checking the token-account authority, so a caller cannot route the
+// supplement to a different account under the same authority (I-03).
+pub const SUPPLEMENT_VAULT_TOKEN_ACCOUNT: Pubkey = pubkey!("11111111111111111111111111111111");
 
 // ── HIP 149 Decision 4: Advisory Council compensation carve-out ─────────────────────────
 /// The community-nominated Council seats share 1.25% of the supplement (HIP 149 Decision 4).

--- a/tests/helium-sub-daos.ts
+++ b/tests/helium-sub-daos.ts
@@ -1,5 +1,6 @@
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
+import { PythSolanaReceiver } from "@pythnetwork/pyth-solana-receiver";
 import { init as cbInit } from "@helium/circuit-breaker-sdk";
 import { Keypair as HeliumKeypair } from "@helium/crypto";
 import {
@@ -1073,9 +1074,23 @@ describe("helium-sub-daos", () => {
               // Delivered Mobile data deployer HNT = total_rewards x mobile_share x 0.70.
               const alpha = (mobileShare / 0xffffffff) * 0.7;
               const delivered = di.totalRewards.toNumber() * alpha;
-              // Price-derived target: deployer_cap_hnt is 3x carrier-paid USD in HNT, the
-              // floor target is 0.5x => target == cap / 6. The floor should deliver it.
-              const target = di.deployerCapHnt.toNumber() / 6;
+              // deployer_cap_hnt is 3x carrier-paid USD converted at the EMA point price;
+              // the floor target is 0.5x converted at the lower-bound price (ema - 2*conf).
+              // So target == (cap / 6) x (ema / price_lower), not simply cap / 6 (the two
+              // coincide only at zero confidence). Read the cloned mainnet price to
+              // reconstruct the ratio.
+              const pythReceiver = new PythSolanaReceiver({
+                connection: provider.connection,
+                wallet: provider.wallet as any,
+              });
+              const priceAcc = await pythReceiver.fetchPriceUpdateAccount(
+                HNT_PYTH_PRICE_FEED
+              );
+              const emaPrice = priceAcc!.priceMessage.emaPrice.toNumber();
+              const emaConf = priceAcc!.priceMessage.emaConf.toNumber();
+              const priceLower = emaPrice - 2 * emaConf;
+              const target =
+                (di.deployerCapHnt.toNumber() / 6) * (emaPrice / priceLower);
 
               expect(mobileShare).to.be.greaterThan(0);
               expect(delivered).to.be.closeTo(target, target * 0.02);


### PR DESCRIPTION
Hardening for the HIP 149 backstop, addressing findings from the incremental security review of PR #1197. Targets the PR branch so it lands as a single follow-up before re-review.

## Changes

- **Backstop can no longer be permissionlessly suppressed.** `calculate_utility_score_v0` is permissionless and finalizes the epoch's utility score on first call, so a caller could front-run the cron with the (previously optional) price and Mobile epoch-info accounts omitted, permanently locking the epoch with the backstop dormant (`top_up = 0`, `deployer_cap_hnt = 0`) — defeating both the deployer floor and the staker overflow. In production the price account is now mandatory and pinned to the canonical HNT Pyth feed (`HNT_PYTH_PRICE_FEED`), and the Mobile epoch-info accounts must be present (`mobile_signals` errors on omission). Because a *successful* call now requires the real inputs, racing the cron produces the honest result and gains nothing. Price *content* stays fail-safe: malformed/unverified/stale/non-positive makes the epoch dormant, never halting reward issuance. All production-only guards are `!TESTING`.

- **Earnings cap binds at exactly 3x using the EMA point price.** The floor keeps the lower confidence bound (`ema - 2·conf`), the conservative direction for a minimum. The cap uses the EMA point price (no confidence adjustment) so it lands on the HIP's 3.0x rather than biasing the ceiling in either direction by the confidence width. (The original code used the same lower price for both, which relaxed the cap.)

- **Top-up demand overflow fails safe.** A `u64` overflow in the demand conversion previously fell back to `u64::MAX` ("use the whole burn budget"); it now yields zero top-up, matching the dormant-on-untrusted-price behavior.

- **Supplement vault pinned to an exact token account.** The Decision 2 destination was validated only by token-account authority, letting a caller route it to any account under that authority. It is now pinned to `SUPPLEMENT_VAULT_TOKEN_ACCOUNT`, mirroring the Council fanout; the HNT mint is enforced by the mint CPI.

## Operational notes

- **Rotating the HNT Pyth feed account now requires a coordinated upgrade.** The pin means the `HNT_PYTH_PRICE_FEED` constant and the account the end-epoch cron forwards must move together. A closed or stale canonical account fails safe (the epoch goes dormant, issuance continues), but repointing the cron at a *different* account without also upgrading the constant hard-fails the pin (`InvalidPriceOracle`) and halts issuance. Documented on the constant.
- **Manual cranking is stricter.** A fallback caller of `calculate_utility_score_v0` must now pass the canonical price account and the Mobile epoch-info accounts, or the call reverts. The cron and the admin `end-epoch` path both already do this; a naive third-party crank that used to "just work" (dormant) will not.
- **Deploy constant renamed:** `SUPPLEMENT_VAULT_OWNER` → `SUPPLEMENT_VAULT_TOKEN_ACCOUNT` — set it to the Receiving Entity vault's exact HNT token account (not the authority) before deploy.

## Not addressed (deliberately)

- The HST-haircut question in the top-up formula: HST has been 0% since early 2025 and HIP-138 removed the HST payout instruction, so the formula already matches the live (no-HST) configuration and the HIP's published formula.
- The one-epoch smoothing lag between the share used to size the top-up and the share used at issuance is inherent (the current-epoch smoothed share isn't known until issuance) and within the HIP's best-effort-per-epoch aim.
- The report's note that `mint_data_credits_v0` shares the not-pinned-account pattern is a separate, pre-existing instruction outside this PR's scope.

## Verification

- `helium-sub-daos` Rust unit tests: 20/20 (incl. cap-uses-point-price).
- `TESTING=true anchor build`: clean (BPF + IDL).
- HIP 149 backstop integration tests (cap redirect, floor delivery) pass on Node 24. The full suite otherwise runs in CI; note the world-setup Metaplex CPI (cloned from mainnet) intermittently exceeds the compute meter — an existing flake unrelated to this change.