### PR TITLE
Fix/queue end epoch heap oom

### DIFF
--- a/.changeset/hip149-idls-regen.md
+++ b/.changeset/hip149-idls-regen.md
@@ -1,0 +1,5 @@
+---
+"@helium/idls": patch
+---
+
+Republish IDL types with the HIP 149 changes from #1197: `queue_end_epoch` now requires the `hnt_price_oracle` account and `calculate_utility_score_v0` accepts an optional `hnt_price_oracle`

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,36 @@ jobs:
       - run: cargo fmt -- --check
       - run: cargo clippy --all-targets -- -D warnings -A clippy::result_large_err -A clippy::too_many_arguments -A clippy::uninlined-format-args -A clippy::manual_is_multiple_of -A ambiguous_glob_reexports -A unexpected-cfgs
 
+  check-idls-changeset:
+    name: Check @helium/idls Changeset
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Require an @helium/idls changeset when program sources change
+        # @helium/idls has no src/ of its own -- it compiles the generated
+        # target/types, which is gitignored. Changesets tooling only diffs
+        # packages/, so program interface changes never trigger an idls bump
+        # on their own and the published package silently goes stale.
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          if ! git diff --name-only "$BASE"...HEAD | grep -qE '^programs/[^/]+/src/'; then
+            echo "No program source changes; skipping."
+            exit 0
+          fi
+          ADDED=$(git diff --name-only --diff-filter=A "$BASE"...HEAD -- '.changeset/*.md')
+          if [ -n "$ADDED" ] && grep -l '@helium/idls' $ADDED > /dev/null 2>&1; then
+            echo "Found @helium/idls changeset."
+            exit 0
+          fi
+          echo "This PR changes program sources but adds no changeset for @helium/idls."
+          echo "Program changes alter the generated IDL types that @helium/idls publishes,"
+          echo "but changesets can't detect that because target/types is gitignored."
+          echo "Run: npx changeset -- and include \"@helium/idls\" (patch is usually right)."
+          exit 1
+
   test-unit:
     name: Rust Unit Tests
     runs-on: ubuntu-latest
@@ -209,6 +239,7 @@ jobs:
           - tests/mobile-entity-manager.ts
           - tests/helium-sub-daos.ts
           - tests/hexboosting.ts
+          - tests/hpl-crons.ts
           - tests/lazy-distributor.ts
           - tests/lazy-transactions.ts
           - tests/treasury-management.ts

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -61,6 +61,7 @@ startup_wait = 20000
 
 [test.validator]
 url = "https://api.mainnet-beta.solana.com"
+bind_address = "127.0.0.1"
 
 [[test.validator.clone]]
 address = "tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA" # tuktuk

--- a/packages/helium-admin-cli/src/update-data-credits.ts
+++ b/packages/helium-admin-cli/src/update-data-credits.ts
@@ -56,7 +56,6 @@ export async function run(args: any = process.argv) {
         newAuthority: argv.newAuthority
           ? new PublicKey(argv.newAuthority)
           : null,
-        hntPriceOracle: null,
       })
       .accountsPartial({
         dataCredits,

--- a/packages/helium-admin-cli/src/update-data-credits.ts
+++ b/packages/helium-admin-cli/src/update-data-credits.ts
@@ -1,38 +1,38 @@
-import * as anchor from '@coral-xyz/anchor';
-import { dataCreditsKey, init as initDc } from '@helium/data-credits-sdk';
-import { PublicKey, TransactionInstruction } from '@solana/web3.js';
-import os from 'os';
-import yargs from 'yargs/yargs';
+import * as anchor from "@coral-xyz/anchor";
+import { dataCreditsKey, init as initDc } from "@helium/data-credits-sdk";
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import os from "os";
+import yargs from "yargs/yargs";
 import {
   loadKeypair,
   sendInstructionsOrCreateProposal,
   sendInstructionsOrSquadsV4,
-} from './utils';
+} from "./utils";
 
 export async function run(args: any = process.argv) {
   const yarg = yargs(args).options({
     wallet: {
-      alias: 'k',
-      describe: 'Anchor wallet keypair',
+      alias: "k",
+      describe: "Anchor wallet keypair",
       default: `${os.homedir()}/.config/solana/id.json`,
     },
     url: {
-      alias: 'u',
-      default: 'http://127.0.0.1:8899',
-      describe: 'The solana url',
+      alias: "u",
+      default: "http://127.0.0.1:8899",
+      describe: "The solana url",
     },
     dcMint: {
       required: true,
-      type: 'string',
-      describe: 'Data credits mint address',
+      type: "string",
+      describe: "Data credits mint address",
     },
     newAuthority: {
-      type: 'string',
+      type: "string",
     },
     multisig: {
-      type: 'string',
+      type: "string",
       describe:
-        'Address of the squads multisig to be authority. If not provided, your wallet will be the authority',
+        "Address of the squads multisig to be authority. If not provided, your wallet will be the authority",
     },
   });
   const argv = await yarg.argv;
@@ -47,7 +47,7 @@ export async function run(args: any = process.argv) {
 
   const dataCredits = dataCreditsKey(new PublicKey(argv.dcMint))[0];
   const dataCreditsAcc = await program.account.dataCreditsV0.fetch(dataCredits);
-  console.log('Data Credits', dataCredits.toBase58());
+  console.log("Data Credits", dataCredits.toBase58());
 
   console.log(dataCreditsAcc.authority.toBase58());
   instructions.push(
@@ -56,6 +56,7 @@ export async function run(args: any = process.argv) {
         newAuthority: argv.newAuthority
           ? new PublicKey(argv.newAuthority)
           : null,
+        hntPriceOracle: null,
       })
       .accountsPartial({
         dataCredits,
@@ -74,5 +75,5 @@ export async function run(args: any = process.argv) {
 }
 
 function isNull(vehntDelegated: string | undefined | null) {
-  return vehntDelegated === null || typeof vehntDelegated == 'undefined';
+  return vehntDelegated === null || typeof vehntDelegated == "undefined";
 }

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -263,14 +263,14 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
       // At the end of each epoch, schedule the next epoch end and reschedule the cron
       TaskReturnV0 {
         trigger: end_of_epoch_trigger,
-        transaction: TransactionSourceV0::CompiledV0(compiled_tx.clone()),
+        transaction: TransactionSourceV0::CompiledV0(compiled_tx),
         crank_reward: None,
         free_tasks: 0,
         description: format!("end epoch {}", curr_epoch),
       },
       TaskReturnV0 {
         trigger: end_of_epoch_trigger,
-        transaction: TransactionSourceV0::CompiledV0(compiled_reschedule_tx.clone()),
+        transaction: TransactionSourceV0::CompiledV0(compiled_reschedule_tx),
         crank_reward: None,
         free_tasks: 2,
         description: format!("queue end epoch {}", curr_epoch),

--- a/tests/hpl-crons.ts
+++ b/tests/hpl-crons.ts
@@ -1,0 +1,199 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { sendInstructions } from "@helium/spl-utils";
+import { Tuktuk } from "@helium/tuktuk-idls/lib/types/tuktuk";
+import {
+  compileTransaction,
+  customSignerKey,
+  init as initTuktuk,
+  runTask,
+  taskKey,
+  taskQueueKey,
+  taskQueueNameMappingKey,
+  tuktukConfigKey,
+} from "@helium/tuktuk-sdk";
+import {
+  ComputeBudgetProgram,
+  PublicKey,
+  SystemProgram,
+} from "@solana/web3.js";
+import { expect } from "chai";
+import { init as initHsd } from "../packages/helium-sub-daos-sdk/src";
+import {
+  epochTrackerKey,
+  init as initHplCrons,
+  taskReturnAccountKey,
+} from "../packages/hpl-crons-sdk/src";
+import { HeliumSubDaos } from "../target/types/helium_sub_daos";
+import { HplCrons } from "../target/types/hpl_crons";
+import { initTestDao, initTestSubdao } from "./utils/daos";
+
+describe("hpl-crons", () => {
+  anchor.setProvider(anchor.AnchorProvider.local("http://127.0.0.1:8899"));
+
+  const provider = anchor.getProvider() as anchor.AnchorProvider;
+  const me = provider.wallet.publicKey;
+  const tuktukConfig: PublicKey = tuktukConfigKey()[0];
+  const taskQueueName = `test-${Math.random().toString(36).substring(2, 15)}`;
+
+  let program: Program<HplCrons>;
+  let hsdProgram: Program<HeliumSubDaos>;
+  let tuktukProgram: Program<Tuktuk>;
+  let taskQueue: PublicKey;
+  let dao: PublicKey;
+  let iotSubDao: PublicKey;
+  let mobileSubDao: PublicKey;
+
+  before(async () => {
+    program = await initHplCrons(
+      provider,
+      anchor.workspace.HplCrons.programId,
+      anchor.workspace.HplCrons.idl
+    );
+    hsdProgram = await initHsd(
+      provider,
+      anchor.workspace.HeliumSubDaos.programId,
+      anchor.workspace.HeliumSubDaos.idl
+    );
+    tuktukProgram = await initTuktuk(provider);
+
+    const config = await tuktukProgram.account.tuktukConfigV0.fetch(
+      tuktukConfig
+    );
+    taskQueue = taskQueueKey(tuktukConfig, config.nextTaskQueueId)[0];
+    await tuktukProgram.methods
+      .initializeTaskQueueV0({
+        name: taskQueueName,
+        minCrankReward: new anchor.BN(1),
+        capacity: 100,
+        lookupTables: [],
+        staleTaskAge: 10000,
+      })
+      .accounts({
+        tuktukConfig,
+        payer: me,
+        updateAuthority: me,
+        taskQueue,
+        taskQueueNameMapping: taskQueueNameMappingKey(
+          tuktukConfig,
+          taskQueueName
+        )[0],
+      })
+      .rpc();
+
+    await tuktukProgram.methods
+      .addQueueAuthorityV0()
+      .accounts({
+        payer: me,
+        queueAuthority: me,
+        taskQueue,
+      })
+      .rpc();
+
+    ({ dao } = await initTestDao(hsdProgram, provider, 100, me));
+    ({ subDao: iotSubDao } = await initTestSubdao({
+      hsdProgram,
+      provider,
+      authority: me,
+      dao,
+    }));
+    ({ subDao: mobileSubDao } = await initTestSubdao({
+      hsdProgram,
+      provider,
+      authority: me,
+      dao,
+    }));
+
+    await program.methods
+      .initEpochTracker()
+      .accounts({
+        payer: me,
+        dao,
+        authority: me,
+      })
+      .rpc({ skipPreflight: true });
+  });
+
+  // Regression test for the mainnet outage where queue_end_epoch blew the 32KB
+  // SBF heap ("memory allocation failed, out of memory") while serializing the
+  // two compiled return transactions. Mirrors the production flow exactly:
+  // start-cron.ts queues the bootstrap task, then a crank turner runs it.
+  it("runs queue_end_epoch through tuktuk without exhausting the heap", async () => {
+    const [customWallet, bump] = customSignerKey(taskQueue, [
+      Buffer.from("helium", "utf-8"),
+    ]);
+    // The custom signer PDA pays rent for the task return account
+    await sendInstructions(provider, [
+      SystemProgram.transfer({
+        fromPubkey: me,
+        toPubkey: customWallet,
+        lamports: 1000000000,
+      }),
+    ]);
+
+    const bumpBuffer = Buffer.alloc(1);
+    bumpBuffer.writeUint8(bump);
+    const [epochTracker] = epochTrackerKey(dao);
+    const { transaction, remainingAccounts } = compileTransaction(
+      [
+        await program.methods
+          .queueEndEpoch()
+          .accountsStrict({
+            payer: customWallet,
+            taskReturnAccount: taskReturnAccountKey()[0],
+            epochTracker,
+            taskQueue,
+            dao,
+            iotSubDao,
+            mobileSubDao,
+            hntPriceOracle: me,
+            systemProgram: SystemProgram.programId,
+          })
+          .instruction(),
+      ],
+      [[Buffer.from("helium", "utf-8"), bumpBuffer]]
+    );
+
+    const epochBefore = (
+      await program.account.epochTrackerV0.fetch(epochTracker)
+    ).epoch;
+
+    const task = taskKey(taskQueue, 0)[0];
+    await tuktukProgram.methods
+      .queueTaskV0({
+        id: 0,
+        trigger: { now: {} },
+        crankReward: null,
+        freeTasks: 2,
+        transaction: {
+          compiledV0: [transaction],
+        },
+        description: `queue end epoch ${epochBefore.add(new anchor.BN(1))}`,
+      })
+      .accountsPartial({
+        task,
+        taskQueue,
+      })
+      .remainingAccounts(remainingAccounts)
+      .rpc({ skipPreflight: true });
+
+    // This is the step that OOMed on mainnet: RunTaskV0 CPIs into
+    // queue_end_epoch, which compiles the 5-instruction end-epoch transaction
+    // plus its own reschedule and writes both into the task return account.
+    await sendInstructions(provider, [
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
+      ...(await runTask({
+        program: tuktukProgram,
+        task,
+        crankTurner: me,
+      })),
+    ]);
+
+    const epochAfter = (
+      await program.account.epochTrackerV0.fetch(epochTracker)
+    ).epoch;
+    expect(epochAfter.toString()).to.equal(
+      epochBefore.add(new anchor.BN(1)).toString()
+    );
+  });
+});


### PR DESCRIPTION
Why queue_end_epoch blew the heap

  HIP 149 threads hnt_price_oracle and the Mobile epoch-info accounts into every calculate_utility_score_v0 in the compiled end-epoch transaction, growing compiled_tx. The handler then .clone()d both
  compiled transactions into the TaskReturnV0s, doubling the now-larger allocations and pushing past the 32KB BPF heap when run via tuktuk's runTask. Fix: move instead of clone — the values aren't
  used afterward.