### PR TITLE
HIP 149: activate the supplement mint and forward its destinations

### DIFF
--- a/packages/helium-admin-cli/src/create-council-fanout.ts
+++ b/packages/helium-admin-cli/src/create-council-fanout.ts
@@ -153,6 +153,26 @@ export async function run(args: any = process.argv) {
   );
 
   // Schedule the first distribution task; the fanout self-reschedules thereafter.
+  //
+  // `schedule_task_v0` declares `has_one = task_queue / next_task / next_pre_task` on the
+  // fanout, and Anchor's client resolver satisfies those by fetching it. The instruction
+  // above creates the fanout in this same transaction, so there is nothing on chain to fetch
+  // and resolution fails before anything is sent. Each of those accounts is known ahead of
+  // time instead: `initialize_mini_fanout_v0` stores the task queue it was handed, and sets
+  // `next_task` and `next_pre_task` to the fanout's own key, the "no next task" sentinel that
+  // the scheduling constraint accepts.
+  const [queueAuthority] = PublicKey.findProgramAddressSync(
+    [Buffer.from("queue_authority", "utf-8")],
+    program.programId
+  );
+  const [taskQueueAuthority] = PublicKey.findProgramAddressSync(
+    [
+      Buffer.from("task_queue_authority", "utf-8"),
+      TASK_QUEUE_ID.toBuffer(),
+      queueAuthority.toBuffer(),
+    ],
+    tuktukProgram.programId
+  );
   const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
     TASK_QUEUE_ID
   );
@@ -160,9 +180,14 @@ export async function run(args: any = process.argv) {
   instructions.push(
     await program.methods
       .scheduleTaskV0({ taskId, preTaskId })
-      .accounts({
+      .accountsPartial({
         payer: wallet.publicKey,
         miniFanout: miniFanout!,
+        taskQueue: TASK_QUEUE_ID,
+        queueAuthority,
+        taskQueueAuthority,
+        nextTask: miniFanout!,
+        nextPreTask: miniFanout!,
         task: taskKey(TASK_QUEUE_ID, taskId)[0],
         preTask: taskKey(TASK_QUEUE_ID, preTaskId)[0],
       })

--- a/packages/helium-admin-cli/src/create-council-fanout.ts
+++ b/packages/helium-admin-cli/src/create-council-fanout.ts
@@ -37,6 +37,9 @@ import { loadKeypair } from "./utils";
 //     members from that point forward, per the HIP).
 //   - Keep the fanout funded with lamports; it pays its own crank reward and silently
 //     unschedules itself if it runs dry.
+//   - The fanout's stored `rent_refund` is the PAYER, not the `rentRefund` account passed
+//     below: initialize_mini_fanout_v0 writes `ctx.accounts.payer.key()` and ignores that
+//     account. Closing the fanout therefore refunds its rent to whoever paid to create it.
 export async function run(args: any = process.argv) {
   const yarg = yargs(args).options({
     wallet: {

--- a/packages/helium-admin-cli/src/create-council-fanout.ts
+++ b/packages/helium-admin-cli/src/create-council-fanout.ts
@@ -37,9 +37,9 @@ import { loadKeypair } from "./utils";
 //     members from that point forward, per the HIP).
 //   - Keep the fanout funded with lamports; it pays its own crank reward and silently
 //     unschedules itself if it runs dry.
-//   - The fanout's stored `rent_refund` is the PAYER, not the `rentRefund` account passed
-//     below: initialize_mini_fanout_v0 writes `ctx.accounts.payer.key()` and ignores that
-//     account. Closing the fanout therefore refunds its rent to whoever paid to create it.
+//   - Closing the fanout refunds its rent to whoever paid to create it, not to the owner:
+//     initialize_mini_fanout_v0 stores `ctx.accounts.payer.key()` as `rent_refund` and never
+//     reads the account passed under that name. Pick the payer accordingly.
 export async function run(args: any = process.argv) {
   const yarg = yargs(args).options({
     wallet: {
@@ -140,7 +140,12 @@ export async function run(args: any = process.argv) {
       payer: wallet.publicKey,
       owner,
       taskQueue: TASK_QUEUE_ID,
-      rentRefund: owner,
+      // The account required here does not decide where rent goes:
+      // initialize_mini_fanout_v0 stores `ctx.accounts.payer.key()` and never reads this one.
+      // Passing the payer keeps the argument honest about the refund destination, and keeps a
+      // vault that has no other role in this instruction out of the writable set. Change the
+      // payer to change where closing the fanout refunds its rent.
+      rentRefund: wallet.publicKey,
       mint: HNT_MINT,
     })
     .prepare();

--- a/packages/helium-admin-cli/src/end-epoch.ts
+++ b/packages/helium-admin-cli/src/end-epoch.ts
@@ -76,6 +76,16 @@ export async function run(args: any = process.argv) {
         type: "number",
         describe: "The timestamp to start ending epochs from",
       },
+      supplementVault: {
+        type: "string",
+        describe:
+          "HIP 149 Decision 2 Receiving Entity vault HNT token account. Required to close an epoch inside a supplement window; issue_rewards_v0 pins it to SUPPLEMENT_VAULT_TOKEN_ACCOUNT, so a wrong value fails the instruction rather than misrouting the mint. Omit while the supplement is dormant.",
+      },
+      councilVault: {
+        type: "string",
+        describe:
+          "HIP 149 Decision 4 Council fanout HNT token account. Same requirement and same on-chain pinning as --supplementVault.",
+      },
     });
     const argv = await yarg.argv;
     process.env.ANCHOR_WALLET = argv.wallet;
@@ -89,6 +99,12 @@ export async function run(args: any = process.argv) {
     const unixNow = new Date().valueOf() / 1000;
     const [dao] = daoKey(hntMint);
     const basePriorityFee = Number(argv.basePriorityFee || 1);
+    const supplementVault = argv.supplementVault
+      ? new PublicKey(argv.supplementVault)
+      : null;
+    const councilVault = argv.councilVault
+      ? new PublicKey(argv.councilVault)
+      : null;
 
     const subDaos = await heliumSubDaosProgram.account.subDaoV0.all([
       {
@@ -212,8 +228,8 @@ export async function run(args: any = process.argv) {
                     .issueRewardsV0({ epoch })
                     .accountsPartial({
                       subDao: subDao.publicKey,
-                      supplementVault: null,
-                      councilVault: null,
+                      supplementVault,
+                      councilVault,
                     })
                     .instruction(),
                 ],

--- a/programs/helium-sub-daos/src/supplement.rs
+++ b/programs/helium-sub-daos/src/supplement.rs
@@ -53,13 +53,16 @@ pub const INFLATION_FLAT_PER_EPOCH_PER_SUBDAO: u64 = 98_000 * 100_000_000;
 /// then decaying linearly to zero across the taper window.
 pub const INFLATION_TAPER_INITIAL_PER_EPOCH_PER_SUBDAO: u64 = INFLATION_FLAT_PER_EPOCH_PER_SUBDAO;
 
-// PATCH-TIME: the Receiving Entity's Squads vault HNT token account that receives the
-// supplement. Placeholder (the system program id); set to the real token account before
-// deploy. issue_rewards_v0 requires the supplied supplement token account to equal this key
-// (relaxed under TESTING), pinned to the exact account — like COUNCIL_FANOUT_TOKEN_ACCOUNT —
-// rather than only checking the token-account authority, so a caller cannot route the
-// supplement to a different account under the same authority (I-03).
-pub const SUPPLEMENT_VAULT_TOKEN_ACCOUNT: Pubkey = pubkey!("11111111111111111111111111111111");
+/// The Receiving Entity's HNT token account: the associated token account of vault index 0 of
+/// Squads multisig `2g7qF5d3p2XeJALK6RzAF1sFY8Emt8LuMLXATF6hjWyy`, whose vault is
+/// `Cuy6WiVdHE6Wznqos86AUwLpA4zPfPABYq3qszMa6E6A`.
+///
+/// issue_rewards_v0 requires the supplied supplement token account to equal this key (relaxed
+/// under TESTING). Pinning the exact account, rather than only checking the token account's
+/// authority, is what stops a caller routing the supplement to a different account under the
+/// same authority.
+pub const SUPPLEMENT_VAULT_TOKEN_ACCOUNT: Pubkey =
+  pubkey!("AGPDcgpXan5RB2Y9usHvdJmmJHpyyYqcQm8KouRkK6f4");
 
 // ── HIP 149 Decision 4: Advisory Council compensation carve-out ─────────────────────────
 /// The community-nominated Council seats share 1.25% of the supplement (HIP 149 Decision 4).
@@ -131,6 +134,24 @@ mod tests {
 
   fn amt(now: i64) -> u64 {
     supplement_amount(now, START, FLAT_END, TAPER_END, FLAT, FLAT)
+  }
+
+  /// Derives the supplement destination from the Receiving Entity's Squads vault rather than
+  /// restating the constant, so a mistyped address, a wrong mint, or an on-curve derivation
+  /// fails here. The vault itself is off-curve, which `get_associated_token_address` handles;
+  /// changing the destination means changing the vault named here, deliberately.
+  #[test]
+  fn supplement_destination_is_the_receiving_entity_vault_hnt_ata() {
+    const RECEIVING_ENTITY_VAULT: Pubkey = pubkey!("Cuy6WiVdHE6Wznqos86AUwLpA4zPfPABYq3qszMa6E6A");
+    const HNT_MINT: Pubkey = pubkey!("hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux");
+
+    assert_eq!(
+      SUPPLEMENT_VAULT_TOKEN_ACCOUNT,
+      anchor_spl::associated_token::get_associated_token_address(
+        &RECEIVING_ENTITY_VAULT,
+        &HNT_MINT
+      )
+    );
   }
 
   /// Pins the three deployed boundary timestamps, and which epoch crank mints first, against

--- a/programs/helium-sub-daos/src/supplement.rs
+++ b/programs/helium-sub-daos/src/supplement.rs
@@ -11,11 +11,11 @@
 //! supplement isn't misread as burned HNT (see the supply-tracking note there).
 //!
 //! All parameters are hardcoded; changing them requires a community-voted program upgrade.
-//! The two destination token accounts are **patch-time** values, still placeholders here, and
-//! a supplement window that opens against a placeholder fails every epoch: the accounts are
-//! mandatory once a window is open, and `hpl-crons` withholds a placeholder rather than
-//! forward it. So the mint destinations and `INFLATION_START` have to be real in the same
-//! deploy, and no build carrying a placeholder may reach a live window.
+//! That includes the two destination token accounts, so the supplement cannot be redirected
+//! without a community-voted upgrade either. Both destinations are mandatory while a window is
+//! open, and `hpl-crons` withholds a destination that still holds its pre-activation
+//! placeholder rather than forwarding it, so a build whose destinations are not real fails
+//! every epoch of a live window instead of minting somewhere unintended.
 
 use anchor_lang::prelude::*;
 
@@ -72,12 +72,15 @@ pub const SUPPLEMENT_VAULT_TOKEN_ACCOUNT: Pubkey =
 /// Expressed in basis points; the HIP caps the total at 1.25%, so this is a ceiling.
 pub const COUNCIL_COMPENSATION_BPS: u64 = 125;
 
-// PATCH-TIME: the Council compensation fanout's HNT token account (a mini_fanout PDA-owned
-// ATA). Placeholder (the system program id); set to the real fanout token account before
-// deploy. issue_rewards_v0 requires the supplied Council token account to equal this key
-// (relaxed under TESTING). The fanout's `owner` (who edits the seated-member set) is the
-// governance multisig, never the Receiving Entity; see the create-council-fanout tooling.
-pub const COUNCIL_FANOUT_TOKEN_ACCOUNT: Pubkey = pubkey!("11111111111111111111111111111111");
+/// The Council compensation fanout's HNT token account: the associated token account of
+/// `mini_fanout` `2pCpQYrUmQor9igsF4cY7tkmd3jBQzHFEB75gtpjdWA2`.
+///
+/// issue_rewards_v0 requires the supplied Council token account to equal this key (relaxed
+/// under TESTING). The fanout's `owner`, the only authority that can edit the seated-member
+/// set, is the governance multisig vault and never the Receiving Entity, so seating and
+/// removal reach the chain only through a multisig action.
+pub const COUNCIL_FANOUT_TOKEN_ACCOUNT: Pubkey =
+  pubkey!("EYbAXgLq1aRr9a9y55DbjfMdXNrZuMa69WXN9c1UR6eK");
 
 /// The Council compensation carve-out (1.25%) of a per-sub-DAO supplement amount. The
 /// remainder (`supplement - council_cut`) goes to the Receiving Entity vault.
@@ -151,6 +154,30 @@ mod tests {
         &RECEIVING_ENTITY_VAULT,
         &HNT_MINT
       )
+    );
+  }
+
+  /// Derives the Council destination through the whole chain that produced it: the fanout PDA
+  /// from the mini_fanout program, the creating wallet as namespace and the seed, then that
+  /// fanout's HNT associated token account. Repointing Council compensation means changing one
+  /// of those inputs, deliberately, rather than editing an opaque address.
+  #[test]
+  fn council_destination_is_the_seated_fanout_hnt_ata() {
+    const MINI_FANOUT_PROGRAM: Pubkey = pubkey!("mfanLprNnaiP4RX9Zz1BMcDosYHCqnG24H1fMEbi9Gn");
+    const NAMESPACE: Pubkey = pubkey!("hprdnjkbziK8NqhThmAn5Gu4XqrBbctX8du4PfJdgvW");
+    const HNT_MINT: Pubkey = pubkey!("hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux");
+
+    let (fanout, _bump) = Pubkey::find_program_address(
+      &[b"mini_fanout", NAMESPACE.as_ref(), b"hip149-council"],
+      &MINI_FANOUT_PROGRAM,
+    );
+    assert_eq!(
+      fanout,
+      pubkey!("2pCpQYrUmQor9igsF4cY7tkmd3jBQzHFEB75gtpjdWA2")
+    );
+    assert_eq!(
+      COUNCIL_FANOUT_TOKEN_ACCOUNT,
+      anchor_spl::associated_token::get_associated_token_address(&fanout, &HNT_MINT)
     );
   }
 

--- a/programs/helium-sub-daos/src/supplement.rs
+++ b/programs/helium-sub-daos/src/supplement.rs
@@ -10,22 +10,34 @@
 //! `calculate_utility_score_v0` adds the same total back into `current_hnt_supply` so the
 //! supplement isn't misread as burned HNT (see the supply-tracking note there).
 //!
-//! All parameters are hardcoded; changing them requires a community-voted program
-//! upgrade. Several are **patch-time** values set just before the mainnet deploy — by
-//! default they leave the supplement INACTIVE (a far-future start), so the program is safe
-//! to ship before they're finalized.
+//! All parameters are hardcoded; changing them requires a community-voted program upgrade.
+//! The two destination token accounts are **patch-time** values, still placeholders here, and
+//! a supplement window that opens against a placeholder fails every epoch: the accounts are
+//! mandatory once a window is open, and `hpl-crons` withholds a placeholder rather than
+//! forward it. So the mint destinations and `INFLATION_START` have to be real in the same
+//! deploy, and no build carrying a placeholder may reach a live window.
 
 use anchor_lang::prelude::*;
+
+use crate::TESTING;
 
 const EPOCH_LENGTH: i64 = 24 * 60 * 60;
 
 // ── Patch-time constants ─────────────────────────────────────────────────────────────
-// PATCH-TIME: set INFLATION_START to the real mint-start unix timestamp (the upgrade slot
-// + ~2 weeks, the Council pre-mint review window) before the mainnet deploy. The default
-// is a far-future sentinel (2100-01-01) so the supplement stays dormant until deliberately
-// configured — shipping without setting it mints nothing, and the test suite (which runs
-// at present-day wall-clock) sees a zero supplement and is unaffected.
-pub const INFLATION_START: i64 = 4_102_444_800;
+/// Mint start, 2026-08-05T12:00:00Z. Epochs settle on the 00:00 UTC boundary, so the first
+/// supplement mint lands at the 2026-08-06T00:00:00Z crank, closing the Council's pre-mint
+/// review window. The value sits between two crank boundaries rather than on one, so neither
+/// Solana clock drift nor a late crank can change which epoch mints first; the flat window
+/// then spans exactly 360 cranks (through 2027-08-01) and the taper exactly 720.
+///
+/// Under TESTING the start stays a far-future sentinel (2100-01-01), keeping the supplement
+/// dormant for the localnet suite: an open window makes both destination accounts mandatory
+/// in `issue_rewards_v0`, and every test there closes epochs without them.
+pub const INFLATION_START: i64 = if TESTING {
+  4_102_444_800
+} else {
+  1_785_931_200
+};
 
 /// End of the flat window (~12 months / ~360 epochs after the start).
 pub const INFLATION_FLAT_END: i64 = INFLATION_START + 360 * EPOCH_LENGTH;
@@ -119,6 +131,34 @@ mod tests {
 
   fn amt(now: i64) -> u64 {
     supplement_amount(now, START, FLAT_END, TAPER_END, FLAT, FLAT)
+  }
+
+  /// Pins the three deployed boundary timestamps, and which epoch crank mints first, against
+  /// the dates published in the HIP. `cargo test --lib` builds without TESTING and so checks
+  /// the mainnet values; a TESTING build must hold the dormant sentinel instead, and asserting
+  /// both directions means swapping the two branches fails here either way.
+  #[test]
+  fn deployed_window_boundaries_match_the_published_dates() {
+    const AUG_05_0000Z: i64 = 1_785_888_000;
+    const AUG_06_0000Z: i64 = 1_785_974_400;
+
+    if TESTING {
+      assert_eq!(INFLATION_START, 4_102_444_800);
+      assert_eq!(supplement_per_subdao(AUG_06_0000Z), 0);
+      return;
+    }
+
+    assert_eq!(INFLATION_START, 1_785_931_200); // 2026-08-05T12:00:00Z
+    assert_eq!(INFLATION_FLAT_END, 1_817_035_200); // 2027-07-31T12:00:00Z
+    assert_eq!(INFLATION_TAPER_END, 1_879_243_200); // 2029-07-20T12:00:00Z
+
+    // The 00:00 UTC crank on 2026-08-06 is the first one to mint; the one a day earlier
+    // must not, so the Council's pre-mint review window runs its full length.
+    assert_eq!(supplement_per_subdao(AUG_05_0000Z), 0);
+    assert_eq!(
+      supplement_per_subdao(AUG_06_0000Z),
+      INFLATION_FLAT_PER_EPOCH_PER_SUBDAO
+    );
   }
 
   #[test]

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -2,8 +2,10 @@ use std::cmp::max;
 
 use anchor_lang::{prelude::*, system_program, InstructionData};
 use helium_sub_daos::{
-  accounts::CalculateUtilityScoreV0, instruction::IssueRewardsV0, CalculateUtilityScoreArgsV0,
-  DaoV0, IssueRewardsArgsV0, SubDaoV0,
+  accounts::CalculateUtilityScoreV0,
+  instruction::IssueRewardsV0,
+  supplement::{COUNCIL_FANOUT_TOKEN_ACCOUNT, SUPPLEMENT_VAULT_TOKEN_ACCOUNT},
+  CalculateUtilityScoreArgsV0, DaoV0, IssueRewardsArgsV0, SubDaoV0,
 };
 use spl_token::solana_program::instruction::{AccountMeta, Instruction};
 use tuktuk_program::{
@@ -13,6 +15,13 @@ use tuktuk_program::{
 };
 
 use crate::{hpl_crons::CIRCUIT_BREAKER_PROGRAM, EpochTrackerV0, EPOCH_LENGTH};
+
+/// A HIP 149 supplement destination to forward into `issue_rewards_v0`, or `None` while the
+/// constant still holds its pre-activation placeholder (the system program id, which is also
+/// `Pubkey::default()`).
+fn supplement_account(configured: Pubkey) -> Option<Pubkey> {
+  (configured != Pubkey::default()).then_some(configured)
+}
 
 #[derive(Accounts)]
 pub struct QueueEndEpoch<'info> {
@@ -184,12 +193,19 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
         treasury: sub_dao.treasury,
         rewards_escrow: ctx.accounts.dao.rewards_escrow,
         delegator_pool: ctx.accounts.dao.delegator_pool,
-        // HIP 149 Decision 2 supplement vault + Decision 4 Council fanout. None while the
-        // supplement window is inactive (the default). At patch-time activation, set these to
-        // the Receiving Entity vault's HNT ATA and the Council fanout's HNT token account
-        // before rescheduling the cron.
-        supplement_vault: None,
-        council_vault: None,
+        // HIP 149 Decision 2 supplement vault + Decision 4 Council fanout, read from the
+        // helium-sub-daos constants so the two programs cannot disagree about the destinations.
+        // `issue_rewards_v0` requires them only while a supplement window is open, but a task
+        // is queued one epoch before it runs, so window state at queue time says nothing about
+        // window state at execution: both are forwarded whenever the constants are real, or the
+        // first epoch of a window would settle against a task built without them and fail
+        // closed, stopping the self-rescheduling chain.
+        //
+        // A placeholder constant is withheld instead, because Anchor deserializes a forwarded
+        // account as a `TokenAccount` regardless of window state and the placeholder is the
+        // system program id.
+        supplement_vault: supplement_account(SUPPLEMENT_VAULT_TOKEN_ACCOUNT),
+        council_vault: supplement_account(COUNCIL_FANOUT_TOKEN_ACCOUNT),
       }
       .to_account_metas(None),
       data: reward_args.data(),
@@ -283,4 +299,23 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     tasks: vec![],
     accounts: return_accounts,
   })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn placeholder_supplement_destination_is_not_forwarded() {
+    // Anchor deserializes a forwarded account as a TokenAccount regardless of whether a
+    // supplement window is open, so forwarding the pre-activation placeholder would fail
+    // every epoch. Pubkey::default() is the system program id the constants ship with.
+    assert_eq!(supplement_account(Pubkey::default()), None);
+  }
+
+  #[test]
+  fn configured_supplement_destination_is_forwarded() {
+    let configured = Pubkey::new_unique();
+    assert_eq!(supplement_account(configured), Some(configured));
+  }
 }

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -71,39 +71,68 @@ fn sub_dao_epoch_info_pda(sub_dao: &Pubkey, epoch: u64) -> Pubkey {
   .0
 }
 
-pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
-  let sub_daos = [&ctx.accounts.iot_sub_dao, &ctx.accounts.mobile_sub_dao];
-  let prev_epoch = ctx.accounts.epoch_tracker.epoch;
-  let curr_epoch = prev_epoch + 1;
-  ctx.accounts.epoch_tracker.epoch = curr_epoch;
+/// One sub-DAO's contribution to the end-epoch instruction set.
+pub struct SubDaoInputs {
+  pub key: Pubkey,
+  pub dnt_mint: Pubkey,
+  pub treasury: Pubkey,
+}
 
-  let dao_key = ctx.accounts.dao.key();
-  let prev_dao_epoch_info = Pubkey::find_program_address(
-    &[
-      b"dao_epoch_info",
-      dao_key.as_ref(),
-      &prev_epoch.to_le_bytes(),
-    ],
-    &helium_sub_daos::ID,
-  )
-  .0;
+/// The plain values the end-epoch instruction set is built from, lifted out of the Anchor
+/// context so it can be built, and its allocation cost measured, without one.
+pub struct EndEpochInputs {
+  pub payer: Pubkey,
+  pub registrar: Pubkey,
+  pub dao: Pubkey,
+  pub hnt_mint: Pubkey,
+  pub rewards_escrow: Pubkey,
+  pub delegator_pool: Pubkey,
+  pub hnt_price_oracle: Pubkey,
+  pub mobile_sub_dao: Pubkey,
+  /// IoT first, then Mobile, matching the order the handler passes them.
+  pub sub_daos: [SubDaoInputs; 2],
+  pub prev_epoch: u64,
+  pub curr_epoch: u64,
+}
 
-  let dao_epoch_info = Pubkey::find_program_address(
-    &[
-      b"dao_epoch_info",
-      dao_key.as_ref(),
-      &curr_epoch.to_le_bytes(),
-    ],
-    &helium_sub_daos::ID,
-  )
-  .0;
+/// Builds the calculate/issue/no-emit instruction set the end-epoch task executes.
+///
+/// Separate from the handler because its allocation cost is what has to stay inside the 32KB
+/// heap, and measuring that needs to be cheaper than standing up a localnet.
+pub fn end_epoch_ixs(inputs: &EndEpochInputs) -> Vec<Instruction> {
+  let EndEpochInputs {
+    payer,
+    registrar,
+    dao: dao_key,
+    hnt_mint,
+    rewards_escrow,
+    delegator_pool,
+    hnt_price_oracle,
+    mobile_sub_dao,
+    sub_daos,
+    prev_epoch,
+    curr_epoch,
+  } = inputs;
+  let (prev_epoch, curr_epoch) = (*prev_epoch, *curr_epoch);
+  let (dao_key, hnt_mint) = (*dao_key, *hnt_mint);
 
-  let hnt_mint = ctx.accounts.dao.hnt_mint;
+  let dao_epoch_info_pda = |epoch: u64| {
+    Pubkey::find_program_address(
+      &[b"dao_epoch_info", dao_key.as_ref(), &epoch.to_le_bytes()],
+      &helium_sub_daos::ID,
+    )
+    .0
+  };
+  let prev_dao_epoch_info = dao_epoch_info_pda(prev_epoch);
+  let dao_epoch_info = dao_epoch_info_pda(curr_epoch);
+
   let hnt_circuit_breaker = Pubkey::find_program_address(
     &[b"mint_windowed_breaker", hnt_mint.as_ref()],
     &CIRCUIT_BREAKER_PROGRAM,
   )
   .0;
+  let not_emitted_counter =
+    Pubkey::find_program_address(&[b"not_emitted_counter", hnt_mint.as_ref()], &no_emit::ID).0;
 
   let calc_args = helium_sub_daos::instruction::CalculateUtilityScoreV0 {
     args: CalculateUtilityScoreArgsV0 { epoch: curr_epoch },
@@ -112,57 +141,32 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     args: IssueRewardsArgsV0 { epoch: curr_epoch },
   };
 
-  msg!("Queueing epoch {}", curr_epoch);
-
   let mut ixs = Vec::with_capacity(5);
-
-  // Pre-calculate PDAs for each sub-dao
-  let sub_dao_infos: Vec<_> = sub_daos
-    .iter()
-    .map(|sub_dao| {
-      let sub_dao_key = sub_dao.key();
-      let prev_sub_dao_epoch_info = sub_dao_epoch_info_pda(&sub_dao_key, prev_epoch);
-      let sub_dao_epoch_info = sub_dao_epoch_info_pda(&sub_dao_key, curr_epoch);
-
-      (
-        sub_dao,
-        sub_dao_key,
-        prev_sub_dao_epoch_info,
-        sub_dao_epoch_info,
-      )
-    })
-    .collect();
 
   // HIP 149 backstop: every calculate_utility_score_v0 (both the IoT and Mobile pass)
   // reads the Mobile sub-DAO's current- and previous-epoch info to size the deployer
   // top-up, so total_rewards is independent of sub-DAO ordering. These are passed as
   // read-only remaining accounts and located on-chain by PDA.
-  let mobile_sub_dao_key = ctx.accounts.mobile_sub_dao.key();
-  let mobile_curr_epoch_info = sub_dao_epoch_info_pda(&mobile_sub_dao_key, curr_epoch);
-  let mobile_prev_epoch_info = sub_dao_epoch_info_pda(&mobile_sub_dao_key, prev_epoch);
+  let mobile_curr_epoch_info = sub_dao_epoch_info_pda(mobile_sub_dao, curr_epoch);
+  let mobile_prev_epoch_info = sub_dao_epoch_info_pda(mobile_sub_dao, prev_epoch);
 
-  // Add all calculate instructions
-  for (_, sub_dao_key, prev_sub_dao_epoch_info, sub_dao_epoch_info) in sub_dao_infos.iter() {
+  for sub_dao in sub_daos.iter() {
     let mut accounts = CalculateUtilityScoreV0 {
-      payer: ctx.accounts.payer.key(),
-      registrar: ctx.accounts.dao.registrar,
+      payer: *payer,
+      registrar: *registrar,
       dao: dao_key,
       hnt_mint,
-      sub_dao: *sub_dao_key,
+      sub_dao: sub_dao.key,
       prev_dao_epoch_info,
       dao_epoch_info,
-      sub_dao_epoch_info: *sub_dao_epoch_info,
+      sub_dao_epoch_info: sub_dao_epoch_info_pda(&sub_dao.key, curr_epoch),
       system_program: system_program::ID,
       token_program: spl_token::ID,
       circuit_breaker_program: CIRCUIT_BREAKER_PROGRAM,
-      prev_sub_dao_epoch_info: *prev_sub_dao_epoch_info,
-      not_emitted_counter: Pubkey::find_program_address(
-        &[b"not_emitted_counter", hnt_mint.as_ref()],
-        &no_emit::ID,
-      )
-      .0,
+      prev_sub_dao_epoch_info: sub_dao_epoch_info_pda(&sub_dao.key, prev_epoch),
+      not_emitted_counter,
       no_emit_program: no_emit::ID,
-      hnt_price_oracle: Some(ctx.accounts.hnt_price_oracle.key()),
+      hnt_price_oracle: Some(*hnt_price_oracle),
     }
     .to_account_metas(None);
     accounts.push(AccountMeta::new_readonly(mobile_curr_epoch_info, false));
@@ -174,25 +178,24 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     });
   }
 
-  // Add all issue instructions
-  for (sub_dao, sub_dao_key, prev_sub_dao_epoch_info, sub_dao_epoch_info) in sub_dao_infos.iter() {
+  for sub_dao in sub_daos.iter() {
     ixs.push(Instruction {
       program_id: helium_sub_daos::ID,
       accounts: helium_sub_daos::accounts::IssueRewardsV0 {
         dao: dao_key,
         hnt_mint,
-        sub_dao: *sub_dao_key,
+        sub_dao: sub_dao.key,
         dao_epoch_info,
-        sub_dao_epoch_info: *sub_dao_epoch_info,
+        sub_dao_epoch_info: sub_dao_epoch_info_pda(&sub_dao.key, curr_epoch),
         system_program: system_program::ID,
         token_program: spl_token::ID,
         circuit_breaker_program: CIRCUIT_BREAKER_PROGRAM,
-        prev_sub_dao_epoch_info: *prev_sub_dao_epoch_info,
+        prev_sub_dao_epoch_info: sub_dao_epoch_info_pda(&sub_dao.key, prev_epoch),
         hnt_circuit_breaker,
         dnt_mint: sub_dao.dnt_mint,
         treasury: sub_dao.treasury,
-        rewards_escrow: ctx.accounts.dao.rewards_escrow,
-        delegator_pool: ctx.accounts.dao.delegator_pool,
+        rewards_escrow: *rewards_escrow,
+        delegator_pool: *delegator_pool,
         // HIP 149 Decision 2 supplement vault + Decision 4 Council fanout, read from the
         // helium-sub-daos constants so the two programs cannot disagree about the destinations.
         // `issue_rewards_v0` requires them only while a supplement window is open, but a task
@@ -212,19 +215,14 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     });
   }
 
-  // Add no_emit instruction
   let no_emit_wallet = Pubkey::find_program_address(&[b"not_emitted"], &no_emit::ID).0;
   ixs.push(Instruction {
     program_id: no_emit::ID,
     accounts: no_emit::accounts::NoEmitV0 {
-      system_program: ctx.accounts.system_program.key(),
-      payer: ctx.accounts.payer.key(),
+      system_program: system_program::ID,
+      payer: *payer,
       no_emit_wallet,
-      not_emitted_counter: Pubkey::find_program_address(
-        &[b"not_emitted_counter", hnt_mint.as_ref()],
-        &no_emit::ID,
-      )
-      .0,
+      not_emitted_counter,
       token_account: spl_associated_token_account::get_associated_token_address(
         &no_emit_wallet,
         &hnt_mint,
@@ -236,13 +234,47 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     data: no_emit::instruction::NoEmitV0.data(),
   });
 
-  // This handler runs inside tuktuk's `run_task`, under a 32KB heap that the two compiled
-  // transactions below dominate, and it has already overflowed once in production. Every
-  // allocation here is therefore load-bearing: `sub_dao_infos` is dead by this point and is
-  // dropped rather than left to the end of scope, the seeds are rebuilt instead of cloned, and
-  // the account metas are moved rather than copied.
-  drop(sub_dao_infos);
+  ixs
+}
 
+pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
+  let prev_epoch = ctx.accounts.epoch_tracker.epoch;
+  let curr_epoch = prev_epoch + 1;
+  ctx.accounts.epoch_tracker.epoch = curr_epoch;
+
+  msg!("Queueing epoch {}", curr_epoch);
+
+  let ixs = end_epoch_ixs(&EndEpochInputs {
+    payer: ctx.accounts.payer.key(),
+    registrar: ctx.accounts.dao.registrar,
+    dao: ctx.accounts.dao.key(),
+    hnt_mint: ctx.accounts.dao.hnt_mint,
+    rewards_escrow: ctx.accounts.dao.rewards_escrow,
+    delegator_pool: ctx.accounts.dao.delegator_pool,
+    hnt_price_oracle: ctx.accounts.hnt_price_oracle.key(),
+    mobile_sub_dao: ctx.accounts.mobile_sub_dao.key(),
+    sub_daos: [
+      SubDaoInputs {
+        key: ctx.accounts.iot_sub_dao.key(),
+        dnt_mint: ctx.accounts.iot_sub_dao.dnt_mint,
+        treasury: ctx.accounts.iot_sub_dao.treasury,
+      },
+      SubDaoInputs {
+        key: ctx.accounts.mobile_sub_dao.key(),
+        dnt_mint: ctx.accounts.mobile_sub_dao.dnt_mint,
+        treasury: ctx.accounts.mobile_sub_dao.treasury,
+      },
+    ],
+    prev_epoch,
+    curr_epoch,
+  });
+
+  // This handler runs inside tuktuk's `run_task` under a 32KB heap, which the two compiled
+  // transactions below dominate, and it has overflowed in production once already. The SBF
+  // heap is a bump allocator whose `dealloc` is a no-op, so what has to stay bounded is the
+  // total bytes ever allocated, not the peak live: dropping a value early buys nothing, and
+  // only never allocating does. Hence rebuilding the seeds rather than cloning them, and
+  // moving the account metas rather than copying them.
   let bump = ctx.bumps.payer;
   let seeds = || vec![vec![b"helium".to_vec(), bump.to_le_bytes().to_vec()]];
   let (compiled_tx, _) = compile_transaction(ixs, seeds())?;
@@ -307,9 +339,149 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
   })
 }
 
+/// Tallies every allocation on the calling thread, mirroring how the SBF heap behaves: its
+/// `dealloc` is a no-op, so a program is bounded by the total bytes it ever allocates rather
+/// than by its peak live set. Freeing is therefore deliberately not subtracted here.
+///
+/// The counter is thread-local because the test harness runs each test on its own thread, and a
+/// process-wide counter would pick up every other test's allocations. `Cell` with a const
+/// initialiser keeps the TLS access itself allocation-free.
+#[cfg(test)]
+mod alloc_tally {
+  use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    cell::Cell,
+  };
+
+  thread_local! {
+    static BYTES: Cell<usize> = const { Cell::new(0) };
+  }
+
+  pub struct Tallying;
+
+  unsafe impl GlobalAlloc for Tallying {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+      BYTES.with(|b| b.set(b.get().saturating_add(layout.size())));
+      System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+      System.dealloc(ptr, layout)
+    }
+  }
+
+  /// Total bytes allocated on this thread while `f` ran.
+  pub fn bytes_allocated_by<T>(f: impl FnOnce() -> T) -> usize {
+    let before = BYTES.with(|b| b.get());
+    let out = f();
+    let after = BYTES.with(|b| b.get());
+    drop(out);
+    after - before
+  }
+}
+
+#[cfg(test)]
+#[global_allocator]
+static TALLYING_ALLOCATOR: alloc_tally::Tallying = alloc_tally::Tallying;
+
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  fn test_inputs() -> EndEpochInputs {
+    EndEpochInputs {
+      payer: Pubkey::new_unique(),
+      registrar: Pubkey::new_unique(),
+      dao: Pubkey::new_unique(),
+      hnt_mint: Pubkey::new_unique(),
+      rewards_escrow: Pubkey::new_unique(),
+      delegator_pool: Pubkey::new_unique(),
+      hnt_price_oracle: Pubkey::new_unique(),
+      mobile_sub_dao: Pubkey::new_unique(),
+      sub_daos: [
+        SubDaoInputs {
+          key: Pubkey::new_unique(),
+          dnt_mint: Pubkey::new_unique(),
+          treasury: Pubkey::new_unique(),
+        },
+        SubDaoInputs {
+          key: Pubkey::new_unique(),
+          dnt_mint: Pubkey::new_unique(),
+          treasury: Pubkey::new_unique(),
+        },
+      ],
+      prev_epoch: 20_667,
+      curr_epoch: 20_668,
+    }
+  }
+
+  /// The end-epoch task has already exhausted the 32KB SBF heap in production, and the localnet
+  /// regression test only reports that after an anchor build and a running validator. This runs
+  /// in milliseconds and yields a number, so growth is visible while there is still headroom
+  /// rather than only once it has been spent.
+  ///
+  /// The budget is calibrated against the host allocator, which is not the SBF one: treat it as
+  /// a drift detector on the delta, not as a literal 32KB assertion. The localnet test remains
+  /// the ground truth for whether the real heap holds.
+  fn build_and_compile(inputs: &EndEpochInputs) {
+    let ixs = end_epoch_ixs(inputs);
+    let seeds = vec![vec![b"helium".to_vec(), 255u8.to_le_bytes().to_vec()]];
+    compile_transaction(ixs, seeds).expect("compile end-epoch transaction");
+  }
+
+  #[test]
+  fn end_epoch_instruction_set_stays_within_its_allocation_budget() {
+    // Measured at 24,604 bytes without the two supplement destinations and 24,740 with them, so
+    // they cost 136. The budget leaves ~1KB over the current figure: enough that an incidental
+    // change does not trip it, tight enough that anything structural does.
+    const BUDGET: usize = 26_000;
+
+    let inputs = test_inputs();
+    // The first measured region on a thread also captures one-time initialisation, which is
+    // worth ~1.5KB here and would make the figure depend on test ordering. Warm it up first.
+    build_and_compile(&inputs);
+
+    let bytes = alloc_tally::bytes_allocated_by(|| build_and_compile(&inputs));
+
+    println!("end-epoch instruction set + compile allocated {bytes} bytes");
+    assert!(
+      bytes <= BUDGET,
+      "end-epoch build allocated {bytes} bytes, over the {BUDGET} budget. The SBF heap never \
+       reuses freed memory, so this is what the 32KB limit is spent on, and the task has been \
+       within ~136 bytes of that limit. Reclaim allocations or reduce what the task carries; \
+       shaving incidental clones will not create durable headroom."
+    );
+  }
+
+  /// Pins what the task actually carries, so a lost account shows up here rather than as a
+  /// failed epoch. Five instructions: a calculate and an issue per sub-DAO, plus no-emit.
+  #[test]
+  fn end_epoch_forwards_both_supplement_destinations() {
+    let ixs = end_epoch_ixs(&test_inputs());
+    assert_eq!(ixs.len(), 5);
+
+    let issue_ixs: Vec<_> = ixs
+      .iter()
+      .filter(|ix| {
+        ix.data
+          == IssueRewardsV0 {
+            args: IssueRewardsArgsV0 { epoch: 20_668 },
+          }
+          .data()
+      })
+      .collect();
+    assert_eq!(issue_ixs.len(), 2);
+
+    for ix in issue_ixs {
+      for destination in [SUPPLEMENT_VAULT_TOKEN_ACCOUNT, COUNCIL_FANOUT_TOKEN_ACCOUNT] {
+        assert!(
+          ix.accounts.iter().any(|a| a.pubkey == destination),
+          "issue_rewards_v0 must carry {destination}, or the first epoch of a supplement \
+           window settles without it and the cron chain stops"
+        );
+      }
+    }
+  }
 
   #[test]
   fn placeholder_supplement_destination_is_not_forwarded() {

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -236,9 +236,16 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     data: no_emit::instruction::NoEmitV0.data(),
   });
 
+  // This handler runs inside tuktuk's `run_task`, under a 32KB heap that the two compiled
+  // transactions below dominate, and it has already overflowed once in production. Every
+  // allocation here is therefore load-bearing: `sub_dao_infos` is dead by this point and is
+  // dropped rather than left to the end of scope, the seeds are rebuilt instead of cloned, and
+  // the account metas are moved rather than copied.
+  drop(sub_dao_infos);
+
   let bump = ctx.bumps.payer;
-  let seeds = vec![vec![b"helium".to_vec(), bump.to_le_bytes().to_vec()]];
-  let (compiled_tx, _) = compile_transaction(ixs, seeds.clone())?;
+  let seeds = || vec![vec![b"helium".to_vec(), bump.to_le_bytes().to_vec()]];
+  let (compiled_tx, _) = compile_transaction(ixs, seeds())?;
 
   let reschedule_ix = Instruction {
     program_id: crate::ID,
@@ -253,11 +260,10 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
       task_queue: ctx.accounts.task_queue.to_account_info(),
       epoch_tracker: ctx.accounts.epoch_tracker.to_account_info(),
     }
-    .to_account_metas(None)
-    .to_vec(),
+    .to_account_metas(None),
     data: crate::instruction::QueueEndEpoch.data(),
   };
-  let (compiled_reschedule_tx, _) = compile_transaction(vec![reschedule_ix], seeds).unwrap();
+  let (compiled_reschedule_tx, _) = compile_transaction(vec![reschedule_ix], seeds()).unwrap();
 
   let end_of_epoch_trigger = TriggerV0::Timestamp(max(
     Clock::get()?.unix_timestamp,


### PR DESCRIPTION
Activates HIP 149 Decision 2 and wires Decision 4's destination through the cron.

**Not deployable as it stands.** `SUPPLEMENT_VAULT_TOKEN_ACCOUNT` and
`COUNCIL_FANOUT_TOKEN_ACCOUNT` are still the placeholder, and a window that opens against a
placeholder mints nothing and fails every epoch. Both get their real values, in this branch,
before it leaves draft.

## Mint start

`INFLATION_START = 1785931200` (2026-08-05T12:00:00Z), so the first mint lands at the
2026-08-06T00:00:00Z epoch crank. The value sits between two crank boundaries rather than on
one, which fixes which epoch mints first regardless of clock drift or a late crank, and makes
the flat window exactly 360 cranks (through 2027-08-01) and the taper exactly 720.

Under `TESTING` the start stays at the dormant sentinel. Once a window is open both destination
accounts are mandatory in `issue_rewards_v0`, and every localnet test closes epochs without
them. The cost of that gate is that no integration test exercises the active window, including
the supply-tracking correction in `calculate_utility_score_v0`; removing it means reworking the
exact-`currentHntSupply` assertions in `tests/helium-sub-daos.ts`, which belongs in its own PR.

## Deploy order

`queue_end_epoch` forwards both destinations, read from the `helium-sub-daos` constants so the
two programs cannot disagree about where the supplement goes. A task is queued an epoch before
it runs, so window state at queue time says nothing about window state at execution: withholding
the accounts until a window is observed open would make the first epoch of a window fail closed
and stop the self-rescheduling chain. A placeholder constant is withheld instead, since Anchor
deserializes a forwarded account as a `TokenAccount` whether or not the window is open.

So the two mint destinations and `INFLATION_START` have to be real in one deploy, and both
programs ship together. A `helium-sub-daos` carrying a real start alongside an `hpl-crons` that
forwards nothing halts every epoch from the first crank of the window, which halts all rewards.
Already-queued tasks were compiled without the two accounts, so the cron needs the same
re-bootstrap the backstop rollout used.

`end-epoch` takes both accounts as flags, so the permissionless manual fallback still closes an
epoch inside a window. It passed nulls, which fails once the supplement is live. Each is pinned
on chain to its constant, so a wrong value fails the instruction rather than misrouting a mint.

## Coverage

Mutation-tested, 8 enumerated and 8 measured. Caught: inverting the placeholder guard, forwarding
unconditionally, swapping the `TESTING` branches, moving the start a day, a 359-epoch flat window,
and a 250bp Council cut.

Not caught, both at the call site: `supplement_vault: None` and `council_vault: None` in
`queue_end_epoch`. No test can close these, because the destinations are compile-time constants
that are deliberately placeholders in a `TESTING` build, so absence is the correct expectation
there and an assertion would pass either way. The check moved to the deploy runbook instead:
decode the queued `end epoch` task before the boundary and confirm the `issue_rewards_v0`
instruction carries both accounts.
