### PR TITLE
fix(ci): pin solana-verify to 0.5.0 to unblock devnet deploys

### DIFF
--- a/.github/actions/build-verified/action.yaml
+++ b/.github/actions/build-verified/action.yaml
@@ -36,8 +36,11 @@ runs:
       with:
         path: |
           ~/.cargo/bin/solana-verify
-        key: cargo-${{ runner.os }}-solana-verify
-    - run: cargo install solana-verify --locked --force
+        key: cargo-${{ runner.os }}-solana-verify-0.5.0
+    # Pinned: solana-verify 0.5.1+ pulls deps (solana-address, solana-system-interface)
+    # that require rustc 1.89, but the build toolchain is pinned to 1.85. 0.5.0 is the
+    # newest release that still builds on 1.85. Bump alongside the rustc pin.
+    - run: cargo install solana-verify --version 0.5.0 --locked --force
       if: steps.cache-solana-verify.outputs.cache-hit != 'true'
       shell: bash
     - run: ${{ inputs.testing == 'true' && 'TESTING=true' || '' }} ~/.cargo/bin/solana-verify build --library-name $PROGRAM ${{ inputs.devnet == 'true' && '-- --features devnet' || '' }}


### PR DESCRIPTION
## Problem

Every devnet program deploy fails at the `build-verified` step:

```
error: failed to compile `solana-verify v0.5.1`
Caused by:
  rustc 1.85.0 is not supported by the following packages:
    solana-address@2.6.0 requires rustc 1.89.0
    solana-system-interface@3.2.0 requires rustc 1.89.0
```

`.github/actions/build-verified/action.yaml` ran `cargo install solana-verify --locked --force` with **no version pin**. A cache miss (the cache key had no version) pulled the latest `solana-verify` 0.5.1, whose transitive deps now require rustc **1.89**, but the build toolchain is pinned to **1.85** (`setup-anchor`). Surfaced when deploying `helium-sub-daos` / `hpl-crons`, but it blocks **all** program deploys.

## Fix

- Pin `cargo install solana-verify --version 0.5.0` — the newest release that still builds on rustc 1.85 (verified in a `rust:1.85.0` x86_64 container: 0.5.1 fails the MSRV gate, 0.5.0 installs clean).
- Stamp the version into the cache key (`...-solana-verify-0.5.0`) so a future version bump invalidates the stale cache instead of silently reusing it.

To move to a newer `solana-verify` later, bump the rustc pin and this version together.

## Scope

Unrelated to the program code. Companion to #1209 (which fixed the `build-anchor`/IDL step); with both merged, the `helium-sub-daos` + `hpl-crons` devnet deploy proceeds past both build steps.