### PR TITLE
fix(idls): rebuild types with tsc -b instead of skipping once built

### DIFF
--- a/packages/idls/package.json
+++ b/packages/idls/package.json
@@ -24,7 +24,7 @@
     "clean": "npx shx rm -rf **/tsconfig*.tsbuildinfo && npx shx rm -rf lib && npx shx mkdir -p lib/cjs lib/esm",
     "package": "npx shx mkdir -p lib/cjs lib/esm",
     "prebuild": "test -f lib/cjs/circuit_breaker.js || (npm run clean && npm run package)",
-    "build": "test -f lib/cjs/circuit_breaker.js && echo 'idls already built, skipping' || tsc -b tsconfig.json"
+    "build": "tsc -b tsconfig.json"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.0",


### PR DESCRIPTION
`@helium/idls`'s `build` script skipped `tsc` entirely whenever `lib/cjs/circuit_breaker.js` already existed:

```
"build": "test -f lib/cjs/circuit_breaker.js && echo 'idls already built, skipping' || tsc -b tsconfig.json"
```

Once `lib/` was built, regenerated `target/types` were never recompiled, so downstream packages (the SDKs and `helium-admin-cli`) type-checked against stale idl types (missing newly added accounts/instructions). `tsc -b` is already incremental via `.tsbuildinfo`, so running it unconditionally recompiles only what changed.

CI is unaffected: a fresh checkout has no `lib/`, so it always took the `tsc -b` branch. This only changes local incremental rebuilds, which previously silently served stale types.