### PR TITLE
Allow veHNT position transfer to a target owned by another wallet

### DIFF
--- a/.changeset/vehnt-cross-wallet-transfer.md
+++ b/.changeset/vehnt-cross-wallet-transfer.md
@@ -1,0 +1,5 @@
+---
+"@helium/blockchain-api": minor
+---
+
+Allow veHNT position transfer to a target position owned by another wallet. `positions/transfer` no longer requires the caller to own the target position, matching the on-chain `transferV0` constraint, and adds registrar/voting-mint-config compatibility checks between source and target.

--- a/packages/blockchain-api-client/src/contracts/governance.ts
+++ b/packages/blockchain-api-client/src/contracts/governance.ts
@@ -120,7 +120,7 @@ export const governanceContract = oc
         path: "/positions/{positionMint}/transfer",
         summary: "Transfer between positions",
         description:
-          "Transfer tokens from one position to another. Both positions must have no active votes.",
+          "Transfer tokens from one position to another. Both positions must have no active votes. The target position may be owned by a different wallet, enabling veHNT transfer between wallets.",
       })
       .input(TransferPositionInputSchema)
       .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS })
@@ -132,7 +132,7 @@ export const governanceContract = oc
         path: "/positions/{positionMint}/transfer-ownership",
         summary: "Transfer position ownership",
         description:
-          "Transfer ownership of a position NFT to another wallet. Both the current owner and new owner must sign the transaction.",
+          "Transfer ownership of a position NFT to another wallet. Only the current owner must sign the transaction; the recipient does not.",
       })
       .input(TransferPositionOwnershipInputSchema)
       .errors({ BAD_REQUEST, NOT_FOUND, INSUFFICIENT_FUNDS })

--- a/packages/blockchain-api-client/src/schemas/governance.ts
+++ b/packages/blockchain-api-client/src/schemas/governance.ts
@@ -97,13 +97,13 @@ export const SplitPositionInputSchema = z.object({
 
 export const TransferPositionInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns both positions"
+    "Wallet address that owns the source position and pays transaction fees"
   ),
   positionMint: PublicKeySchema.describe(
     "Mint address of the source position NFT"
   ),
   targetPositionMint: PublicKeySchema.describe(
-    "Mint address of the target position NFT"
+    "Mint address of the target position NFT. May be owned by a different wallet; its lockup must be equal-or-longer and equal-or-stricter than the source's."
   ),
   amount: z
     .string()

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/transfer.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/transfer.ts
@@ -14,12 +14,35 @@ import {
 import { init as initHsd } from "@helium/helium-sub-daos-sdk";
 import { init as initVsr, positionKey } from "@helium/voter-stake-registry-sdk";
 import { NATIVE_MINT } from "@solana/spl-token";
-import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import {
+  PublicKey,
+  SYSVAR_CLOCK_PUBKEY,
+  TransactionInstruction,
+} from "@solana/web3.js";
 import BN from "bn.js";
 import {
   validatePositionOwnership,
   createTransferInstruction,
 } from "../helpers";
+
+interface LockupLike {
+  startTs: BN;
+  endTs: BN;
+  kind: object;
+}
+
+function rawLockupKind(lockup: LockupLike): string {
+  return Object.keys(lockup.kind)[0];
+}
+
+function lockupStrictness(lockup: LockupLike): number {
+  return rawLockupKind(lockup) === "none" ? 0 : 1;
+}
+
+function lockupSecondsLeft(lockup: LockupLike, unixNow: BN): BN {
+  const currTs = rawLockupKind(lockup) === "constant" ? lockup.startTs : unixNow;
+  return currTs.gte(lockup.endTs) ? new BN(0) : lockup.endTs.sub(currTs);
+}
 
 export const transfer = publicProcedure.governance.transferPosition.handler(
   async ({ input, errors }) => {
@@ -82,6 +105,29 @@ export const transfer = publicProcedure.governance.transferPosition.handler(
     ) {
       throw errors.BAD_REQUEST({
         message: "Target position uses a different voting mint configuration",
+      });
+    }
+
+    const clockInfo = await connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+    const unixNow = new BN(Number(clockInfo!.data.readBigInt64LE(8 * 4)));
+
+    if (
+      lockupSecondsLeft(targetPositionAcc.lockup, unixNow).lt(
+        lockupSecondsLeft(sourcePositionAcc.lockup, unixNow),
+      )
+    ) {
+      throw errors.BAD_REQUEST({
+        message:
+          "Target position lockup must be equal-or-longer than the source's",
+      });
+    }
+    if (
+      lockupStrictness(targetPositionAcc.lockup) <
+      lockupStrictness(sourcePositionAcc.lockup)
+    ) {
+      throw errors.BAD_REQUEST({
+        message:
+          "Target position lockup kind must be equal-or-stricter than the source's",
       });
     }
 

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/transfer.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/transfer.ts
@@ -48,27 +48,15 @@ export const transfer = publicProcedure.governance.transferPosition.handler(
       throw errors.NOT_FOUND({ message: "Target position not found" });
     }
 
-    const [sourceOwnership, targetOwnership] = await Promise.all([
-      validatePositionOwnership(
-        connection,
-        sourcePositionMintPubkey,
-        walletPubkey,
-      ),
-      validatePositionOwnership(
-        connection,
-        targetPositionMintPubkey,
-        walletPubkey,
-      ),
-    ]);
+    const sourceOwnership = await validatePositionOwnership(
+      connection,
+      sourcePositionMintPubkey,
+      walletPubkey,
+    );
 
     if (!sourceOwnership.isOwner) {
       throw errors.BAD_REQUEST({
         message: "Wallet does not own the source position",
-      });
-    }
-    if (!targetOwnership.isOwner) {
-      throw errors.BAD_REQUEST({
-        message: "Wallet does not own the target position",
       });
     }
 
@@ -80,6 +68,20 @@ export const transfer = publicProcedure.governance.transferPosition.handler(
     if (targetPositionAcc.numActiveVotes > 0) {
       throw errors.BAD_REQUEST({
         message: "Target position has active votes and cannot receive transfer",
+      });
+    }
+
+    if (!targetPositionAcc.registrar.equals(sourcePositionAcc.registrar)) {
+      throw errors.BAD_REQUEST({
+        message: "Target position belongs to a different registrar",
+      });
+    }
+    if (
+      targetPositionAcc.votingMintConfigIdx !==
+      sourcePositionAcc.votingMintConfigIdx
+    ) {
+      throw errors.BAD_REQUEST({
+        message: "Target position uses a different voting mint configuration",
       });
     }
 

--- a/packages/blockchain-api/tests/e2e/governance.test.ts
+++ b/packages/blockchain-api/tests/e2e/governance.test.ts
@@ -478,6 +478,82 @@ describe("governance", () => {
         targetAmountBefore + transferAmount
       );
     });
+
+    it("transfers tokens between positions owned by different wallets", async () => {
+      // #given a source position owned by ctx.payer and a target position owned by another wallet
+      const source = await createAndFundPosition(ctx, {
+        amount: "200000000",
+        lockupKind: "cliff",
+        lockupPeriodsInDays: 60,
+      });
+
+      const recipient = Keypair.generate();
+      await ensureFunds(recipient.publicKey, 0.1 * LAMPORTS_PER_SOL);
+      await ensureTokenBalance(recipient.publicKey, HNT_MINT, 10);
+
+      const { data: targetData, error: targetError } =
+        await ctx.safeClient.governance.createPosition({
+          walletAddress: recipient.publicKey.toBase58(),
+          tokenAmount: { amount: "100000000", mint: HNT_MINT.toBase58() },
+          lockupKind: "cliff",
+          lockupPeriodsInDays: 90,
+        });
+      if (targetError) {
+        throw new Error(
+          `Failed to create recipient position: ${JSON.stringify(targetError)}`
+        );
+      }
+      await signAndSubmitTransactionData(
+        ctx.connection,
+        targetData!.transactionData,
+        recipient
+      );
+      const targetPositionMint = targetData!.transactionData.transactions[0]
+        .metadata?.positionMint as string;
+
+      const { vsrProgram } = await getPrograms(ctx);
+      const [sourcePubkey] = positionKey(new PublicKey(source.positionMint));
+      const [targetPubkey] = positionKey(new PublicKey(targetPositionMint));
+      const sourceAmountBefore = (
+        await vsrProgram.account.positionV0.fetch(sourcePubkey)
+      ).amountDepositedNative.toNumber();
+      const targetAmountBefore = (
+        await vsrProgram.account.positionV0.fetch(targetPubkey)
+      ).amountDepositedNative.toNumber();
+
+      // #when the source owner transfers part of their position to the recipient's position
+      const transferAmount = 50000000; // 0.5 HNT
+      const { data, error } = await ctx.safeClient.governance.transferPosition({
+        walletAddress,
+        positionMint: source.positionMint,
+        targetPositionMint,
+        amount: transferAmount.toString(),
+      });
+
+      // #then only the source owner's signature is required and the transfer succeeds
+      if (error) {
+        expect.fail(`Unexpected error: ${JSON.stringify(error)}`);
+      }
+      const sigs = await signAndSubmitTransactionData(
+        ctx.connection,
+        data.transactionData,
+        ctx.payer
+      );
+      expect(sigs).to.have.length(1);
+
+      const sourceAfter = await vsrProgram.account.positionV0.fetch(
+        sourcePubkey
+      );
+      const targetAfter = await vsrProgram.account.positionV0.fetch(
+        targetPubkey
+      );
+      expect(sourceAfter.amountDepositedNative.toNumber()).to.equal(
+        sourceAmountBefore - transferAmount
+      );
+      expect(targetAfter.amountDepositedNative.toNumber()).to.equal(
+        targetAmountBefore + transferAmount
+      );
+    });
   });
 
   describe("position ownership transfer", () => {


### PR DESCRIPTION
## Summary

- `positions/transfer` (backing the amount-based position transfer, e.g. `useTransferPosition`) required the caller's wallet to own both the source and target position. The on-chain `transferV0` instruction has no such restriction on the target — only the source position's authority signs. This relaxes the API to match, enabling veHNT transfer between wallets by moving a deposited amount into a target position someone else already owns.
- Adds explicit registrar and voting-mint-config compatibility checks between source and target so a mismatch returns `BAD_REQUEST` instead of an opaque on-chain constraint failure.
- Fixes the `transfer-ownership` route description, which claimed both wallets must sign; only the current owner (`from`) does.