### PR TITLE
feat(blockchain-api): Squads v3 proposal lifecycle endpoints

### DIFF
--- a/packages/blockchain-api-client/src/contracts/index.ts
+++ b/packages/blockchain-api-client/src/contracts/index.ts
@@ -11,6 +11,7 @@ import { webhooksContract } from "./webhooks";
 import { migrationContract } from "./migration";
 import { dataCreditsContract } from "./data-credits";
 import { squadsContract } from "./squads";
+import { squadsV3Contract } from "./squadsV3";
 import { oc } from "@orpc/contract";
 
 export * from "./governance";
@@ -26,6 +27,7 @@ export * from "./webhooks";
 export * from "./migration";
 export * from "./data-credits";
 export * from "./squads";
+export * from "./squadsV3";
 
 /**
  * Public API contract definition (for external consumers).
@@ -43,6 +45,7 @@ export const apiContract = oc.router({
   migration: migrationContract,
   dataCredits: dataCreditsContract,
   squads: squadsContract,
+  squadsV3: squadsV3Contract,
 });
 
 /**

--- a/packages/blockchain-api-client/src/contracts/squadsV3.ts
+++ b/packages/blockchain-api-client/src/contracts/squadsV3.ts
@@ -1,0 +1,65 @@
+import { oc } from "@orpc/contract";
+import {
+  SquadsV3ProposalVoteInputSchema,
+  SquadsV3ExecuteProposalInputSchema,
+  SquadsV3ProposeConfigChangeInputSchema,
+} from "../schemas/squadsV3";
+import { TransactionDataSchema } from "../schemas/common";
+import { BAD_REQUEST, NOT_FOUND } from "../errors/common";
+import { INSUFFICIENT_FUNDS } from "../errors/solana";
+
+/**
+ * Squads v3 multisig transaction lifecycle. Every endpoint builds one or more
+ * unsigned transactions to be signed by the acting member and submitted via the
+ * transactions router. v3 votes act directly on a transaction PDA (there is no
+ * separate proposal account). Reads (list/inspect transactions) live in the
+ * client SDK, not here.
+ */
+export const squadsV3Contract = oc.tag("Squads v3").router({
+  approveProposal: oc
+    .route({
+      method: "POST",
+      path: "/squads/v3/proposals/approve",
+      summary: "Approve a Squads v3 transaction",
+    })
+    .input(SquadsV3ProposalVoteInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+  rejectProposal: oc
+    .route({
+      method: "POST",
+      path: "/squads/v3/proposals/reject",
+      summary: "Reject a Squads v3 transaction",
+    })
+    .input(SquadsV3ProposalVoteInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+  cancelProposal: oc
+    .route({
+      method: "POST",
+      path: "/squads/v3/proposals/cancel",
+      summary: "Cancel an approved Squads v3 transaction",
+    })
+    .input(SquadsV3ProposalVoteInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+  executeProposal: oc
+    .route({
+      method: "POST",
+      path: "/squads/v3/proposals/execute",
+      summary: "Execute an approved Squads v3 transaction",
+    })
+    .input(SquadsV3ExecuteProposalInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+  proposeConfigChange: oc
+    .route({
+      method: "POST",
+      path: "/squads/v3/proposals/config",
+      summary:
+        "Propose a Squads v3 config change (add/remove member, change threshold)",
+    })
+    .input(SquadsV3ProposeConfigChangeInputSchema)
+    .output(TransactionDataSchema)
+    .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS }),
+});

--- a/packages/blockchain-api-client/src/schemas/squadsV3.ts
+++ b/packages/blockchain-api-client/src/schemas/squadsV3.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { PublicKeySchema } from "./common";
+
+/**
+ * Shared inputs for a Squads v3 transaction vote (approve / reject / cancel).
+ * v3 votes act directly on the transaction PDA (there is no separate proposal
+ * account as in v4). The member casting the vote is also the fee payer for the
+ * returned transaction.
+ */
+export const SquadsV3ProposalVoteInputSchema = z.object({
+  member: PublicKeySchema.describe(
+    "Wallet address of the multisig member casting the vote (signer and fee payer)"
+  ),
+  multisig: PublicKeySchema.describe("Multisig account PDA"),
+  transactionPda: PublicKeySchema.describe(
+    "PDA of the target Squads v3 transaction (MsTransaction account)"
+  ),
+});
+
+export type SquadsV3ProposalVoteInput = z.infer<
+  typeof SquadsV3ProposalVoteInputSchema
+>;
+
+/**
+ * Input for executing an approved Squads v3 transaction. The server reads the
+ * transaction account to assemble the inner instruction accounts, so only the
+ * transaction PDA and acting member are required.
+ */
+export const SquadsV3ExecuteProposalInputSchema = z.object({
+  member: PublicKeySchema.describe(
+    "Wallet address of the multisig member executing the transaction (signer and fee payer)"
+  ),
+  multisig: PublicKeySchema.describe("Multisig account PDA"),
+  transactionPda: PublicKeySchema.describe(
+    "PDA of the approved Squads v3 transaction to execute"
+  ),
+});
+
+export type SquadsV3ExecuteProposalInput = z.infer<
+  typeof SquadsV3ExecuteProposalInputSchema
+>;
+
+/**
+ * A single config change to include in a Squads v3 config-change proposal.
+ * v3 expresses membership and threshold changes as program instructions
+ * (addMember / removeMember / changeThreshold) wrapped in a proposed
+ * transaction, unlike v4's distinct config-transaction type.
+ */
+export const SquadsV3ConfigActionSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("addMember"),
+    newMember: PublicKeySchema.describe("Pubkey of the member to add"),
+  }),
+  z.object({
+    type: z.literal("removeMember"),
+    oldMember: PublicKeySchema.describe("Pubkey of the member to remove"),
+  }),
+  z.object({
+    type: z.literal("changeThreshold"),
+    newThreshold: z
+      .number()
+      .int()
+      .min(1)
+      .describe("New approval threshold for the multisig"),
+  }),
+]);
+
+export type SquadsV3ConfigAction = z.infer<typeof SquadsV3ConfigActionSchema>;
+
+/**
+ * Input for proposing a Squads v3 config change. The server creates a
+ * transaction at the multisig's next index, adds the config instruction(s),
+ * and activates it; the assigned transaction PDA is returned in actionMetadata.
+ */
+export const SquadsV3ProposeConfigChangeInputSchema = z.object({
+  member: PublicKeySchema.describe(
+    "Wallet address of the multisig member creating the proposal (signer and fee payer)"
+  ),
+  multisig: PublicKeySchema.describe("Multisig account PDA"),
+  actions: z
+    .array(SquadsV3ConfigActionSchema)
+    .nonempty()
+    .describe("One or more config changes to apply when the proposal executes"),
+});
+
+export type SquadsV3ProposeConfigChangeInput = z.infer<
+  typeof SquadsV3ProposeConfigChangeInputSchema
+>;

--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -67,6 +67,7 @@
     "@solana/spl-token": "^0.4.13",
     "@solana/web3.js": "^1.98.2",
     "@sqds/multisig": "^2.1.4",
+    "@sqds/sdk": "2.0.4",
     "@t3-oss/env-nextjs": "^0.13.8",
     "@tanstack/react-query": "^5.80.10",
     "@types/bn.js": "^5.2.0",

--- a/packages/blockchain-api/src/lib/utils/squads-tx.ts
+++ b/packages/blockchain-api/src/lib/utils/squads-tx.ts
@@ -1,0 +1,67 @@
+import {
+  Connection,
+  PublicKey,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import {
+  buildVersionedTransaction,
+  serializeTransaction,
+} from "@/lib/utils/build-transaction";
+import { getTransactionFee } from "@/lib/utils/balance-validation";
+
+/** Fee-shortfall reporter, wired to a procedure's typed INSUFFICIENT_FUNDS error. */
+export type InsufficientFundsReporter = (info: {
+  required: number;
+  available: number;
+}) => Error;
+
+/**
+ * The subset of a procedure's typed `errors` builders the squads helpers need.
+ * The full oRPC `errors` object satisfies this structurally.
+ */
+export type ProposalErrors = {
+  INSUFFICIENT_FUNDS: (opts: {
+    message: string;
+    data: { required: number; available: number };
+  }) => Error;
+  NOT_FOUND: (opts: { message: string }) => Error;
+};
+
+/**
+ * Build an unsigned Squads transaction from a set of instructions, verify the
+ * acting member can cover the fee, and return the base64-serialized tx plus the
+ * estimated fee in lamports. Version-neutral: used by both the v3 and v4 routers.
+ *
+ * Passes `addressLookupTableAddresses` through verbatim (default empty) so the
+ * common Helium LUT is not auto-attached to these small governance txns; a
+ * vault execute supplies the inner message's own lookup tables here.
+ */
+export async function buildSquadsTransaction({
+  connection,
+  member,
+  instructions,
+  addressLookupTableAddresses = [],
+  insufficientFunds,
+}: {
+  connection: Connection;
+  member: PublicKey;
+  instructions: TransactionInstruction[];
+  addressLookupTableAddresses?: PublicKey[];
+  insufficientFunds: InsufficientFundsReporter;
+}): Promise<{ serializedTransaction: string; feeLamports: number }> {
+  const tx = await buildVersionedTransaction({
+    connection,
+    draft: { instructions, feePayer: member, addressLookupTableAddresses },
+  });
+
+  const required = getTransactionFee(tx);
+  const available = await connection.getBalance(member);
+  if (available < required) {
+    throw insufficientFunds({ required, available });
+  }
+
+  return {
+    serializedTransaction: serializeTransaction(tx),
+    feeLamports: required,
+  };
+}

--- a/packages/blockchain-api/src/lib/utils/transaction-tags.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-tags.ts
@@ -57,6 +57,13 @@ export const TRANSACTION_TYPES = {
   SQUADS_PROPOSAL_EXECUTE: "squads_proposal_execute",
   SQUADS_CONFIG_CHANGE: "squads_config_change",
 
+  // Squads v3 multisig
+  SQUADS_V3_PROPOSAL_APPROVE: "squads_v3_proposal_approve",
+  SQUADS_V3_PROPOSAL_REJECT: "squads_v3_proposal_reject",
+  SQUADS_V3_PROPOSAL_CANCEL: "squads_v3_proposal_cancel",
+  SQUADS_V3_PROPOSAL_EXECUTE: "squads_v3_proposal_execute",
+  SQUADS_V3_CONFIG_CHANGE: "squads_v3_config_change",
+
   // Squads propose mode of the action endpoints
   TOKEN_TRANSFER_PROPOSAL: "token_transfer_proposal",
   TOKEN_BURN_PROPOSAL: "token_burn_proposal",

--- a/packages/blockchain-api/src/server/api/index.ts
+++ b/packages/blockchain-api/src/server/api/index.ts
@@ -12,6 +12,7 @@ import { webhooksRouter } from "./routers/webhooks/router";
 import { migrationRouter } from "./routers/migration/router";
 import { dataCreditsRouter } from "./routers/data-credits/router";
 import { squadsRouter } from "./routers/squads/router";
+import { squadsV3Router } from "./routers/squadsV3/router";
 import { implement } from "@orpc/server";
 import { fullApiContract, apiContract } from "@helium/blockchain-api";
 
@@ -27,6 +28,7 @@ const sharedRouters = {
   migration: migrationRouter,
   dataCredits: dataCreditsRouter,
   squads: squadsRouter,
+  squadsV3: squadsV3Router,
 };
 
 export const publicRouter = implement(apiContract).router(sharedRouters);

--- a/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/squads/procedures/helpers.ts
@@ -7,72 +7,20 @@ import {
 } from "@solana/web3.js";
 import * as multisig from "@sqds/multisig";
 import {
-  buildVersionedTransaction,
-  serializeTransaction,
-} from "@/lib/utils/build-transaction";
-import { getTransactionFee } from "@/lib/utils/balance-validation";
-import {
   generateTransactionTag,
   TRANSACTION_TYPES,
   TransactionType,
 } from "@/lib/utils/transaction-tags";
+import {
+  buildSquadsTransaction,
+  ProposalErrors,
+} from "@/lib/utils/squads-tx";
 
-/** Fee-shortfall reporter, wired to a procedure's typed INSUFFICIENT_FUNDS error. */
-export type InsufficientFundsReporter = (info: {
-  required: number;
-  available: number;
-}) => Error;
-
-/**
- * The subset of a procedure's typed `errors` builders the squads helpers need.
- * The full oRPC `errors` object satisfies this structurally.
- */
-export type ProposalErrors = {
-  INSUFFICIENT_FUNDS: (opts: {
-    message: string;
-    data: { required: number; available: number };
-  }) => Error;
-  NOT_FOUND: (opts: { message: string }) => Error;
-};
-
-/**
- * Build an unsigned Squads transaction from a set of instructions, verify the
- * acting member can cover the fee, and return the base64-serialized tx plus the
- * estimated fee in lamports.
- *
- * Passes `addressLookupTableAddresses` through verbatim (default empty) so the
- * common Helium LUT is not auto-attached to these small governance txns; a
- * vault execute supplies the inner message's own lookup tables here.
- */
-export async function buildSquadsTransaction({
-  connection,
-  member,
-  instructions,
-  addressLookupTableAddresses = [],
-  insufficientFunds,
-}: {
-  connection: Connection;
-  member: PublicKey;
-  instructions: TransactionInstruction[];
-  addressLookupTableAddresses?: PublicKey[];
-  insufficientFunds: InsufficientFundsReporter;
-}): Promise<{ serializedTransaction: string; feeLamports: number }> {
-  const tx = await buildVersionedTransaction({
-    connection,
-    draft: { instructions, feePayer: member, addressLookupTableAddresses },
-  });
-
-  const required = getTransactionFee(tx);
-  const available = await connection.getBalance(member);
-  if (available < required) {
-    throw insufficientFunds({ required, available });
-  }
-
-  return {
-    serializedTransaction: serializeTransaction(tx),
-    feeLamports: required,
-  };
-}
+export {
+  buildSquadsTransaction,
+  type InsufficientFundsReporter,
+  type ProposalErrors,
+} from "@/lib/utils/squads-tx";
 
 type VoteIxBuilder = (args: {
   multisigPda: PublicKey;

--- a/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/approve.ts
+++ b/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/approve.ts
@@ -1,0 +1,15 @@
+import { publicProcedure } from "../../../procedures";
+import { buildProposalVote, createSquadsV3, SQUADS_V3_VOTE_ACTIONS } from "./helpers";
+
+export const approveProposal = publicProcedure.squadsV3.approveProposal.handler(
+  async ({ input, errors }) => {
+    const { connection, squads } = createSquadsV3(input.member);
+    return buildProposalVote({
+      input,
+      connection,
+      squads,
+      action: SQUADS_V3_VOTE_ACTIONS.approve,
+      errors,
+    });
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/cancel.ts
+++ b/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/cancel.ts
@@ -1,0 +1,15 @@
+import { publicProcedure } from "../../../procedures";
+import { buildProposalVote, createSquadsV3, SQUADS_V3_VOTE_ACTIONS } from "./helpers";
+
+export const cancelProposal = publicProcedure.squadsV3.cancelProposal.handler(
+  async ({ input, errors }) => {
+    const { connection, squads } = createSquadsV3(input.member);
+    return buildProposalVote({
+      input,
+      connection,
+      squads,
+      action: SQUADS_V3_VOTE_ACTIONS.cancel,
+      errors,
+    });
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/execute.ts
+++ b/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/execute.ts
@@ -1,0 +1,66 @@
+import { publicProcedure } from "../../../procedures";
+import { PublicKey } from "@solana/web3.js";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "@/lib/utils/transaction-tags";
+import { buildSquadsTransaction } from "@/lib/utils/squads-tx";
+import { createSquadsV3 } from "./helpers";
+
+export const executeProposal = publicProcedure.squadsV3.executeProposal.handler(
+  async ({ input, errors }) => {
+    const { member, multisig: multisigAddress, transactionPda } = input;
+    const memberKey = new PublicKey(member);
+    const txPda = new PublicKey(transactionPda);
+    const { connection, squads } = createSquadsV3(member);
+
+    // Surface a missing or foreign account as NOT_FOUND up front;
+    // buildExecuteTransaction reads and deserializes the account to assemble the
+    // inner instruction accounts and would otherwise throw an opaque error.
+    const account = await connection.getAccountInfo(txPda);
+    if (!account || !account.owner.equals(squads.multisigProgramId)) {
+      throw errors.NOT_FOUND({
+        message: `No Squads v3 transaction found at ${transactionPda}`,
+      });
+    }
+
+    const ix = await squads.buildExecuteTransaction(txPda, memberKey);
+
+    const { serializedTransaction } = await buildSquadsTransaction({
+      connection,
+      member: memberKey,
+      instructions: [ix],
+      insufficientFunds: ({ required, available }) =>
+        errors.INSUFFICIENT_FUNDS({
+          message: "Insufficient SOL balance to execute the proposal",
+          data: { required, available },
+        }),
+    });
+
+    const tag = generateTransactionTag({
+      type: TRANSACTION_TYPES.SQUADS_V3_PROPOSAL_EXECUTE,
+      member,
+      multisig: multisigAddress,
+      transactionPda,
+    });
+
+    return {
+      transactions: [
+        {
+          serializedTransaction,
+          metadata: {
+            type: TRANSACTION_TYPES.SQUADS_V3_PROPOSAL_EXECUTE,
+            description: `Execute transaction ${transactionPda}`,
+          },
+        },
+      ],
+      parallel: false,
+      tag,
+      actionMetadata: {
+        type: TRANSACTION_TYPES.SQUADS_V3_PROPOSAL_EXECUTE,
+        multisig: multisigAddress,
+        transactionPda,
+      },
+    };
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/helpers.ts
@@ -1,0 +1,137 @@
+import { Connection, PublicKey, TransactionInstruction } from "@solana/web3.js";
+import Squads from "@sqds/sdk";
+import { createSolanaConnection } from "@/lib/solana";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+  TransactionType,
+} from "@/lib/utils/transaction-tags";
+import { buildSquadsTransaction, ProposalErrors } from "@/lib/utils/squads-tx";
+
+/**
+ * Squads v3 authority index reserved for the multisig's own internal authority.
+ * Config-change instructions (addMember / removeMember / changeThreshold)
+ * require the multisig account itself as signer, so their wrapping transaction
+ * is created under this index.
+ */
+export const CONFIG_AUTHORITY_INDEX = 0;
+
+/**
+ * Instantiate the v3 Squads SDK for a given acting member. The SDK's `build*`
+ * methods read `wallet.publicKey` as the member / creator / approver, so the
+ * non-signing wallet from `createSolanaConnection` scopes every built
+ * instruction to `member`.
+ */
+export function createSquadsV3(member: string): {
+  connection: Connection;
+  squads: Squads;
+} {
+  const { connection, wallet } = createSolanaConnection(member);
+  // The SDK types `wallet` as a NodeWallet (with a signing `payer`), but we only
+  // call non-signing `build*` methods, which read `wallet.publicKey` alone. The
+  // non-signing wallet from createSolanaConnection is sufficient here.
+  const squads = new Squads({
+    connection,
+    wallet: wallet as unknown as ConstructorParameters<
+      typeof Squads
+    >[0]["wallet"],
+  });
+  return { connection, squads };
+}
+
+/**
+ * Per-vote-action descriptor. `type` keys both the tag and the metadata; `verb`
+ * is its human-readable label; `buildIx` is the v3 SDK instruction builder for
+ * the vote (all v3 vote builders act on the transaction PDA directly).
+ */
+export type ProposalVoteAction = {
+  type: TransactionType;
+  verb: string;
+  buildIx: (
+    squads: Squads,
+    multisigPda: PublicKey,
+    transactionPda: PublicKey
+  ) => Promise<TransactionInstruction>;
+};
+
+export const SQUADS_V3_VOTE_ACTIONS = {
+  approve: {
+    type: TRANSACTION_TYPES.SQUADS_V3_PROPOSAL_APPROVE,
+    verb: "Approve",
+    buildIx: (squads, multisigPda, transactionPda) =>
+      squads.buildApproveTransaction(multisigPda, transactionPda),
+  },
+  reject: {
+    type: TRANSACTION_TYPES.SQUADS_V3_PROPOSAL_REJECT,
+    verb: "Reject",
+    buildIx: (squads, multisigPda, transactionPda) =>
+      squads.buildRejectTransaction(multisigPda, transactionPda),
+  },
+  cancel: {
+    type: TRANSACTION_TYPES.SQUADS_V3_PROPOSAL_CANCEL,
+    verb: "Cancel",
+    buildIx: (squads, multisigPda, transactionPda) =>
+      squads.buildCancelTransaction(multisigPda, transactionPda),
+  },
+} as const satisfies Record<string, ProposalVoteAction>;
+
+/**
+ * Shared body for the v3 approve / reject / cancel endpoints, which differ only
+ * in the Squads instruction they build and their labels.
+ */
+export async function buildProposalVote({
+  input,
+  connection,
+  squads,
+  action,
+  errors,
+}: {
+  input: { member: string; multisig: string; transactionPda: string };
+  connection: Connection;
+  squads: Squads;
+  action: ProposalVoteAction;
+  errors: ProposalErrors;
+}) {
+  const member = new PublicKey(input.member);
+  const multisigPda = new PublicKey(input.multisig);
+  const transactionPda = new PublicKey(input.transactionPda);
+
+  const ix = await action.buildIx(squads, multisigPda, transactionPda);
+
+  const { serializedTransaction } = await buildSquadsTransaction({
+    connection,
+    member,
+    instructions: [ix],
+    insufficientFunds: ({ required, available }) =>
+      errors.INSUFFICIENT_FUNDS({
+        message: `Insufficient SOL balance to ${action.verb.toLowerCase()} the proposal`,
+        data: { required, available },
+      }),
+  });
+
+  const tag = generateTransactionTag({
+    type: action.type,
+    member: input.member,
+    multisig: input.multisig,
+    transactionPda: input.transactionPda,
+  });
+
+  return {
+    transactions: [
+      {
+        serializedTransaction,
+        metadata: {
+          type: action.type,
+          description: `${action.verb} transaction ${input.transactionPda}`,
+        },
+      },
+    ],
+    parallel: false,
+    tag,
+    actionMetadata: {
+      type: action.type,
+      multisig: input.multisig,
+      transactionPda: input.transactionPda,
+    },
+  };
+}

--- a/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/proposeConfigChange.ts
+++ b/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/proposeConfigChange.ts
@@ -1,0 +1,103 @@
+import { publicProcedure } from "../../../procedures";
+import { PublicKey } from "@solana/web3.js";
+import Squads from "@sqds/sdk";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "@/lib/utils/transaction-tags";
+import { buildSquadsTransaction } from "@/lib/utils/squads-tx";
+import { CONFIG_AUTHORITY_INDEX, createSquadsV3 } from "./helpers";
+
+type TransactionBuilder = Awaited<
+  ReturnType<Squads["getTransactionBuilder"]>
+>;
+
+type ConfigAction =
+  | { type: "addMember"; newMember: string }
+  | { type: "removeMember"; oldMember: string }
+  | { type: "changeThreshold"; newThreshold: number };
+
+/** Apply a single config action to the running transaction builder. */
+function applyAction(
+  builder: TransactionBuilder,
+  action: ConfigAction
+): Promise<TransactionBuilder> {
+  switch (action.type) {
+    case "addMember":
+      return builder.withAddMember(new PublicKey(action.newMember));
+    case "removeMember":
+      return builder.withRemoveMember(new PublicKey(action.oldMember));
+    case "changeThreshold":
+      return builder.withChangeThreshold(action.newThreshold);
+  }
+}
+
+export const proposeConfigChange =
+  publicProcedure.squadsV3.proposeConfigChange.handler(
+    async ({ input, errors }) => {
+      const { member, multisig: multisigAddress, actions } = input;
+      const memberKey = new PublicKey(member);
+      const multisigPda = new PublicKey(multisigAddress);
+      const { connection, squads } = createSquadsV3(member);
+
+      // Config-change instructions require the multisig account as signer, so
+      // the wrapping transaction is created under the internal authority index.
+      let builder = await squads
+        .getTransactionBuilder(multisigPda, CONFIG_AUTHORITY_INDEX)
+        .catch(() => {
+          throw errors.NOT_FOUND({
+            message: `Multisig ${multisigAddress} not found`,
+          });
+        });
+      for (const action of actions) {
+        builder = await applyAction(builder, action);
+      }
+
+      // getInstructions yields the create + per-instruction add ixs; activate
+      // moves the transaction from draft to votable, mirroring v4's proposalCreate.
+      const [createIxs, transactionPda] = await builder.getInstructions();
+      const activateIx = await squads.buildActivateTransaction(
+        multisigPda,
+        transactionPda
+      );
+
+      const { serializedTransaction } = await buildSquadsTransaction({
+        connection,
+        member: memberKey,
+        instructions: [...createIxs, activateIx],
+        insufficientFunds: ({ required, available }) =>
+          errors.INSUFFICIENT_FUNDS({
+            message: "Insufficient SOL balance to propose the config change",
+            data: { required, available },
+          }),
+      });
+
+      const transactionPdaStr = transactionPda.toBase58();
+      const tag = generateTransactionTag({
+        type: TRANSACTION_TYPES.SQUADS_V3_CONFIG_CHANGE,
+        member,
+        multisig: multisigAddress,
+        transactionPda: transactionPdaStr,
+        actions: actions.map((a) => a.type),
+      });
+
+      return {
+        transactions: [
+          {
+            serializedTransaction,
+            metadata: {
+              type: TRANSACTION_TYPES.SQUADS_V3_CONFIG_CHANGE,
+              description: `Propose config change ${transactionPdaStr}`,
+            },
+          },
+        ],
+        parallel: false,
+        tag,
+        actionMetadata: {
+          type: TRANSACTION_TYPES.SQUADS_V3_CONFIG_CHANGE,
+          multisig: multisigAddress,
+          transactionPda: transactionPdaStr,
+        },
+      };
+    }
+  );

--- a/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/reject.ts
+++ b/packages/blockchain-api/src/server/api/routers/squadsV3/procedures/reject.ts
@@ -1,0 +1,15 @@
+import { publicProcedure } from "../../../procedures";
+import { buildProposalVote, createSquadsV3, SQUADS_V3_VOTE_ACTIONS } from "./helpers";
+
+export const rejectProposal = publicProcedure.squadsV3.rejectProposal.handler(
+  async ({ input, errors }) => {
+    const { connection, squads } = createSquadsV3(input.member);
+    return buildProposalVote({
+      input,
+      connection,
+      squads,
+      action: SQUADS_V3_VOTE_ACTIONS.reject,
+      errors,
+    });
+  }
+);

--- a/packages/blockchain-api/src/server/api/routers/squadsV3/router.ts
+++ b/packages/blockchain-api/src/server/api/routers/squadsV3/router.ts
@@ -1,0 +1,15 @@
+import { approveProposal } from "./procedures/approve";
+import { rejectProposal } from "./procedures/reject";
+import { cancelProposal } from "./procedures/cancel";
+import { executeProposal } from "./procedures/execute";
+import { proposeConfigChange } from "./procedures/proposeConfigChange";
+import { squadsV3Contract } from "@helium/blockchain-api/contracts";
+import { implement } from "@orpc/server";
+
+export const squadsV3Router = implement(squadsV3Contract).router({
+  approveProposal,
+  rejectProposal,
+  cancelProposal,
+  executeProposal,
+  proposeConfigChange,
+});


### PR DESCRIPTION
Adds a standalone `squadsV3` router giving Squads **v3** multisigs the same proposal-lifecycle surface the v4 router already provides, under `/squads/v3/*`. Built on `@sqds/sdk`.

## Endpoints
| Endpoint | Path |
|---|---|
| `approveProposal` | `POST /squads/v3/proposals/approve` |
| `rejectProposal` | `POST /squads/v3/proposals/reject` |
| `cancelProposal` | `POST /squads/v3/proposals/cancel` |
| `executeProposal` | `POST /squads/v3/proposals/execute` |
| `proposeConfigChange` | `POST /squads/v3/proposals/config` |

Each returns unsigned transaction(s) for the acting member to sign, matching the v4 response envelope.

## Notes on the v3 model
- v3 votes/execute key off the **transaction PDA** directly (no separate proposal account as in v4), so inputs are `{ member, multisig, transactionPda }`.
- `proposeConfigChange` builds `createTransaction + addInstruction + activateTransaction` into one unsigned tx, mirroring v4's create-only (no auto-vote).
- The version-neutral `buildSquadsTransaction` (+ types) is factored into `lib/utils/squads-tx.ts` and shared by both routers; v4 re-exports it, so v4 consumers are untouched.

## Draft — one item needs verification before merge
See the flagged inline comment: the `authorityIndex` for v3 config-change transactions is set to `0` and has **not** been verified end-to-end against the on-chain squads-mpl program. The four vote/execute endpoints have unambiguous account derivation; only `proposeConfigChange` carries this open question.