### PR TITLE
fix: stop requiring zero-reward claims to close expired delegations

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -3,15 +3,19 @@ description: "Setup"
 runs:
   using: "composite"
   steps:
-      - run: sudo apt-get update
-        shell: bash
-      - run: sudo apt-get install -y pkg-config build-essential libudev-dev
-        shell: bash
-        # TODO: We're on anchor latest because of https://github.com/coral-xyz/anchor/issues/2568
-        # On anchor 0.28.1 we can probably stop using 0 as the source
-      - run: echo "ANCHOR_VERSION=0.31.1" >> $GITHUB_ENV
-        shell: bash
-      - run: echo "ANCHOR_SHA=3e8bc76d72e2bfdb3962868b5066" >> $GITHUB_ENV
-        shell: bash
-      - run: git submodule update --init --recursive --depth 1
-        shell: bash
+    # Runner-preinstalled Microsoft repos (azure-cli etc.) intermittently
+    # serve corrupt indexes and fail apt-get update; nothing here needs them.
+    - run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod* /etc/apt/sources.list.d/azure-cli*
+      shell: bash
+    - run: sudo apt-get update
+      shell: bash
+    - run: sudo apt-get install -y pkg-config build-essential libudev-dev
+      shell: bash
+      # TODO: We're on anchor latest because of https://github.com/coral-xyz/anchor/issues/2568
+      # On anchor 0.28.1 we can probably stop using 0 as the source
+    - run: echo "ANCHOR_VERSION=0.31.1" >> $GITHUB_ENV
+      shell: bash
+    - run: echo "ANCHOR_SHA=3e8bc76d72e2bfdb3962868b5066" >> $GITHUB_ENV
+      shell: bash
+    - run: git submodule update --init --recursive --depth 1
+      shell: bash

--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -12,7 +12,34 @@ on:
       - "packages/blockchain-api-client/**"
 
 jobs:
+  # Build anchor once and share the generated types/IDLs as an artifact. The
+  # matrix jobs only need target/types (to build @helium/idls); having each of
+  # them run build-anchor meant 17 full rebuilds whenever the cache was evicted
+  # (the repo sits at the 10GB Actions cache cap), and a cold anchor build
+  # can't finish inside the matrix jobs' 20-minute timeout.
+  build-idls:
+    runs-on: ubuntu-latest
+    # A cold-cache anchor build of the whole workspace takes well over 20
+    # minutes; this is the only job that compiles, so give it room.
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/build-anchor/
+        with:
+          testing: true
+      - name: Upload anchor types and IDLs
+        uses: actions/upload-artifact@v4
+        with:
+          name: anchor-types
+          path: |
+            target/types
+            target/idl
+          retention-days: 1
+          if-no-files-found: error
+
   e2e-tests:
+    needs: build-idls
     runs-on: ubuntu-latest
     # Backstop so a hung test (e.g. a stalled RPC) fails fast instead of running
     # until GitHub's default 6h job timeout and holding a runner.
@@ -119,9 +146,11 @@ jobs:
         run: |
           cargo install --git https://github.com/txtx/surfpool --tag v0.11.2 --locked --force
 
-      - uses: ./.github/actions/build-anchor/
+      - name: Download anchor types and IDLs
+        uses: actions/download-artifact@v4
         with:
-          testing: true
+          name: anchor-types
+          path: target
       - uses: ./.github/actions/setup-ts/
 
       - name: Write TESTING_KEY to file

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,17 +40,73 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Require an @helium/idls changeset when program sources change
-        # @helium/idls has no src/ of its own -- it compiles the generated
-        # target/types, which is gitignored. Changesets tooling only diffs
-        # packages/, so program interface changes never trigger an idls bump
-        # on their own and the published package silently goes stale.
+      - name: Detect changed programs
+        id: changed
         run: |
           BASE=${{ github.event.pull_request.base.sha }}
-          if ! git diff --name-only "$BASE"...HEAD | grep -qE '^programs/[^/]+/src/'; then
+          DIRS=$(git diff --name-only "$BASE"...HEAD | grep -E '^programs/[^/]+/src/' | cut -d/ -f2 | sort -u | tr '\n' ' ')
+          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+          if [ -z "$DIRS" ]; then
             echo "No program source changes; skipping."
+          else
+            echo "Changed programs: $DIRS"
+          fi
+      - uses: ./.github/actions/setup-anchor/
+        if: steps.changed.outputs.dirs != ''
+      - uses: actions/cache@v4
+        if: steps.changed.outputs.dirs != ''
+        name: Cache Cargo registry + index
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+      - name: Require an @helium/idls changeset when the generated IDL changes
+        if: steps.changed.outputs.dirs != ''
+        # @helium/idls has no src/ of its own -- it compiles the generated
+        # target/types, which is gitignored. Changesets tooling only diffs
+        # packages/, so IDL changes never trigger an idls bump on their own
+        # and the published package silently goes stale. Internal-only logic
+        # changes don't alter the IDL, so build the IDL at base and head
+        # (anchor idl build parses the source; no BPF build) and require a
+        # changeset only when the generated IDL actually differs.
+        run: |
+          set -e
+          BASE=${{ github.event.pull_request.base.sha }}
+          DIRS="${{ steps.changed.outputs.dirs }}"
+          mkdir -p /tmp/idl-head /tmp/idl-base
+          for dir in $DIRS; do
+            name=$(echo "$dir" | tr '-' '_')
+            ~/.cargo/bin/anchor idl build -p "$name" > "/tmp/idl-head/$name.json"
+          done
+          git checkout --detach "$BASE"
+          DIFFERING=""
+          for dir in $DIRS; do
+            name=$(echo "$dir" | tr '-' '_')
+            if [ ! -d "programs/$dir" ]; then
+              DIFFERING="$DIFFERING $name(new-program)"
+              continue
+            fi
+            if ! ~/.cargo/bin/anchor idl build -p "$name" > "/tmp/idl-base/$name.json"; then
+              DIFFERING="$DIFFERING $name(base-idl-build-failed)"
+              continue
+            fi
+            # metadata.version tracks the crate version, not the interface --
+            # a version bump alone shouldn't demand an idls republish.
+            if ! diff <(jq -S 'del(.metadata.version)' "/tmp/idl-base/$name.json") \
+                      <(jq -S 'del(.metadata.version)' "/tmp/idl-head/$name.json") > "/tmp/$name.idl.diff"; then
+              DIFFERING="$DIFFERING $name"
+              echo "=== IDL diff for $name ==="
+              cat "/tmp/$name.idl.diff"
+            fi
+          done
+          git checkout -
+          if [ -z "$DIFFERING" ]; then
+            echo "Program sources changed but generated IDLs are identical; no @helium/idls bump needed."
             exit 0
           fi
+          echo "IDL changed for:$DIFFERING"
           ADDED=$(git diff --name-only --diff-filter=A "$BASE"...HEAD -- '.changeset/*.md')
           if [ -n "$ADDED" ] && grep -l '@helium/idls' $ADDED > /dev/null 2>&1; then
             echo "Found @helium/idls changeset."
@@ -63,9 +119,8 @@ jobs:
             echo "@helium/idls version already bumped in this PR (changeset consumed)."
             exit 0
           fi
-          echo "This PR changes program sources but adds no changeset for @helium/idls."
-          echo "Program changes alter the generated IDL types that @helium/idls publishes,"
-          echo "but changesets can't detect that because target/types is gitignored."
+          echo "This PR changes the generated IDL for:$DIFFERING -- but adds no"
+          echo "changeset for @helium/idls, which publishes those generated types."
           echo "Run: npx changeset -- and include \"@helium/idls\" (patch is usually right)."
           exit 1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "helium-sub-daos"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/packages/blockchain-api/src/lib/solana.ts
+++ b/packages/blockchain-api/src/lib/solana.ts
@@ -27,7 +27,10 @@ let cachedConnection: Connection | undefined;
 
 function getConnection(): Connection {
   if (!cachedConnection) {
-    cachedConnection = new Connection(env.SOLANA_RPC_URL);
+    // "confirmed" so state reads see recently-landed transactions; the default
+    // ("finalized") lags ~15-30s, causing repeat rounds of claim flows to
+    // rebuild epochs that were already claimed.
+    cachedConnection = new Connection(env.SOLANA_RPC_URL, "confirmed");
   }
   return cachedConnection;
 }

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
@@ -34,6 +34,15 @@ type HsdProgram = Awaited<ReturnType<typeof initHsd>>;
 const DAO = daoKey(HNT_MINT)[0];
 const EPOCHS_PER_BATCH = 128;
 
+// Epochs at or after the delegation's expiration pay zero rewards and
+// close_delegation_v0 no longer requires claiming them. The epoch containing
+// expiration_ts still pays, so the exclusive end-epoch bound is
+// epoch(expiration - 1) + 1. An expirationTs of 0 means no expiration.
+export const expirationCapEpoch = (expirationTs: BN): number =>
+  expirationTs.isZero()
+    ? Number.MAX_SAFE_INTEGER
+    : expirationTs.sub(new BN(1)).div(new BN(EPOCH_LENGTH)).toNumber() + 1;
+
 interface PositionInfo {
   mint: PublicKey;
   pubkey: PublicKey;
@@ -142,17 +151,11 @@ export async function buildClaimInstructions(
       position.delegatedPosition;
     const startEpoch = lastClaimedEpoch.add(new BN(1));
     const bitmapWindowEnd = lastClaimedEpoch.add(new BN(129)).toNumber();
-    // Epochs at or after the delegation's expiration pay zero rewards and
-    // close_delegation_v0 no longer requires claiming them. The epoch
-    // containing expiration_ts still pays, so cap after epoch(expiration - 1).
-    const expirationCapEpoch = expirationTs.isZero()
-      ? Number.MAX_SAFE_INTEGER
-      : expirationTs.sub(new BN(1)).div(new BN(EPOCH_LENGTH)).toNumber() + 1;
     const rawEndEpoch = Math.min(
       isDecayed
         ? decayedEpoch.add(new BN(1)).toNumber()
         : currentEpoch.toNumber(),
-      expirationCapEpoch
+      expirationCapEpoch(expirationTs)
     );
     const endEpoch = Math.min(rawEndEpoch, bitmapWindowEnd);
 

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
@@ -49,6 +49,7 @@ interface PositionInfo {
     subDao: PublicKey;
     lastClaimedEpoch: BN;
     claimedEpochsBitmap: BN;
+    expirationTs: BN;
   };
 }
 
@@ -68,7 +69,7 @@ export interface BuildClaimInstructionsParams {
 
 async function getMultipleAccounts(
   connection: Connection,
-  keys: PublicKey[],
+  keys: PublicKey[]
 ): Promise<(Awaited<ReturnType<Connection["getAccountInfo"]>> | null)[]> {
   const batchSize = 100;
   const batches = Math.ceil(keys.length / batchSize);
@@ -85,7 +86,7 @@ async function getMultipleAccounts(
 }
 
 export async function buildClaimInstructions(
-  params: BuildClaimInstructionsParams,
+  params: BuildClaimInstructionsParams
 ): Promise<ClaimInstructionsResult> {
   const { positions, walletPubkey, connection, hsdProgram } = params;
 
@@ -94,7 +95,7 @@ export async function buildClaimInstructions(
   const currentEpoch = new BN(unixNow).div(new BN(EPOCH_LENGTH));
 
   const subDaoKeys = new Set(
-    positions.map((p) => p.delegatedPosition.subDao.toBase58()),
+    positions.map((p) => p.delegatedPosition.subDao.toBase58())
   );
 
   type SubDaoAccount = Awaited<
@@ -105,8 +106,8 @@ export async function buildClaimInstructions(
       async (key): Promise<[string, SubDaoAccount]> => [
         key,
         await hsdProgram.account.subDaoV0.fetch(new PublicKey(key)),
-      ],
-    ),
+      ]
+    )
   );
   const subDaos: Record<string, SubDaoAccount> =
     Object.fromEntries(subDaoEntries);
@@ -137,13 +138,22 @@ export async function buildClaimInstructions(
     const subDao = position.delegatedPosition.subDao;
     const subDaoAcc = subDaos[subDao.toBase58()];
 
-    const { lastClaimedEpoch, claimedEpochsBitmap } =
+    const { lastClaimedEpoch, claimedEpochsBitmap, expirationTs } =
       position.delegatedPosition;
     const startEpoch = lastClaimedEpoch.add(new BN(1));
     const bitmapWindowEnd = lastClaimedEpoch.add(new BN(129)).toNumber();
-    const rawEndEpoch = isDecayed
-      ? decayedEpoch.add(new BN(1)).toNumber()
-      : currentEpoch.toNumber();
+    // Epochs at or after the delegation's expiration pay zero rewards and
+    // close_delegation_v0 no longer requires claiming them. The epoch
+    // containing expiration_ts still pays, so cap after epoch(expiration - 1).
+    const expirationCapEpoch = expirationTs.isZero()
+      ? Number.MAX_SAFE_INTEGER
+      : expirationTs.sub(new BN(1)).div(new BN(EPOCH_LENGTH)).toNumber() + 1;
+    const rawEndEpoch = Math.min(
+      isDecayed
+        ? decayedEpoch.add(new BN(1)).toNumber()
+        : currentEpoch.toNumber(),
+      expirationCapEpoch
+    );
     const endEpoch = Math.min(rawEndEpoch, bitmapWindowEnd);
 
     if (rawEndEpoch > bitmapWindowEnd) {
@@ -188,11 +198,11 @@ export async function buildClaimInstructions(
   for (const chunk of chunks(allEpochsToClaim, EPOCHS_PER_BATCH)) {
     const subDaoEpochInfoKeys = chunk.map(
       ({ epoch, subDao }) =>
-        subDaoEpochInfoKey(subDao, epoch.mul(new BN(EPOCH_LENGTH)))[0],
+        subDaoEpochInfoKey(subDao, epoch.mul(new BN(EPOCH_LENGTH)))[0]
     );
     const subDaoEpochInfoAccounts = await getMultipleAccounts(
       connection,
-      subDaoEpochInfoKeys,
+      subDaoEpochInfoKeys
     );
 
     const batchInstructions = await Promise.all(
@@ -202,7 +212,7 @@ export async function buildClaimInstructions(
 
         const subDaoEpochInfoData = hsdProgram.coder.accounts.decode(
           "subDaoEpochInfoV0",
-          subDaoEpochInfoAccount.data,
+          subDaoEpochInfoAccount.data
         );
 
         if (!subDaoEpochInfoData.rewardsIssuedAt) return null;
@@ -212,7 +222,7 @@ export async function buildClaimInstructions(
           mint: position.mint,
           positionTokenAccount: getAssociatedTokenAddressSync(
             position.mint,
-            walletPubkey,
+            walletPubkey
           ),
           positionAuthority: walletPubkey,
           registrar: position.account.registrar,
@@ -236,15 +246,15 @@ export async function buildClaimInstructions(
               hntMint: daoAcc.hntMint,
               daoEpochInfo: daoEpochInfoKey(
                 subDaoAcc.dao,
-                epoch.mul(new BN(EPOCH_LENGTH)),
+                epoch.mul(new BN(EPOCH_LENGTH))
               )[0],
               delegatorPool: daoAcc.delegatorPool,
               delegatorAta: getAssociatedTokenAddressSync(
                 daoAcc.hntMint,
-                walletPubkey,
+                walletPubkey
               ),
               delegatorPoolCircuitBreaker: accountWindowedBreakerKey(
-                daoAcc.delegatorPool,
+                daoAcc.delegatorPool
               )[0],
             })
             .instruction();
@@ -257,20 +267,20 @@ export async function buildClaimInstructions(
               dntMint: subDaoAcc.dntMint,
               subDaoEpochInfo: subDaoEpochInfoKey(
                 subDao,
-                epoch.mul(new BN(EPOCH_LENGTH)),
+                epoch.mul(new BN(EPOCH_LENGTH))
               )[0],
               delegatorPool: subDaoAcc.delegatorPool,
               delegatorAta: getAssociatedTokenAddressSync(
                 subDaoAcc.dntMint,
-                walletPubkey,
+                walletPubkey
               ),
               delegatorPoolCircuitBreaker: accountWindowedBreakerKey(
-                subDaoAcc.delegatorPool,
+                subDaoAcc.delegatorPool
               )[0],
             })
             .instruction();
         }
-      }),
+      })
     );
 
     const validInstructions = batchInstructions.filter(truthy);

--- a/packages/blockchain-api/tests/unit/expiration-cap-epoch.test.ts
+++ b/packages/blockchain-api/tests/unit/expiration-cap-epoch.test.ts
@@ -1,0 +1,25 @@
+import { EPOCH_LENGTH } from "@helium/helium-sub-daos-sdk";
+import BN from "bn.js";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { expirationCapEpoch } from "../../src/server/api/routers/governance/procedures/helpers/build-claim-instructions";
+
+const epochStart = (epoch: number) => new BN(epoch).mul(new BN(EPOCH_LENGTH));
+
+describe("expirationCapEpoch", () => {
+  it("does not cap when there is no expiration", () => {
+    expect(expirationCapEpoch(new BN(0))).to.eq(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("includes the epoch containing a mid-epoch expiration", () => {
+    // Expiration mid-epoch 50: epoch 50 still pays, so the exclusive end
+    // bound is 51 and the last claimed epoch is 50.
+    expect(expirationCapEpoch(epochStart(50).add(new BN(10)))).to.eq(51);
+  });
+
+  it("excludes the epoch when expiration falls exactly on its start", () => {
+    // Expiration at the start of epoch 50 means epoch 50 pays zero; epoch 49
+    // is the last paying epoch, so the exclusive end bound is 50.
+    expect(expirationCapEpoch(epochStart(50))).to.eq(50);
+  });
+});

--- a/programs/helium-sub-daos/Cargo.toml
+++ b/programs/helium-sub-daos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helium-sub-daos"
-version = "0.2.41"
+version = "0.2.42"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/programs/helium-sub-daos/src/instructions/delegation/close_delegation_v0.rs
+++ b/programs/helium-sub-daos/src/instructions/delegation/close_delegation_v0.rs
@@ -59,6 +59,30 @@ pub fn get_closing_epoch_bytes(
   .to_le_bytes()
 }
 
+// Last epoch that must be claimed before a delegation can close. An ended
+// cliff position stops earning at lockup end. Epochs at or after the
+// delegation's expiration pay zero rewards (claim_rewards_v1 pays 0 once
+// expiration_ts <= epoch start), so an expired delegation only needs claims
+// through the last epoch that could pay out. expiration_ts == 0 means no
+// expiration; keep the strict requirement.
+pub fn to_claim_to_epoch(
+  curr_ts: i64,
+  lockup_end_ts: i64,
+  is_cliff: bool,
+  expiration_ts: i64,
+) -> u64 {
+  let curr_epoch = current_epoch(curr_ts);
+  let mut to_claim_to_epoch = if lockup_end_ts < curr_ts && is_cliff {
+    current_epoch(lockup_end_ts) - 1
+  } else {
+    curr_epoch - 1
+  };
+  if expiration_ts != 0 {
+    to_claim_to_epoch = min(to_claim_to_epoch, current_epoch(expiration_ts - 1));
+  }
+  to_claim_to_epoch
+}
+
 #[derive(Accounts)]
 pub struct CloseDelegationV0<'info> {
   #[account(mut)]
@@ -162,19 +186,12 @@ pub fn raw_handler(accounts: &mut CloseDelegationAccounts, sde_bump: u8) -> Resu
   // make sure to account for when the position ends
   // unless we're testing, in which case we don't care
   let curr_epoch = current_epoch(curr_ts);
-  let mut to_claim_to_epoch =
-    if position.lockup.end_ts < curr_ts && position.lockup.kind == LockupKind::Cliff {
-      current_epoch(position.lockup.end_ts) - 1
-    } else {
-      curr_epoch - 1
-    };
-  // Epochs at or after the delegation's expiration pay zero rewards
-  // (claim_rewards_v1 pays 0 once expiration_ts <= epoch start), so an expired
-  // delegation only needs claims through the last epoch that could pay out.
-  // expiration_ts == 0 means no expiration; keep the strict requirement.
-  if expiration_ts != 0 {
-    to_claim_to_epoch = min(to_claim_to_epoch, current_epoch(expiration_ts - 1));
-  }
+  let to_claim_to_epoch = to_claim_to_epoch(
+    curr_ts,
+    position.lockup.end_ts,
+    position.lockup.kind == LockupKind::Cliff,
+    expiration_ts,
+  );
   assert!((accounts.delegated_position.last_claimed_epoch >= to_claim_to_epoch) || TESTING);
 
   let delegated_position = &mut accounts.delegated_position;
@@ -324,4 +341,79 @@ pub fn handler(ctx: Context<CloseDelegationV0>) -> Result<()> {
   };
   raw_handler(&mut accounts, ctx.bumps.sub_dao_epoch_info)?;
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::EPOCH_LENGTH;
+
+  const NO_EXPIRATION: i64 = 0;
+
+  fn epoch_start(epoch: i64) -> i64 {
+    epoch * EPOCH_LENGTH
+  }
+
+  #[test]
+  fn no_expiration_requires_claims_through_previous_epoch() {
+    let curr_ts = epoch_start(100) + 5;
+    assert_eq!(
+      to_claim_to_epoch(curr_ts, epoch_start(200), false, NO_EXPIRATION),
+      99
+    );
+  }
+
+  #[test]
+  fn future_expiration_does_not_relax_the_requirement() {
+    let curr_ts = epoch_start(100) + 5;
+    assert_eq!(
+      to_claim_to_epoch(curr_ts, epoch_start(300), false, epoch_start(200)),
+      99
+    );
+  }
+
+  #[test]
+  fn expired_delegation_only_requires_claims_through_last_paying_epoch() {
+    // Expiration mid-epoch 50: epoch 50 still pays, epochs 51+ pay zero, so an
+    // expired delegation must be closable with last_claimed_epoch = 50 even
+    // though the current epoch is 100.
+    let curr_ts = epoch_start(100) + 5;
+    let expiration_ts = epoch_start(50) + 10;
+    assert_eq!(
+      to_claim_to_epoch(curr_ts, epoch_start(300), false, expiration_ts),
+      50
+    );
+  }
+
+  #[test]
+  fn expiration_on_epoch_boundary_excludes_that_epoch() {
+    // Expiration exactly at the start of epoch 50 means epoch 50 pays zero;
+    // epoch 49 is the last paying epoch.
+    let curr_ts = epoch_start(100) + 5;
+    assert_eq!(
+      to_claim_to_epoch(curr_ts, epoch_start(300), false, epoch_start(50)),
+      49
+    );
+  }
+
+  #[test]
+  fn ended_cliff_requires_claims_through_epoch_before_lockup_end() {
+    let curr_ts = epoch_start(100) + 5;
+    let lockup_end_ts = epoch_start(60) + 10;
+    assert_eq!(
+      to_claim_to_epoch(curr_ts, lockup_end_ts, true, NO_EXPIRATION),
+      59
+    );
+  }
+
+  #[test]
+  fn ended_cliff_with_earlier_expiration_takes_the_expiration_cap() {
+    let curr_ts = epoch_start(100) + 5;
+    let lockup_end_ts = epoch_start(60) + 10;
+    let expiration_ts = epoch_start(50) + 10;
+    assert_eq!(
+      to_claim_to_epoch(curr_ts, lockup_end_ts, true, expiration_ts),
+      50
+    );
+  }
 }

--- a/programs/helium-sub-daos/src/instructions/delegation/close_delegation_v0.rs
+++ b/programs/helium-sub-daos/src/instructions/delegation/close_delegation_v0.rs
@@ -162,12 +162,19 @@ pub fn raw_handler(accounts: &mut CloseDelegationAccounts, sde_bump: u8) -> Resu
   // make sure to account for when the position ends
   // unless we're testing, in which case we don't care
   let curr_epoch = current_epoch(curr_ts);
-  let to_claim_to_epoch =
+  let mut to_claim_to_epoch =
     if position.lockup.end_ts < curr_ts && position.lockup.kind == LockupKind::Cliff {
       current_epoch(position.lockup.end_ts) - 1
     } else {
       curr_epoch - 1
     };
+  // Epochs at or after the delegation's expiration pay zero rewards
+  // (claim_rewards_v1 pays 0 once expiration_ts <= epoch start), so an expired
+  // delegation only needs claims through the last epoch that could pay out.
+  // expiration_ts == 0 means no expiration; keep the strict requirement.
+  if expiration_ts != 0 {
+    to_claim_to_epoch = min(to_claim_to_epoch, current_epoch(expiration_ts - 1));
+  }
   assert!((accounts.delegated_position.last_claimed_epoch >= to_claim_to_epoch) || TESTING);
 
   let delegated_position = &mut accounts.delegated_position;

--- a/tests/circuit-breaker.ts
+++ b/tests/circuit-breaker.ts
@@ -5,7 +5,7 @@ import { Program } from "@coral-xyz/anchor";
 import {
   getAssociatedTokenAddress,
   createAssociatedTokenAccountInstruction,
-  getMint
+  getMint,
 } from "@solana/spl-token";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { BN } from "bn.js";
@@ -163,10 +163,12 @@ describe("circuit-breaker", () => {
     });
 
     it("allows removing the mint authority", async () => {
-      const method = await program.methods.removeMintAuthorityV0().accountsPartial({
-        rentRefund: me,
-        circuitBreaker: mintWindowedBreakerKey(mint)[0],
-      });
+      const method = await program.methods
+        .removeMintAuthorityV0()
+        .accountsPartial({
+          rentRefund: me,
+          circuitBreaker: mintWindowedBreakerKey(mint)[0],
+        });
       const circuitBreaker = (await method.pubkeys()).circuitBreaker!;
       await method.rpc({ skipPreflight: true });
       const cb =
@@ -192,6 +194,10 @@ describe("circuit-breaker", () => {
 
       try {
         // Curr supply: 250, agg value: 50... Break threshold at 125
+        // Keep preflight on: a preflight failure surfaces as an AnchorError
+        // with code and logs, while a post-send confirmation failure races
+        // anchor's getTransaction log fetch and can come back as an opaque
+        // SendTransactionError with neither.
         await program.methods
           .mintV0({
             amount: new BN(80),
@@ -200,7 +206,7 @@ describe("circuit-breaker", () => {
             mint,
             to: dest,
           })
-          .rpc({ skipPreflight: true });
+          .rpc();
         throw new Error("should not get here");
       } catch (e: any) {
         expectCircuitBreakerTriggered(e);
@@ -324,6 +330,7 @@ describe("circuit-breaker", () => {
         .rpc({ skipPreflight: true });
 
       try {
+        // Preflight on, for the same reason as the mint windowed test above.
         await program.methods
           .transferV0({
             amount: new BN(50),
@@ -334,7 +341,7 @@ describe("circuit-breaker", () => {
             to: dest,
             owner: accountHolder.publicKey,
           })
-          .rpc({ skipPreflight: true });
+          .rpc();
         throw new Error("should not get here");
       } catch (e: any) {
         expectCircuitBreakerTriggered(e);

--- a/tests/voter-stake-registry.ts
+++ b/tests/voter-stake-registry.ts
@@ -854,9 +854,11 @@ describe("voter-stake-registry", () => {
           error = e;
         }
         expect(error, "Expected vote to fail").to.exist;
-        // The error surfaces as an AnchorError or a raw InstructionError
-        // depending on whether it arrives via simulation or websocket
-        const code = error.code ?? error.InstructionError?.[1]?.Custom;
+        // The error surfaces as an AnchorError, a raw InstructionError, or a
+        // confirmation result ({ err, slot, confirmations }) depending on
+        // whether it arrives via simulation or websocket
+        const code =
+          error.code ?? (error.err ?? error).InstructionError?.[1]?.Custom;
         expect(code).to.eq(6044);
       });
 


### PR DESCRIPTION
Fixes the [helium-vote#284 ](https://github.com/helium/helium-vote/issues/284)'infinite signing loop': close_delegation_v0 required claiming through curr_epoch - 1 even though every epoch at or after the delegation's expiration_ts pays zero (claim_rewards_v1 zeroes delegated vehnt once expiration_ts <= epoch start). Users with expired delegations had to sign ~13 rounds of no-op claim bundles whose wallet preview showed only the Jito tip transfer.

- close_delegation_v0: cap to_claim_to_epoch at epoch(expiration_ts - 1) when expiration_ts is set; the epoch containing the expiration still pays and remains required. Bump helium-sub-daos to 0.2.42.
- blockchain-api buildClaimInstructions: apply the same cap so undelegate skips straight to closeDelegationV0. Must deploy the program before shipping this, or close txs fail the old on-chain assert.
- blockchain-api shared Connection: read at 'confirmed' instead of the default 'finalized', whose 15-30s lag made repeat claim rounds rebuild already-claimed epochs (observed: 216 of 288 epochs claimed 2-4x).