### PR TITLE
fix(blockchain-api): allow an off-curve owner when deriving associated token addresses

### DIFF
--- a/.changeset/multisig-held-wallet-batching.md
+++ b/.changeset/multisig-held-wallet-batching.md
@@ -1,0 +1,9 @@
+---
+"@helium/blockchain-api": patch
+---
+
+Let a multisig-held wallet use the governance endpoints. A Squads vault owns its assets through a program address, and eleven call sites derived associated token addresses without `allowOwnerOffCurve`, so `getAssociatedTokenAddressSync` threw `TokenOwnerOffCurveError` and failed the whole request rather than one derivation.
+
+`buildClaimInstructions` is one of them, and the claim, undelegate and delegate procedures all call it first, so claiming delegation rewards, undelegating, and re-delegating an expired position were unavailable to every vault-held veHNT position that had an unclaimed epoch. `delegate.ts` also derived the reward account this way when enabling autoclaim, so a vault could not turn automation back on.
+
+The derived address is identical either way and the on-chain programs re-validate the account they receive against their own `associated_token::authority` and `token::authority` constraints, so this decides whether a multisig can use an endpoint at all, not who is allowed to do what.

--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -38,6 +38,30 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # Unit tests need no chain, no secrets and no surfpool, so they run as their
+  # own job and report in about a minute rather than waiting on the matrix.
+  unit-tests:
+    needs: build-idls
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: packages/blockchain-api
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download anchor types and IDLs
+        uses: actions/download-artifact@v4
+        with:
+          name: anchor-types
+          path: target
+
+      - uses: ./.github/actions/setup-ts/
+
+      - name: Run unit tests
+        run: pnpm test:unit
+
   e2e-tests:
     needs: build-idls
     runs-on: ubuntu-latest

--- a/packages/blockchain-api/src/lib/utils/can-sign.ts
+++ b/packages/blockchain-api/src/lib/utils/can-sign.ts
@@ -1,0 +1,15 @@
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * Whether `wallet` can sign a transaction itself. An address off the ed25519
+ * curve is a program address, typically a Squads vault: it holds the assets but
+ * has no key, so a transaction built for it is delivered by re-wrapping it into
+ * a multisig proposal that the members approve and execute.
+ *
+ * That re-wrap keeps the transaction's message and discards its signatures, so
+ * an action whose transaction is signed by an ephemeral keypair as it is built
+ * cannot be served to such a wallet.
+ */
+export function canSign(wallet: PublicKey): boolean {
+  return PublicKey.isOnCurve(wallet.toBytes());
+}

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/mint.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/mint.ts
@@ -63,7 +63,8 @@ export const mint = publicProcedure.dataCredits.mint.handler(
       : new PublicKey(owner);
     const recipientDcAta = getAssociatedTokenAddressSync(
       DC_MINT,
-      recipientPubkey
+      recipientPubkey,
+      true
     );
     const recipientDcAtaInfo = await connection.getAccountInfo(recipientDcAta);
     const ataRent = recipientDcAtaInfo ? 0 : RENT_COSTS.ATA;

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/claim-rewards.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/claim-rewards.ts
@@ -131,7 +131,7 @@ export const claimRewards =
 
       // Check which reward ATAs need creation
       const rewardAtaKeys = claimResult.rewardMints.map((mint) =>
-        getAssociatedTokenAddressSync(mint, walletPubkey),
+        getAssociatedTokenAddressSync(mint, walletPubkey, true),
       );
       const rewardAtaAccounts = await connection.getMultipleAccountsInfo(rewardAtaKeys);
       const missingAtaCount = rewardAtaAccounts.filter((a) => !a).length;

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/delegate.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/delegate.ts
@@ -551,6 +551,7 @@ export const delegate = publicProcedure.governance.delegatePositions.handler(
                 delegatorAta: getAssociatedTokenAddressSync(
                   HNT_MINT,
                   walletPubkey,
+                  true,
                 ),
                 task,
                 nextTask:

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
@@ -225,7 +225,8 @@ export async function buildClaimInstructions(
           mint: position.mint,
           positionTokenAccount: getAssociatedTokenAddressSync(
             position.mint,
-            walletPubkey
+            walletPubkey,
+            true
           ),
           positionAuthority: walletPubkey,
           registrar: position.account.registrar,
@@ -254,7 +255,8 @@ export async function buildClaimInstructions(
               delegatorPool: daoAcc.delegatorPool,
               delegatorAta: getAssociatedTokenAddressSync(
                 daoAcc.hntMint,
-                walletPubkey
+                walletPubkey,
+                true
               ),
               delegatorPoolCircuitBreaker: accountWindowedBreakerKey(
                 daoAcc.delegatorPool
@@ -275,7 +277,8 @@ export async function buildClaimInstructions(
               delegatorPool: subDaoAcc.delegatorPool,
               delegatorAta: getAssociatedTokenAddressSync(
                 subDaoAcc.dntMint,
-                walletPubkey
+                walletPubkey,
+                true
               ),
               delegatorPoolCircuitBreaker: accountWindowedBreakerKey(
                 subDaoAcc.delegatorPool

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/create.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/create.ts
@@ -57,6 +57,7 @@ import {
   buildBatchedTransactions,
 } from "../helpers";
 import type { InstructionGroup } from "../helpers";
+import { canSign } from "@/lib/utils/can-sign";
 
 export const create = publicProcedure.governance.createPosition.handler(
   async ({ input, errors }) => {
@@ -71,6 +72,18 @@ export const create = publicProcedure.governance.createPosition.handler(
 
     const { connection, provider } = createSolanaConnection(walletAddress);
     const walletPubkey = new PublicKey(walletAddress);
+
+    // The new position's mint is an ephemeral keypair that signs the transaction
+    // as it is built. A wallet that cannot sign is served by re-wrapping the
+    // message into a multisig proposal, which discards that signature, so the
+    // proposal could only fail on execution after quorum and rent are spent.
+    if (!canSign(walletPubkey)) {
+      throw errors.BAD_REQUEST({
+        message:
+          "Creating a position requires a wallet that can sign; a multisig-held wallet cannot supply the new position mint's signature",
+      });
+    }
+
     const mintPubkey = new PublicKey(tokenAmount.mint);
     const amount = await resolveTokenAmountInput(tokenAmount);
 

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/create.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/create.ts
@@ -282,7 +282,8 @@ export const create = publicProcedure.governance.createPosition.handler(
                 systemProgram: SystemProgram.programId,
                 delegatorAta: getAssociatedTokenAddressSync(
                   HNT_MINT,
-                  walletPubkey
+                  walletPubkey,
+                  true
                 ),
                 task,
                 nextTask: task,
@@ -387,7 +388,11 @@ export const create = publicProcedure.governance.createPosition.handler(
     // verify the user actually holds enough of the deposit mint, otherwise
     // the on-chain tx fails with an opaque SPL token Custom(1) instead of
     // a clean INSUFFICIENT_FUNDS response.
-    const depositAta = getAssociatedTokenAddressSync(mintPubkey, walletPubkey);
+    const depositAta = getAssociatedTokenAddressSync(
+      mintPubkey,
+      walletPubkey,
+      true
+    );
     const depositAtaInfo = await connection
       .getTokenAccountBalance(depositAta)
       .catch(() => null);

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/split.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/positions/split.ts
@@ -32,6 +32,7 @@ import {
   toLockupKindArg,
   LockupKindType,
 } from "../helpers";
+import { canSign } from "@/lib/utils/can-sign";
 
 export const split = publicProcedure.governance.splitPosition.handler(
   async ({ input, errors }) => {
@@ -45,6 +46,19 @@ export const split = publicProcedure.governance.splitPosition.handler(
 
     const { connection, provider } = createSolanaConnection(walletAddress);
     const walletPubkey = new PublicKey(walletAddress);
+
+    // The split's new position mint is an ephemeral keypair that signs the
+    // transaction as it is built. A wallet that cannot sign is served by
+    // re-wrapping the message into a multisig proposal, which discards that
+    // signature, so the proposal could only fail on execution after quorum and
+    // rent are spent.
+    if (!canSign(walletPubkey)) {
+      throw errors.BAD_REQUEST({
+        message:
+          "Splitting a position requires a wallet that can sign; a multisig-held wallet cannot supply the new position mint's signature",
+      });
+    }
+
     const sourcePositionMintPubkey = new PublicKey(positionMint);
 
     const vsrProgram = await initVsr(provider);

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/assign.ts
@@ -242,6 +242,7 @@ export const assign = publicProcedure.governance.assignProxies.handler(
                 tokenAccount: getAssociatedTokenAddressSync(
                   positionMintPubkey,
                   walletPubkey,
+                  true,
                 ),
               })
               .instruction(),
@@ -260,6 +261,7 @@ export const assign = publicProcedure.governance.assignProxies.handler(
           tokenAccount: getAssociatedTokenAddressSync(
             positionMintPubkey,
             walletPubkey,
+            true,
           ),
         })
         .prepare();

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/unassign.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/proxy/unassign.ts
@@ -128,6 +128,7 @@ export const unassign = publicProcedure.governance.unassignProxies.handler(
             tokenAccount: getAssociatedTokenAddressSync(
               positionMintPubkey,
               walletPubkey,
+              true,
             ),
           })
           .instruction(),

--- a/packages/blockchain-api/tests/unit/can-sign.test.ts
+++ b/packages/blockchain-api/tests/unit/can-sign.test.ts
@@ -1,0 +1,19 @@
+import { Keypair } from "@solana/web3.js";
+import * as multisig from "@sqds/multisig";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { canSign } from "../../src/lib/utils/can-sign";
+
+describe("canSign", () => {
+  it("is true for a keypair wallet", () => {
+    expect(canSign(Keypair.generate().publicKey)).to.eq(true);
+  });
+
+  it("is false for a Squads vault, which is a program address", () => {
+    const [vault] = multisig.getVaultPda({
+      multisigPda: Keypair.generate().publicKey,
+      index: 0,
+    });
+    expect(canSign(vault)).to.eq(false);
+  });
+});


### PR DESCRIPTION
## Problem

A Squads vault owns its assets through a program address, which is off the ed25519 curve. Eleven call sites derived associated token addresses without `allowOwnerOffCurve`, so `getAssociatedTokenAddressSync` threw `TokenOwnerOffCurveError` and took down the whole request rather than one derivation. Reproduced against a mainnet vault-held position by invoking the real helper:

```
RESULT: THREW -> TokenOwnerOffCurveError:
```

`buildClaimInstructions` is one of those call sites, and claim, undelegate and delegate all call it first, so all three were unavailable to any vault-held veHNT position with an unclaimed epoch. `delegate.ts` derived the reward account the same way when enabling autoclaim, so a vault could not turn automation back on either.

The derived address is identical either way and the programs re-validate the account they receive (`claim_rewards_v1` constrains `delegator_ata` by `associated_token::authority` and `position_token_account` by `token::mint` plus a positive balance), so this decides whether a multisig can use an endpoint at all, not who is allowed to do what.

## Scope

This started larger and was cut back deliberately. It also changed transaction packing so a vault's batches would survive being re-wrapped as a Squads proposal, and skipped the Jito tip for a payer that cannot sign. Both are dropped, because the benefit turned out to be blocked downstream:

- `getJitoTipTransaction` builds a `SystemProgram.transfer` **from** the fee payer, so a vault can never sign a tip.
- The submit path picks bundle-vs-single from transaction count alone and throws `JitoMissingTipError` when no tip is present.

So a multi-transaction batch for a vault fails at submission with or without the packing change, and a smaller size budget buys nothing until that is fixed. Everything else in this PR is a plain correctness fix, so it ships on its own.

## Known follow-ups, not in this PR

- **The invariant is unenforced.** Nothing stops a new call site omitting the flag. The right fix is an `ata(mint, owner)` wrapper that always passes it, plus an ESLint restriction on importing `getAssociatedTokenAddressSync` directly, which fixes the class rather than scanning for instances. That means migrating all 30 existing call sites, which does not belong in a fix this size.
- **`positions/create.ts` and `positions/split.ts` attach an ephemeral mint keypair.** A wrapping wallet keeps the message and drops that signature, so a vault gets a proposal whose execution can only fail. These endpoints should reject an off-curve fee payer with a typed error.
- **Fee gates overstate the requirement for a vault**, since `jitoTipCost` is added whenever there is more than one transaction on mainnet.
- **Squads propose mode does not cover governance.** `squadsProposeFields` is spread into the token, data-credit and hotspot schemas only; no governance procedure reads `input.multisig` or calls `buildActionProposal`. `buildActionProposal` is also single-proposal, so a delegation recovery spanning many transactions would need a multi-proposal variant.
- **`pnpm test:unit` is referenced by no workflow**, so the four existing unit tests in this package never run in CI.
