### PR TITLE
fix(shared-utils): unblock devnet deploy — allow uint idl-build lint

### DIFF
--- a/utils/shared-utils/src/uint.rs
+++ b/utils/shared-utils/src/uint.rs
@@ -5,6 +5,12 @@
 #![allow(clippy::ptr_offset_with_cast)]
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::manual_div_ceil)]
+// The `uint` crate's construct_uint! expansion (uint_full_mul_reg!) trips
+// semicolon_in_expressions_from_macros on the host x86_64 `anchor idl build`.
+// The lint fires inside third-party macro code we can't edit, and uint 0.9.5
+// (latest 0.9) still emits it; the generated code is correct. Revisit if uint
+// publishes a fix.
+#![allow(semicolon_in_expressions_from_macros)]
 
 use uint::construct_uint;
 


### PR DESCRIPTION
## Problem

The **Deploy Programs to devnet** workflow fails on any change that rebuilds a program depending on `shared-utils` (surfaced by #1197 rebuilding `helium-sub-daos`): [run 29625163191](https://github.com/helium/helium-program-library/actions/runs/29625163191).

```
error: trailing semicolon in macro used in expression position
  --> utils/shared-utils/src/uint.rs:11  (construct_uint! { pub struct U256(4); })
  --> utils/shared-utils/src/uint.rs:14  (construct_uint! { pub struct U192(3); })
```

The `uint` crate's `construct_uint!` -> `uint_full_mul_reg!` expansion trips the `semicolon_in_expressions_from_macros` future-incompat lint (deny-by-default). It only fires on the **host x86_64** compile done by `anchor idl build` (part of the deploy's `anchor build`), not the SBF build — which is why PR CI (SBF) passed while the deploy (host IDL build) failed. `uint.rs` is untouched since April 2025; this is latent, not a #1197 regression, and it will block every future deploy rebuilding a shared-utils dependent.

## Fix

Add `#![allow(semicolon_in_expressions_from_macros)]` to `uint.rs`, alongside the clippy allows already there for the same `construct_uint!` usage. The lint is inside third-party macro code we can't edit; `uint` 0.9.5 (latest 0.9) still emits it; the generated code is correct. Chose suppression over bumping `uint` to avoid behavioral risk to the U256/U192 reward math in a deploy hotfix.

## Verification

Local x86_64 reproduction is blocked by cross-linking from macOS (a known cross-OS blind spot), so this PR's CI is the confirmation. `shared-utils` builds clean on the pinned 1.85.0 toolchain locally with the attribute applied.