### PR TITLE
HIP 149: activate the supplement mint, and make the end-epoch heap cost measurable

### DIFF
--- a/.changeset/hpl-crons-presized-compile.md
+++ b/.changeset/hpl-crons-presized-compile.md
@@ -6,11 +6,11 @@ hpl-crons gains a `TooManyAccounts` error, so the generated IDL changes and the 
 need a republish.
 
 `queue_end_epoch` compiles its task transactions with pre-sized buffers rather than
-`tuktuk_program::compile_transaction`, which allocated 13,148 bytes to produce a 1,248-byte
-transaction: two HashMaps growing from empty by doubling, plus a `remaining_accounts` Vec this
-caller discards. The SBF heap is bump-allocated and never reuses freed memory, so every
-intermediate table stayed resident, and the instruction had already exhausted that heap in
-production once.
+`tuktuk_program::compile_transaction`, which spends ~8,600 bytes more than the pre-sized path to
+produce the same ~1.2KB transaction: two HashMaps growing from empty by doubling, plus a
+`remaining_accounts` Vec this caller discards. The SBF heap is bump-allocated and never reuses
+freed memory, so every intermediate table stayed resident, and the instruction had already
+exhausted that heap in production once.
 
 Indices and the privilege counts in a compiled transaction are `u8`. Past 255 accounts they would
 truncate silently and point instructions at the wrong accounts rather than failing, so the new

--- a/.changeset/hpl-crons-presized-compile.md
+++ b/.changeset/hpl-crons-presized-compile.md
@@ -1,0 +1,17 @@
+---
+"@helium/idls": patch
+---
+
+hpl-crons gains a `TooManyAccounts` error, so the generated IDL changes and the published types
+need a republish.
+
+`queue_end_epoch` compiles its task transactions with pre-sized buffers rather than
+`tuktuk_program::compile_transaction`, which allocated 13,148 bytes to produce a 1,248-byte
+transaction: two HashMaps growing from empty by doubling, plus a `remaining_accounts` Vec this
+caller discards. The SBF heap is bump-allocated and never reuses freed memory, so every
+intermediate table stayed resident, and the instruction had already exhausted that heap in
+production once.
+
+Indices and the privilege counts in a compiled transaction are `u8`. Past 255 accounts they would
+truncate silently and point instructions at the wrong accounts rather than failing, so the new
+error refuses that case instead. The end-epoch set uses 32.

--- a/packages/helium-admin-cli/src/create-council-fanout.ts
+++ b/packages/helium-admin-cli/src/create-council-fanout.ts
@@ -16,6 +16,7 @@ import {
 import * as multisig from "@sqds/multisig";
 import os from "os";
 import yargs from "yargs/yargs";
+import { COUNCIL_FANOUT_TOKEN_ACCOUNT } from "./hip149";
 import { loadKeypair } from "./utils";
 
 // HIP 149 Decision 4: create the Advisory Council compensation fanout. The supplement mint in
@@ -151,6 +152,21 @@ export async function run(args: any = process.argv) {
     .prepare();
   instructions.push(initIx);
 
+  // The fanout PDA is seeded by the `namespace` signer and `--seed`. Anchor resolves that
+  // signer to the provider wallet, so a different wallet, or a different seed, silently
+  // produces a different PDA, a different HNT associated token account, and a fanout that
+  // `issue_rewards_v0` rejects on its account pin. That would fail every epoch close inside a
+  // supplement window. Members, owner and schedule do not enter the derivation, so this only
+  // constrains the two inputs that have to stay fixed. Checked before anything is sent.
+  const tokenAccount = getAssociatedTokenAddressSync(HNT_MINT, miniFanout!, true);
+  if (!tokenAccount.equals(COUNCIL_FANOUT_TOKEN_ACCOUNT)) {
+    throw new Error(
+      `Derived fanout token account ${tokenAccount.toBase58()} does not match the ` +
+        `COUNCIL_FANOUT_TOKEN_ACCOUNT pinned in issue_rewards_v0 ` +
+        `(${COUNCIL_FANOUT_TOKEN_ACCOUNT.toBase58()}). Wrong signing wallet or wrong --seed.`
+    );
+  }
+
   // Fund the fanout so it can pay its own crank reward and stay scheduled.
   instructions.push(
     SystemProgram.transfer({
@@ -206,12 +222,6 @@ export async function run(args: any = process.argv) {
     computeUnitLimit: 500000,
   });
 
-  const tokenAccount = getAssociatedTokenAddressSync(
-    HNT_MINT,
-    miniFanout!,
-    true
-  );
-
   console.log("Council fanout created.");
   if (argv.multisig) {
     console.log(`  multisig:                    ${argv.multisig}`);
@@ -223,7 +233,7 @@ export async function run(args: any = process.argv) {
   members.forEach((m) => console.log(`    - ${m.toBase58()}`));
   console.log("");
   console.log(
-    "  >>> Council fanout token account (set COUNCIL_FANOUT_TOKEN_ACCOUNT):"
+    "  >>> Council fanout token account (matches COUNCIL_FANOUT_TOKEN_ACCOUNT):"
   );
   console.log(`      ${tokenAccount.toBase58()}`);
 }

--- a/packages/helium-admin-cli/src/create-council-fanout.ts
+++ b/packages/helium-admin-cli/src/create-council-fanout.ts
@@ -37,6 +37,9 @@ import { loadKeypair } from "./utils";
 //     members from that point forward, per the HIP).
 //   - Keep the fanout funded with lamports; it pays its own crank reward and silently
 //     unschedules itself if it runs dry.
+//   - Closing the fanout refunds its rent to whoever paid to create it, not to the owner:
+//     initialize_mini_fanout_v0 stores `ctx.accounts.payer.key()` as `rent_refund` and never
+//     reads the account passed under that name. Pick the payer accordingly.
 export async function run(args: any = process.argv) {
   const yarg = yargs(args).options({
     wallet: {
@@ -137,7 +140,12 @@ export async function run(args: any = process.argv) {
       payer: wallet.publicKey,
       owner,
       taskQueue: TASK_QUEUE_ID,
-      rentRefund: owner,
+      // The account required here does not decide where rent goes:
+      // initialize_mini_fanout_v0 stores `ctx.accounts.payer.key()` and never reads this one.
+      // Passing the payer keeps the argument honest about the refund destination, and keeps a
+      // vault that has no other role in this instruction out of the writable set. Change the
+      // payer to change where closing the fanout refunds its rent.
+      rentRefund: wallet.publicKey,
       mint: HNT_MINT,
     })
     .prepare();
@@ -153,6 +161,26 @@ export async function run(args: any = process.argv) {
   );
 
   // Schedule the first distribution task; the fanout self-reschedules thereafter.
+  //
+  // `schedule_task_v0` declares `has_one = task_queue / next_task / next_pre_task` on the
+  // fanout, and Anchor's client resolver satisfies those by fetching it. The instruction
+  // above creates the fanout in this same transaction, so there is nothing on chain to fetch
+  // and resolution fails before anything is sent. Each of those accounts is known ahead of
+  // time instead: `initialize_mini_fanout_v0` stores the task queue it was handed, and sets
+  // `next_task` and `next_pre_task` to the fanout's own key, the "no next task" sentinel that
+  // the scheduling constraint accepts.
+  const [queueAuthority] = PublicKey.findProgramAddressSync(
+    [Buffer.from("queue_authority", "utf-8")],
+    program.programId
+  );
+  const [taskQueueAuthority] = PublicKey.findProgramAddressSync(
+    [
+      Buffer.from("task_queue_authority", "utf-8"),
+      TASK_QUEUE_ID.toBuffer(),
+      queueAuthority.toBuffer(),
+    ],
+    tuktukProgram.programId
+  );
   const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(
     TASK_QUEUE_ID
   );
@@ -160,9 +188,14 @@ export async function run(args: any = process.argv) {
   instructions.push(
     await program.methods
       .scheduleTaskV0({ taskId, preTaskId })
-      .accounts({
+      .accountsPartial({
         payer: wallet.publicKey,
         miniFanout: miniFanout!,
+        taskQueue: TASK_QUEUE_ID,
+        queueAuthority,
+        taskQueueAuthority,
+        nextTask: miniFanout!,
+        nextPreTask: miniFanout!,
         task: taskKey(TASK_QUEUE_ID, taskId)[0],
         preTask: taskKey(TASK_QUEUE_ID, preTaskId)[0],
       })

--- a/packages/helium-admin-cli/src/end-epoch.ts
+++ b/packages/helium-admin-cli/src/end-epoch.ts
@@ -76,6 +76,16 @@ export async function run(args: any = process.argv) {
         type: "number",
         describe: "The timestamp to start ending epochs from",
       },
+      supplementVault: {
+        type: "string",
+        describe:
+          "HIP 149 Decision 2 Receiving Entity vault HNT token account. Required to close an epoch inside a supplement window; issue_rewards_v0 pins it to SUPPLEMENT_VAULT_TOKEN_ACCOUNT, so a wrong value fails the instruction rather than misrouting the mint. Omit while the supplement is dormant.",
+      },
+      councilVault: {
+        type: "string",
+        describe:
+          "HIP 149 Decision 4 Council fanout HNT token account. Same requirement and same on-chain pinning as --supplementVault.",
+      },
     });
     const argv = await yarg.argv;
     process.env.ANCHOR_WALLET = argv.wallet;
@@ -89,6 +99,12 @@ export async function run(args: any = process.argv) {
     const unixNow = new Date().valueOf() / 1000;
     const [dao] = daoKey(hntMint);
     const basePriorityFee = Number(argv.basePriorityFee || 1);
+    const supplementVault = argv.supplementVault
+      ? new PublicKey(argv.supplementVault)
+      : null;
+    const councilVault = argv.councilVault
+      ? new PublicKey(argv.councilVault)
+      : null;
 
     const subDaos = await heliumSubDaosProgram.account.subDaoV0.all([
       {
@@ -212,8 +228,8 @@ export async function run(args: any = process.argv) {
                     .issueRewardsV0({ epoch })
                     .accountsPartial({
                       subDao: subDao.publicKey,
-                      supplementVault: null,
-                      councilVault: null,
+                      supplementVault,
+                      councilVault,
                     })
                     .instruction(),
                 ],

--- a/packages/helium-admin-cli/src/end-epoch.ts
+++ b/packages/helium-admin-cli/src/end-epoch.ts
@@ -35,8 +35,13 @@ import {
   Keypair,
   PublicKey,
   SYSVAR_CLOCK_PUBKEY,
+  SystemProgram,
 } from "@solana/web3.js";
 import { BN } from "bn.js";
+import {
+  COUNCIL_FANOUT_TOKEN_ACCOUNT,
+  SUPPLEMENT_VAULT_TOKEN_ACCOUNT,
+} from "./hip149";
 import b58 from "bs58";
 import os from "os";
 import yargs from "yargs/yargs";
@@ -78,13 +83,15 @@ export async function run(args: any = process.argv) {
       },
       supplementVault: {
         type: "string",
+        default: SUPPLEMENT_VAULT_TOKEN_ACCOUNT.toBase58(),
         describe:
-          "HIP 149 Decision 2 Receiving Entity vault HNT token account. Required to close an epoch inside a supplement window; issue_rewards_v0 pins it to SUPPLEMENT_VAULT_TOKEN_ACCOUNT, so a wrong value fails the instruction rather than misrouting the mint. Omit while the supplement is dormant.",
+          "HIP 149 Decision 2 Receiving Entity vault HNT token account. Required to close an epoch inside a supplement window. Defaults to the address issue_rewards_v0 pins, which is the only value that can succeed while a window is open; a wrong value fails the instruction rather than misrouting the mint. Passing the system program id withholds it, which is what a dormant-supplement build expects.",
       },
       councilVault: {
         type: "string",
+        default: COUNCIL_FANOUT_TOKEN_ACCOUNT.toBase58(),
         describe:
-          "HIP 149 Decision 4 Council fanout HNT token account. Same requirement and same on-chain pinning as --supplementVault.",
+          "HIP 149 Decision 4 Council fanout HNT token account. Same defaulting and same on-chain pinning as --supplementVault.",
       },
     });
     const argv = await yarg.argv;
@@ -99,12 +106,26 @@ export async function run(args: any = process.argv) {
     const unixNow = new Date().valueOf() / 1000;
     const [dao] = daoKey(hntMint);
     const basePriorityFee = Number(argv.basePriorityFee || 1);
-    const supplementVault = argv.supplementVault
-      ? new PublicKey(argv.supplementVault)
-      : null;
-    const councilVault = argv.councilVault
-      ? new PublicKey(argv.councilVault)
-      : null;
+    // The supplement follows crank time, not epoch time: issue_rewards_v0 sizes it from
+    // Clock::get() at execution, not from the epoch it is settling. So backfilling this loop
+    // through several stale epochs while a window is open mints a full per-epoch supplement for
+    // each one, on the day the backfill runs, and cranks that cross a window boundary late are
+    // paid at the later rate. The HNT mint circuit breaker is the backstop that bounds this: at
+    // a 350,000 HNT/day absolute threshold it admits roughly one supplement per day on top of
+    // normal emissions, so a multi-epoch backfill fails on the breaker rather than overminting
+    // without limit. Settle stale epochs one crank interval at a time while a window is open.
+    //
+    // Both destinations default to the pinned constants, so the permissionless fallback cannot
+    // silently omit them: a null vault during an open window makes issue_rewards_v0 fail, and
+    // this loop collects that into `errors` and advances rather than stopping. Pass the system
+    // program id to withhold one deliberately.
+    const asVault = (raw: string | undefined) => {
+      if (!raw) return null;
+      const key = new PublicKey(raw);
+      return key.equals(SystemProgram.programId) ? null : key;
+    };
+    const supplementVault = asVault(argv.supplementVault);
+    const councilVault = asVault(argv.councilVault);
 
     const subDaos = await heliumSubDaosProgram.account.subDaoV0.all([
       {

--- a/packages/helium-admin-cli/src/hip149.ts
+++ b/packages/helium-admin-cli/src/hip149.ts
@@ -1,0 +1,15 @@
+import { PublicKey } from "@solana/web3.js";
+
+// The HIP 149 supplement destinations, as pinned in `helium-sub-daos::supplement`.
+//
+// `issue_rewards_v0` requires whatever it is handed to equal these exact keys while a supplement
+// window is open, so a value that disagrees with the program fails the instruction and can never
+// misroute a mint. That pin is what makes it safe to default the `end-epoch` flags to them, and
+// what `create-council-fanout` checks its derived fanout account against before sending.
+export const SUPPLEMENT_VAULT_TOKEN_ACCOUNT = new PublicKey(
+  "AGPDcgpXan5RB2Y9usHvdJmmJHpyyYqcQm8KouRkK6f4"
+);
+
+export const COUNCIL_FANOUT_TOKEN_ACCOUNT = new PublicKey(
+  "EYbAXgLq1aRr9a9y55DbjfMdXNrZuMa69WXN9c1UR6eK"
+);

--- a/programs/helium-sub-daos/src/supplement.rs
+++ b/programs/helium-sub-daos/src/supplement.rs
@@ -11,8 +11,9 @@
 //! supplement isn't misread as burned HNT (see the supply-tracking note there).
 //!
 //! All parameters are hardcoded; changing them requires a community-voted program upgrade.
-//! That includes the two destination token accounts, so the supplement cannot be redirected
-//! without a community-voted upgrade either. Both destinations are mandatory while a window is
+//! That includes both destination token accounts, so which accounts the supplement mints *into*
+//! cannot change without one; see COUNCIL_FANOUT_TOKEN_ACCOUNT for what that does not fix about
+//! where the Council carve-out ends up. Both destinations are mandatory while a window is
 //! open, and `hpl-crons` withholds a destination that still holds its pre-activation
 //! placeholder rather than forwarding it, so a build whose destinations are not real fails
 //! every epoch of a live window instead of minting somewhere unintended.
@@ -27,8 +28,8 @@ const EPOCH_LENGTH: i64 = 24 * 60 * 60;
 /// Mint start, 2026-08-05T12:00:00Z. Epochs settle on the 00:00 UTC boundary, so the first
 /// supplement mint lands at the 2026-08-06T00:00:00Z crank, closing the Council's pre-mint
 /// review window. The value sits between two crank boundaries rather than on one, so neither
-/// Solana clock drift nor a late crank can change which epoch mints first; the flat window
-/// then spans exactly 360 cranks (through 2027-08-01) and the taper exactly 720.
+/// Solana clock drift nor a late crank can change which epoch mints first, and the windows
+/// come to whole crank counts: 360 flat, then 720 tapering.
 ///
 /// Under TESTING the start stays a far-future sentinel (2100-01-01), keeping the supplement
 /// dormant for the localnet suite: an open window makes both destination accounts mandatory
@@ -76,9 +77,13 @@ pub const COUNCIL_COMPENSATION_BPS: u64 = 125;
 /// `mini_fanout` `2pCpQYrUmQor9igsF4cY7tkmd3jBQzHFEB75gtpjdWA2`.
 ///
 /// issue_rewards_v0 requires the supplied Council token account to equal this key (relaxed
-/// under TESTING). The fanout's `owner`, the only authority that can edit the seated-member
-/// set, is the governance multisig vault and never the Receiving Entity, so seating and
-/// removal reach the chain only through a multisig action.
+/// under TESTING). The fanout's `owner` is the governance multisig vault, never the Receiving
+/// Entity, so the seated-member set changes only through a multisig action.
+///
+/// The pinned address fixes where the carve-out is *minted*, not where it ends up. A seated
+/// member can point their own share at a delegate under their own signature, and closing the
+/// fanout sweeps its balance to the owner and frees the PDA for re-initialisation by the
+/// namespace keypair. Monitor the fanout's shares, not just this address.
 pub const COUNCIL_FANOUT_TOKEN_ACCOUNT: Pubkey =
   pubkey!("EYbAXgLq1aRr9a9y55DbjfMdXNrZuMa69WXN9c1UR6eK");
 
@@ -181,14 +186,42 @@ mod tests {
     );
   }
 
-  /// Pins the three deployed boundary timestamps, and which epoch crank mints first, against
-  /// the dates published in the HIP. `cargo test --lib` builds without TESTING and so checks
-  /// the mainnet values; a TESTING build must hold the dormant sentinel instead, and asserting
-  /// both directions means swapping the two branches fails here either way.
+  /// Pins the deployed mint rate against the amount published in HIP 149 Decision 2: 98,000 HNT
+  /// per sub-DAO per epoch, which across the two sub-DAO passes is the 196,000 HNT/day headline
+  /// figure, and the taper opening at the same rate so the handoff neither steps up nor drops.
+  ///
+  /// The amounts are literals on both sides. An assertion that reads the constant it is meant to
+  /// pin holds for every value that constant could take, and so states only that the window is
+  /// open. The rate is not gated on TESTING, only the window is, so this holds in both builds.
   #[test]
-  fn deployed_window_boundaries_match_the_published_dates() {
+  fn deployed_supplement_rate_matches_the_published_amount() {
+    const HNT: u64 = 100_000_000;
+    const SUB_DAO_PASSES_PER_EPOCH: u64 = 2;
+
+    assert_eq!(INFLATION_FLAT_PER_EPOCH_PER_SUBDAO, 98_000 * HNT);
+    assert_eq!(INFLATION_TAPER_INITIAL_PER_EPOCH_PER_SUBDAO, 98_000 * HNT);
+    assert_eq!(
+      INFLATION_FLAT_PER_EPOCH_PER_SUBDAO * SUB_DAO_PASSES_PER_EPOCH,
+      196_000 * HNT
+    );
+  }
+
+  /// Pins the deployed start timestamp and which epoch crank mints first. `cargo test --lib`
+  /// builds without TESTING and so checks the mainnet value; a TESTING build must hold the
+  /// dormant sentinel instead, and asserting both directions means swapping the two branches
+  /// fails here either way.
+  ///
+  /// Both end boundaries are `INFLATION_START + N * EPOCH_LENGTH`, so what is worth pinning is
+  /// `N` and the rate each crank sees, not a restatement of arithmetic the compiler performed.
+  #[test]
+  fn deployed_window_boundaries_match_the_published_schedule() {
     const AUG_05_0000Z: i64 = 1_785_888_000;
     const AUG_06_0000Z: i64 = 1_785_974_400;
+
+    // Whole crank counts, in both builds: the HIP defines the windows in epochs, and a start
+    // that did not sit between two crank boundaries would leave a fractional remainder.
+    assert_eq!(INFLATION_FLAT_END - INFLATION_START, 360 * EPOCH_LENGTH);
+    assert_eq!(INFLATION_TAPER_END - INFLATION_FLAT_END, 720 * EPOCH_LENGTH);
 
     if TESTING {
       assert_eq!(INFLATION_START, 4_102_444_800);
@@ -197,8 +230,6 @@ mod tests {
     }
 
     assert_eq!(INFLATION_START, 1_785_931_200); // 2026-08-05T12:00:00Z
-    assert_eq!(INFLATION_FLAT_END, 1_817_035_200); // 2027-07-31T12:00:00Z
-    assert_eq!(INFLATION_TAPER_END, 1_879_243_200); // 2029-07-20T12:00:00Z
 
     // The 00:00 UTC crank on 2026-08-06 is the first one to mint; the one a day earlier
     // must not, so the Council's pre-mint review window runs its full length.
@@ -207,6 +238,18 @@ mod tests {
       supplement_per_subdao(AUG_06_0000Z),
       INFLATION_FLAT_PER_EPOCH_PER_SUBDAO
     );
+
+    // Counted in cranks from that first minting one, so the flat window's last full-rate mint,
+    // the taper's first reduced one, and the final paying crank are each pinned without
+    // restating a derived timestamp. 360 flat + 720 tapering = 1,080 cranks that mint.
+    let crank = |n: i64| AUG_06_0000Z + n * EPOCH_LENGTH;
+    assert_eq!(
+      supplement_per_subdao(crank(359)),
+      INFLATION_FLAT_PER_EPOCH_PER_SUBDAO
+    );
+    assert!(supplement_per_subdao(crank(360)) < INFLATION_FLAT_PER_EPOCH_PER_SUBDAO);
+    assert!(supplement_per_subdao(crank(1079)) > 0);
+    assert_eq!(supplement_per_subdao(crank(1080)), 0);
   }
 
   #[test]

--- a/programs/helium-sub-daos/src/supplement.rs
+++ b/programs/helium-sub-daos/src/supplement.rs
@@ -25,17 +25,31 @@ use crate::TESTING;
 const EPOCH_LENGTH: i64 = 24 * 60 * 60;
 
 // ── Patch-time constants ─────────────────────────────────────────────────────────────
+/// A start far enough out that both windows are closed, leaving the supplement dormant.
+/// 2100-01-01.
+const DORMANT_START: i64 = 4_102_444_800;
+
 /// Mint start, 2026-08-05T12:00:00Z. Epochs settle on the 00:00 UTC boundary, so the first
 /// supplement mint lands at the 2026-08-06T00:00:00Z crank, closing the Council's pre-mint
-/// review window. The value sits between two crank boundaries rather than on one, so neither
-/// Solana clock drift nor a late crank can change which epoch mints first, and the windows
-/// come to whole crank counts: 360 flat, then 720 tapering.
+/// review window.
 ///
-/// Under TESTING the start stays a far-future sentinel (2100-01-01), keeping the supplement
-/// dormant for the localnet suite: an open window makes both destination accounts mandatory
-/// in `issue_rewards_v0`, and every test there closes epochs without them.
+/// `issue_rewards_v0` sizes the supplement from the wall clock at execution rather than from the
+/// epoch it is settling, so placing the start midway between two crank boundaries buys 12 hours
+/// of tolerance either side: clock drift, or a crank running late, cannot change which epoch
+/// mints first unless a crank is more than 12 hours late. Cranks normally land within seconds.
+/// The windows also come to whole crank counts this way: 360 flat, then 720 tapering.
+///
+/// Dormant on devnet as well as under TESTING. Both destination constants are associated token
+/// accounts of the mainnet HNT mint, so they cannot exist on another cluster, and an open window
+/// makes both mandatory in `issue_rewards_v0`; a live start anywhere else would stop epochs
+/// closing at the first crank inside the window. Gating the start is what keeps the destinations
+/// from being required, so they need no gating of their own. Devnet builds set the `devnet`
+/// feature and leave `TESTING` unset, so they need their own arm rather than the TESTING one.
+#[cfg(feature = "devnet")]
+pub const INFLATION_START: i64 = DORMANT_START;
+#[cfg(not(feature = "devnet"))]
 pub const INFLATION_START: i64 = if TESTING {
-  4_102_444_800
+  DORMANT_START
 } else {
   1_785_931_200
 };
@@ -207,9 +221,9 @@ mod tests {
   }
 
   /// Pins the deployed start timestamp and which epoch crank mints first. `cargo test --lib`
-  /// builds without TESTING and so checks the mainnet value; a TESTING build must hold the
-  /// dormant sentinel instead, and asserting both directions means swapping the two branches
-  /// fails here either way.
+  /// builds with neither TESTING nor `devnet` and so checks the mainnet value; a build with
+  /// either must hold the dormant sentinel instead. Asserting both directions means a live start
+  /// reaching the wrong cluster fails here, whichever way the arms are swapped.
   ///
   /// Both end boundaries are `INFLATION_START + N * EPOCH_LENGTH`, so what is worth pinning is
   /// `N` and the rate each crank sees, not a restatement of arithmetic the compiler performed.
@@ -218,13 +232,13 @@ mod tests {
     const AUG_05_0000Z: i64 = 1_785_888_000;
     const AUG_06_0000Z: i64 = 1_785_974_400;
 
-    // Whole crank counts, in both builds: the HIP defines the windows in epochs, and a start
+    // Whole crank counts, in every build: the HIP defines the windows in epochs, and a start
     // that did not sit between two crank boundaries would leave a fractional remainder.
     assert_eq!(INFLATION_FLAT_END - INFLATION_START, 360 * EPOCH_LENGTH);
     assert_eq!(INFLATION_TAPER_END - INFLATION_FLAT_END, 720 * EPOCH_LENGTH);
 
-    if TESTING {
-      assert_eq!(INFLATION_START, 4_102_444_800);
+    if TESTING || cfg!(feature = "devnet") {
+      assert_eq!(INFLATION_START, DORMANT_START);
       assert_eq!(supplement_per_subdao(AUG_06_0000Z), 0);
       return;
     }

--- a/programs/helium-sub-daos/src/supplement.rs
+++ b/programs/helium-sub-daos/src/supplement.rs
@@ -10,22 +10,34 @@
 //! `calculate_utility_score_v0` adds the same total back into `current_hnt_supply` so the
 //! supplement isn't misread as burned HNT (see the supply-tracking note there).
 //!
-//! All parameters are hardcoded; changing them requires a community-voted program
-//! upgrade. Several are **patch-time** values set just before the mainnet deploy — by
-//! default they leave the supplement INACTIVE (a far-future start), so the program is safe
-//! to ship before they're finalized.
+//! All parameters are hardcoded; changing them requires a community-voted program upgrade.
+//! That includes the two destination token accounts, so the supplement cannot be redirected
+//! without a community-voted upgrade either. Both destinations are mandatory while a window is
+//! open, and `hpl-crons` withholds a destination that still holds its pre-activation
+//! placeholder rather than forwarding it, so a build whose destinations are not real fails
+//! every epoch of a live window instead of minting somewhere unintended.
 
 use anchor_lang::prelude::*;
+
+use crate::TESTING;
 
 const EPOCH_LENGTH: i64 = 24 * 60 * 60;
 
 // ── Patch-time constants ─────────────────────────────────────────────────────────────
-// PATCH-TIME: set INFLATION_START to the real mint-start unix timestamp (the upgrade slot
-// + ~2 weeks, the Council pre-mint review window) before the mainnet deploy. The default
-// is a far-future sentinel (2100-01-01) so the supplement stays dormant until deliberately
-// configured — shipping without setting it mints nothing, and the test suite (which runs
-// at present-day wall-clock) sees a zero supplement and is unaffected.
-pub const INFLATION_START: i64 = 4_102_444_800;
+/// Mint start, 2026-08-05T12:00:00Z. Epochs settle on the 00:00 UTC boundary, so the first
+/// supplement mint lands at the 2026-08-06T00:00:00Z crank, closing the Council's pre-mint
+/// review window. The value sits between two crank boundaries rather than on one, so neither
+/// Solana clock drift nor a late crank can change which epoch mints first; the flat window
+/// then spans exactly 360 cranks (through 2027-08-01) and the taper exactly 720.
+///
+/// Under TESTING the start stays a far-future sentinel (2100-01-01), keeping the supplement
+/// dormant for the localnet suite: an open window makes both destination accounts mandatory
+/// in `issue_rewards_v0`, and every test there closes epochs without them.
+pub const INFLATION_START: i64 = if TESTING {
+  4_102_444_800
+} else {
+  1_785_931_200
+};
 
 /// End of the flat window (~12 months / ~360 epochs after the start).
 pub const INFLATION_FLAT_END: i64 = INFLATION_START + 360 * EPOCH_LENGTH;
@@ -41,13 +53,16 @@ pub const INFLATION_FLAT_PER_EPOCH_PER_SUBDAO: u64 = 98_000 * 100_000_000;
 /// then decaying linearly to zero across the taper window.
 pub const INFLATION_TAPER_INITIAL_PER_EPOCH_PER_SUBDAO: u64 = INFLATION_FLAT_PER_EPOCH_PER_SUBDAO;
 
-// PATCH-TIME: the Receiving Entity's Squads vault HNT token account that receives the
-// supplement. Placeholder (the system program id); set to the real token account before
-// deploy. issue_rewards_v0 requires the supplied supplement token account to equal this key
-// (relaxed under TESTING), pinned to the exact account — like COUNCIL_FANOUT_TOKEN_ACCOUNT —
-// rather than only checking the token-account authority, so a caller cannot route the
-// supplement to a different account under the same authority (I-03).
-pub const SUPPLEMENT_VAULT_TOKEN_ACCOUNT: Pubkey = pubkey!("11111111111111111111111111111111");
+/// The Receiving Entity's HNT token account: the associated token account of vault index 0 of
+/// Squads multisig `2g7qF5d3p2XeJALK6RzAF1sFY8Emt8LuMLXATF6hjWyy`, whose vault is
+/// `Cuy6WiVdHE6Wznqos86AUwLpA4zPfPABYq3qszMa6E6A`.
+///
+/// issue_rewards_v0 requires the supplied supplement token account to equal this key (relaxed
+/// under TESTING). Pinning the exact account, rather than only checking the token account's
+/// authority, is what stops a caller routing the supplement to a different account under the
+/// same authority.
+pub const SUPPLEMENT_VAULT_TOKEN_ACCOUNT: Pubkey =
+  pubkey!("AGPDcgpXan5RB2Y9usHvdJmmJHpyyYqcQm8KouRkK6f4");
 
 // ── HIP 149 Decision 4: Advisory Council compensation carve-out ─────────────────────────
 /// The community-nominated Council seats share 1.25% of the supplement (HIP 149 Decision 4).
@@ -57,12 +72,15 @@ pub const SUPPLEMENT_VAULT_TOKEN_ACCOUNT: Pubkey = pubkey!("11111111111111111111
 /// Expressed in basis points; the HIP caps the total at 1.25%, so this is a ceiling.
 pub const COUNCIL_COMPENSATION_BPS: u64 = 125;
 
-// PATCH-TIME: the Council compensation fanout's HNT token account (a mini_fanout PDA-owned
-// ATA). Placeholder (the system program id); set to the real fanout token account before
-// deploy. issue_rewards_v0 requires the supplied Council token account to equal this key
-// (relaxed under TESTING). The fanout's `owner` (who edits the seated-member set) is the
-// governance multisig, never the Receiving Entity; see the create-council-fanout tooling.
-pub const COUNCIL_FANOUT_TOKEN_ACCOUNT: Pubkey = pubkey!("11111111111111111111111111111111");
+/// The Council compensation fanout's HNT token account: the associated token account of
+/// `mini_fanout` `2pCpQYrUmQor9igsF4cY7tkmd3jBQzHFEB75gtpjdWA2`.
+///
+/// issue_rewards_v0 requires the supplied Council token account to equal this key (relaxed
+/// under TESTING). The fanout's `owner`, the only authority that can edit the seated-member
+/// set, is the governance multisig vault and never the Receiving Entity, so seating and
+/// removal reach the chain only through a multisig action.
+pub const COUNCIL_FANOUT_TOKEN_ACCOUNT: Pubkey =
+  pubkey!("EYbAXgLq1aRr9a9y55DbjfMdXNrZuMa69WXN9c1UR6eK");
 
 /// The Council compensation carve-out (1.25%) of a per-sub-DAO supplement amount. The
 /// remainder (`supplement - council_cut`) goes to the Receiving Entity vault.
@@ -119,6 +137,76 @@ mod tests {
 
   fn amt(now: i64) -> u64 {
     supplement_amount(now, START, FLAT_END, TAPER_END, FLAT, FLAT)
+  }
+
+  /// Derives the supplement destination from the Receiving Entity's Squads vault rather than
+  /// restating the constant, so a mistyped address, a wrong mint, or an on-curve derivation
+  /// fails here. The vault itself is off-curve, which `get_associated_token_address` handles;
+  /// changing the destination means changing the vault named here, deliberately.
+  #[test]
+  fn supplement_destination_is_the_receiving_entity_vault_hnt_ata() {
+    const RECEIVING_ENTITY_VAULT: Pubkey = pubkey!("Cuy6WiVdHE6Wznqos86AUwLpA4zPfPABYq3qszMa6E6A");
+    const HNT_MINT: Pubkey = pubkey!("hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux");
+
+    assert_eq!(
+      SUPPLEMENT_VAULT_TOKEN_ACCOUNT,
+      anchor_spl::associated_token::get_associated_token_address(
+        &RECEIVING_ENTITY_VAULT,
+        &HNT_MINT
+      )
+    );
+  }
+
+  /// Derives the Council destination through the whole chain that produced it: the fanout PDA
+  /// from the mini_fanout program, the creating wallet as namespace and the seed, then that
+  /// fanout's HNT associated token account. Repointing Council compensation means changing one
+  /// of those inputs, deliberately, rather than editing an opaque address.
+  #[test]
+  fn council_destination_is_the_seated_fanout_hnt_ata() {
+    const MINI_FANOUT_PROGRAM: Pubkey = pubkey!("mfanLprNnaiP4RX9Zz1BMcDosYHCqnG24H1fMEbi9Gn");
+    const NAMESPACE: Pubkey = pubkey!("hprdnjkbziK8NqhThmAn5Gu4XqrBbctX8du4PfJdgvW");
+    const HNT_MINT: Pubkey = pubkey!("hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux");
+
+    let (fanout, _bump) = Pubkey::find_program_address(
+      &[b"mini_fanout", NAMESPACE.as_ref(), b"hip149-council"],
+      &MINI_FANOUT_PROGRAM,
+    );
+    assert_eq!(
+      fanout,
+      pubkey!("2pCpQYrUmQor9igsF4cY7tkmd3jBQzHFEB75gtpjdWA2")
+    );
+    assert_eq!(
+      COUNCIL_FANOUT_TOKEN_ACCOUNT,
+      anchor_spl::associated_token::get_associated_token_address(&fanout, &HNT_MINT)
+    );
+  }
+
+  /// Pins the three deployed boundary timestamps, and which epoch crank mints first, against
+  /// the dates published in the HIP. `cargo test --lib` builds without TESTING and so checks
+  /// the mainnet values; a TESTING build must hold the dormant sentinel instead, and asserting
+  /// both directions means swapping the two branches fails here either way.
+  #[test]
+  fn deployed_window_boundaries_match_the_published_dates() {
+    const AUG_05_0000Z: i64 = 1_785_888_000;
+    const AUG_06_0000Z: i64 = 1_785_974_400;
+
+    if TESTING {
+      assert_eq!(INFLATION_START, 4_102_444_800);
+      assert_eq!(supplement_per_subdao(AUG_06_0000Z), 0);
+      return;
+    }
+
+    assert_eq!(INFLATION_START, 1_785_931_200); // 2026-08-05T12:00:00Z
+    assert_eq!(INFLATION_FLAT_END, 1_817_035_200); // 2027-07-31T12:00:00Z
+    assert_eq!(INFLATION_TAPER_END, 1_879_243_200); // 2029-07-20T12:00:00Z
+
+    // The 00:00 UTC crank on 2026-08-06 is the first one to mint; the one a day earlier
+    // must not, so the Council's pre-mint review window runs its full length.
+    assert_eq!(supplement_per_subdao(AUG_05_0000Z), 0);
+    assert_eq!(
+      supplement_per_subdao(AUG_06_0000Z),
+      INFLATION_FLAT_PER_EPOCH_PER_SUBDAO
+    );
   }
 
   #[test]

--- a/programs/hpl-crons/src/error.rs
+++ b/programs/hpl-crons/src/error.rs
@@ -12,4 +12,6 @@ pub enum ErrorCode {
   UnclaimedIotMobileRewards,
   #[msg("Invalid task for pyth")]
   InvalidTaskForPyth,
+  #[msg("Too many accounts to index a compiled transaction")]
+  TooManyAccounts,
 }

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -9,7 +9,7 @@ use helium_sub_daos::{
 };
 use spl_token::solana_program::instruction::{AccountMeta, Instruction};
 use tuktuk_program::{
-  compile_transaction,
+  types::{CompiledInstructionV0, CompiledTransactionV0},
   write_return_tasks::{write_return_tasks, AccountWithSeeds, PayerInfo, WriteReturnTasksArgs},
   RunTaskReturnV0, TaskReturnV0, TransactionSourceV0, TriggerV0,
 };
@@ -69,6 +69,104 @@ fn sub_dao_epoch_info_pda(sub_dao: &Pubkey, epoch: u64) -> Pubkey {
     &helium_sub_daos::ID,
   )
   .0
+}
+
+/// Compiles instructions into a task transaction, pre-sized.
+///
+/// `tuktuk_program::compile_transaction` is semantically what we want, but it builds two HashMaps
+/// that grow from empty by doubling and a `remaining_accounts` Vec that this caller discards. On
+/// the SBF heap, which is bump-allocated and never reuses freed memory, every intermediate table
+/// is retained for the life of the instruction: measured at 8,672 bytes of a 32KB budget that
+/// `queue_end_epoch` has already exhausted once in production.
+///
+/// Sizing both vectors from the known slot count removes the growth chain, and a linear scan
+/// replaces the hashing. At this instruction's scale, ~73 slots over ~31 distinct accounts, the
+/// scan is cheaper than the allocations it avoids.
+///
+/// The account ordering contract is tuktuk's: writable signers, then read-only signers, then
+/// writable, then read-only, with `num_rw_signers` / `num_ro_signers` / `num_rw` describing the
+/// boundaries so the crank turner can reconstruct each account's privileges. Indices are resolved
+/// against the list built here, so self-consistency is what correctness requires, not matching the
+/// order upstream would have produced. Within a priority group this is insertion order, which is
+/// deterministic; upstream's is HashMap iteration order, which is not.
+fn compile_task_transaction(
+  instructions: Vec<Instruction>,
+  signer_seeds: Vec<Vec<Vec<u8>>>,
+) -> CompiledTransactionV0 {
+  // Upper bound: every account of every instruction, plus each instruction's program id.
+  let slots: usize = instructions.iter().map(|ix| ix.accounts.len() + 1).sum();
+  let mut keys: Vec<Pubkey> = Vec::with_capacity(slots);
+  // (is_signer, is_writable), accumulated across every appearance of the account.
+  let mut privileges: Vec<(bool, bool)> = Vec::with_capacity(slots);
+
+  for ix in &instructions {
+    for (key, signer, writable) in std::iter::once((ix.program_id, false, false)).chain(
+      ix.accounts
+        .iter()
+        .map(|a| (a.pubkey, a.is_signer, a.is_writable)),
+    ) {
+      match keys.iter().position(|k| *k == key) {
+        Some(i) => {
+          privileges[i].0 |= signer;
+          privileges[i].1 |= writable;
+        }
+        None => {
+          keys.push(key);
+          privileges.push((signer, writable));
+        }
+      }
+    }
+  }
+
+  fn rank(privileges: (bool, bool)) -> u8 {
+    match privileges {
+      (true, true) => 0,
+      (true, false) => 1,
+      (false, true) => 2,
+      (false, false) => 3,
+    }
+  }
+
+  let mut order: Vec<usize> = (0..keys.len()).collect();
+  order.sort_by_key(|i| rank(privileges[*i]));
+
+  let mut num_rw_signers = 0u8;
+  let mut num_ro_signers = 0u8;
+  let mut num_rw = 0u8;
+  for i in &order {
+    match rank(privileges[*i]) {
+      0 => num_rw_signers += 1,
+      1 => num_ro_signers += 1,
+      2 => num_rw += 1,
+      _ => {}
+    }
+  }
+
+  let accounts: Vec<Pubkey> = order.iter().map(|i| keys[*i]).collect();
+  let index_of = |key: &Pubkey| {
+    accounts
+      .iter()
+      .position(|k| k == key)
+      .expect("every key was collected above") as u8
+  };
+
+  let compiled = instructions
+    .into_iter()
+    .map(|ix| CompiledInstructionV0 {
+      program_id_index: index_of(&ix.program_id),
+      accounts: ix.accounts.iter().map(|a| index_of(&a.pubkey)).collect(),
+      data: ix.data,
+    })
+    .collect();
+
+  CompiledTransactionV0 {
+    num_ro_signers,
+    num_rw_signers,
+    num_rw,
+    instructions: compiled,
+    signer_seeds,
+    accounts,
+  }
 }
 
 /// One sub-DAO's contribution to the end-epoch instruction set.
@@ -283,7 +381,7 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
   // moving the account metas rather than copying them.
   let bump = ctx.bumps.payer;
   let seeds = || vec![vec![b"helium".to_vec(), bump.to_le_bytes().to_vec()]];
-  let (compiled_tx, _) = compile_transaction(ixs, seeds())?;
+  let compiled_tx = compile_task_transaction(ixs, seeds());
 
   let reschedule_ix = Instruction {
     program_id: crate::ID,
@@ -301,7 +399,7 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     .to_account_metas(None),
     data: crate::instruction::QueueEndEpoch.data(),
   };
-  let (compiled_reschedule_tx, _) = compile_transaction(vec![reschedule_ix], seeds()).unwrap();
+  let compiled_reschedule_tx = compile_task_transaction(vec![reschedule_ix], seeds());
 
   let end_of_epoch_trigger = TriggerV0::Timestamp(max(
     Clock::get()?.unix_timestamp,
@@ -424,7 +522,7 @@ mod tests {
   fn build_and_compile(inputs: &EndEpochInputs) {
     let ixs = end_epoch_ixs(inputs);
     let seeds = vec![vec![b"helium".to_vec(), 255u8.to_le_bytes().to_vec()]];
-    compile_transaction(ixs, seeds).expect("compile end-epoch transaction");
+    compile_task_transaction(ixs, seeds);
   }
 
   /// The end-epoch task has already exhausted the 32KB SBF heap in production, and the localnet
@@ -439,11 +537,12 @@ mod tests {
   /// rather than a literal 32KB assertion. The localnet test remains the ground truth.
   #[test]
   fn end_epoch_instruction_set_stays_within_its_allocation_budget() {
-    // Measured at 24,104 bytes carrying both supplement destinations, against 24,464 on the
-    // pre-HIP-149 baseline: pre-sizing the metas Vec more than pays for the 136 bytes the two
-    // destinations add. The budget leaves a few hundred bytes: enough that an incidental change
-    // does not trip it, tight enough that anything structural does.
-    const BUDGET: usize = 24_500;
+    // Measured at 15,000 bytes carrying both supplement destinations, against 24,464 for the
+    // same work before the pre-sized compile and metas Vec. The two destinations cost 136 of
+    // that, so the margin is now measured in kilobytes rather than bytes. The budget leaves
+    // ~1KB: enough that an incidental change does not trip it, tight enough that anything
+    // structural does.
+    const BUDGET: usize = 16_000;
 
     let inputs = test_inputs();
     // The first measured region on a thread also captures one-time initialisation, which is
@@ -489,6 +588,80 @@ mod tests {
            window settles without it and the cron chain stops"
         );
       }
+    }
+  }
+
+  /// Pins the pre-sized compile against the upstream one it replaces. Ordering within a
+  /// priority group differs by construction, so this asserts the properties the crank turner
+  /// and `run_task_v0` actually rely on: the same accounts, the same privilege boundaries, and
+  /// every instruction index resolving to the same account. Anything that changes those changes
+  /// which accounts a task can write, so this is the guard that matters.
+  #[test]
+  fn presized_compile_matches_upstream() {
+    let inputs = test_inputs();
+    let seeds = || vec![vec![b"helium".to_vec(), vec![255u8]]];
+
+    let (upstream, _) = tuktuk_program::compile_transaction(end_epoch_ixs(&inputs), seeds())
+      .expect("upstream compile");
+    let ours = compile_task_transaction(end_epoch_ixs(&inputs), seeds());
+
+    let mut a = upstream.accounts.clone();
+    let mut b = ours.accounts.clone();
+    a.sort();
+    b.sort();
+    assert_eq!(a, b, "same account set");
+    assert_eq!(
+      (
+        upstream.num_rw_signers,
+        upstream.num_ro_signers,
+        upstream.num_rw
+      ),
+      (ours.num_rw_signers, ours.num_ro_signers, ours.num_rw),
+      "same privilege boundaries"
+    );
+    assert_eq!(upstream.instructions.len(), ours.instructions.len());
+    assert_eq!(upstream.signer_seeds, ours.signer_seeds);
+
+    for (u, o) in upstream.instructions.iter().zip(ours.instructions.iter()) {
+      assert_eq!(u.data, o.data, "instruction data preserved");
+      assert_eq!(
+        upstream.accounts[u.program_id_index as usize], ours.accounts[o.program_id_index as usize],
+        "program id resolves the same"
+      );
+      let resolved_u: Vec<Pubkey> = u
+        .accounts
+        .iter()
+        .map(|i| upstream.accounts[*i as usize])
+        .collect();
+      let resolved_o: Vec<Pubkey> = o
+        .accounts
+        .iter()
+        .map(|i| ours.accounts[*i as usize])
+        .collect();
+      assert_eq!(
+        resolved_u, resolved_o,
+        "indices resolve to the same accounts"
+      );
+    }
+
+    // The boundaries must describe the ordering, or the crank turner grants the wrong
+    // privileges: every account before num_rw_signers is a writable signer, and so on.
+    let rw_signers = ours.num_rw_signers as usize;
+    let signers = rw_signers + ours.num_ro_signers as usize;
+    let writable = signers + ours.num_rw as usize;
+    assert!(writable <= ours.accounts.len());
+    for (i, key) in ours.accounts.iter().enumerate() {
+      let expected_signer = i < signers;
+      let expected_writable = i < rw_signers || (i >= signers && i < writable);
+      let (signer, wr) = end_epoch_ixs(&inputs)
+        .iter()
+        .flat_map(|ix| ix.accounts.iter())
+        .filter(|a| a.pubkey == *key)
+        .fold((false, false), |acc, a| {
+          (acc.0 || a.is_signer, acc.1 || a.is_writable)
+        });
+      assert_eq!(signer, expected_signer, "signer boundary for account {i}");
+      assert_eq!(wr, expected_writable, "writable boundary for account {i}");
     }
   }
 

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -76,8 +76,9 @@ fn sub_dao_epoch_info_pda(sub_dao: &Pubkey, epoch: u64) -> Pubkey {
 /// `tuktuk_program::compile_transaction` is semantically what we want, but it builds two HashMaps
 /// that grow from empty by doubling and a `remaining_accounts` Vec that this caller discards. On
 /// the SBF heap, which is bump-allocated and never reuses freed memory, every intermediate table
-/// is retained for the life of the instruction: measured at 8,672 bytes of a 32KB budget that
-/// `queue_end_epoch` has already exhausted once in production.
+/// is retained for the life of the instruction. Compiling the end-epoch set through it costs
+/// ~8,600 bytes more than this function does, out of a 32KB budget `queue_end_epoch` has already
+/// exhausted once in production.
 ///
 /// Sizing both vectors from the known slot count removes the growth chain, and a linear scan
 /// replaces the hashing. At this instruction's scale, ~73 slots over ~31 distinct accounts, the

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -2,8 +2,10 @@ use std::cmp::max;
 
 use anchor_lang::{prelude::*, system_program, InstructionData};
 use helium_sub_daos::{
-  accounts::CalculateUtilityScoreV0, instruction::IssueRewardsV0, CalculateUtilityScoreArgsV0,
-  DaoV0, IssueRewardsArgsV0, SubDaoV0,
+  accounts::CalculateUtilityScoreV0,
+  instruction::IssueRewardsV0,
+  supplement::{COUNCIL_FANOUT_TOKEN_ACCOUNT, SUPPLEMENT_VAULT_TOKEN_ACCOUNT},
+  CalculateUtilityScoreArgsV0, DaoV0, IssueRewardsArgsV0, SubDaoV0,
 };
 use spl_token::solana_program::instruction::{AccountMeta, Instruction};
 use tuktuk_program::{
@@ -13,6 +15,13 @@ use tuktuk_program::{
 };
 
 use crate::{hpl_crons::CIRCUIT_BREAKER_PROGRAM, EpochTrackerV0, EPOCH_LENGTH};
+
+/// A HIP 149 supplement destination to forward into `issue_rewards_v0`, or `None` while the
+/// constant still holds its pre-activation placeholder (the system program id, which is also
+/// `Pubkey::default()`).
+fn supplement_account(configured: Pubkey) -> Option<Pubkey> {
+  (configured != Pubkey::default()).then_some(configured)
+}
 
 #[derive(Accounts)]
 pub struct QueueEndEpoch<'info> {
@@ -62,39 +71,68 @@ fn sub_dao_epoch_info_pda(sub_dao: &Pubkey, epoch: u64) -> Pubkey {
   .0
 }
 
-pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
-  let sub_daos = [&ctx.accounts.iot_sub_dao, &ctx.accounts.mobile_sub_dao];
-  let prev_epoch = ctx.accounts.epoch_tracker.epoch;
-  let curr_epoch = prev_epoch + 1;
-  ctx.accounts.epoch_tracker.epoch = curr_epoch;
+/// One sub-DAO's contribution to the end-epoch instruction set.
+pub struct SubDaoInputs {
+  pub key: Pubkey,
+  pub dnt_mint: Pubkey,
+  pub treasury: Pubkey,
+}
 
-  let dao_key = ctx.accounts.dao.key();
-  let prev_dao_epoch_info = Pubkey::find_program_address(
-    &[
-      b"dao_epoch_info",
-      dao_key.as_ref(),
-      &prev_epoch.to_le_bytes(),
-    ],
-    &helium_sub_daos::ID,
-  )
-  .0;
+/// The plain values the end-epoch instruction set is built from, lifted out of the Anchor
+/// context so it can be built, and its allocation cost measured, without one.
+pub struct EndEpochInputs {
+  pub payer: Pubkey,
+  pub registrar: Pubkey,
+  pub dao: Pubkey,
+  pub hnt_mint: Pubkey,
+  pub rewards_escrow: Pubkey,
+  pub delegator_pool: Pubkey,
+  pub hnt_price_oracle: Pubkey,
+  pub mobile_sub_dao: Pubkey,
+  /// IoT first, then Mobile, matching the order the handler passes them.
+  pub sub_daos: [SubDaoInputs; 2],
+  pub prev_epoch: u64,
+  pub curr_epoch: u64,
+}
 
-  let dao_epoch_info = Pubkey::find_program_address(
-    &[
-      b"dao_epoch_info",
-      dao_key.as_ref(),
-      &curr_epoch.to_le_bytes(),
-    ],
-    &helium_sub_daos::ID,
-  )
-  .0;
+/// Builds the calculate/issue/no-emit instruction set the end-epoch task executes.
+///
+/// Separate from the handler because its allocation cost is what has to stay inside the 32KB
+/// heap, and measuring that needs to be cheaper than standing up a localnet.
+pub fn end_epoch_ixs(inputs: &EndEpochInputs) -> Vec<Instruction> {
+  let EndEpochInputs {
+    payer,
+    registrar,
+    dao: dao_key,
+    hnt_mint,
+    rewards_escrow,
+    delegator_pool,
+    hnt_price_oracle,
+    mobile_sub_dao,
+    sub_daos,
+    prev_epoch,
+    curr_epoch,
+  } = inputs;
+  let (prev_epoch, curr_epoch) = (*prev_epoch, *curr_epoch);
+  let (dao_key, hnt_mint) = (*dao_key, *hnt_mint);
 
-  let hnt_mint = ctx.accounts.dao.hnt_mint;
+  let dao_epoch_info_pda = |epoch: u64| {
+    Pubkey::find_program_address(
+      &[b"dao_epoch_info", dao_key.as_ref(), &epoch.to_le_bytes()],
+      &helium_sub_daos::ID,
+    )
+    .0
+  };
+  let prev_dao_epoch_info = dao_epoch_info_pda(prev_epoch);
+  let dao_epoch_info = dao_epoch_info_pda(curr_epoch);
+
   let hnt_circuit_breaker = Pubkey::find_program_address(
     &[b"mint_windowed_breaker", hnt_mint.as_ref()],
     &CIRCUIT_BREAKER_PROGRAM,
   )
   .0;
+  let not_emitted_counter =
+    Pubkey::find_program_address(&[b"not_emitted_counter", hnt_mint.as_ref()], &no_emit::ID).0;
 
   let calc_args = helium_sub_daos::instruction::CalculateUtilityScoreV0 {
     args: CalculateUtilityScoreArgsV0 { epoch: curr_epoch },
@@ -103,59 +141,40 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     args: IssueRewardsArgsV0 { epoch: curr_epoch },
   };
 
-  msg!("Queueing epoch {}", curr_epoch);
-
   let mut ixs = Vec::with_capacity(5);
-
-  // Pre-calculate PDAs for each sub-dao
-  let sub_dao_infos: Vec<_> = sub_daos
-    .iter()
-    .map(|sub_dao| {
-      let sub_dao_key = sub_dao.key();
-      let prev_sub_dao_epoch_info = sub_dao_epoch_info_pda(&sub_dao_key, prev_epoch);
-      let sub_dao_epoch_info = sub_dao_epoch_info_pda(&sub_dao_key, curr_epoch);
-
-      (
-        sub_dao,
-        sub_dao_key,
-        prev_sub_dao_epoch_info,
-        sub_dao_epoch_info,
-      )
-    })
-    .collect();
 
   // HIP 149 backstop: every calculate_utility_score_v0 (both the IoT and Mobile pass)
   // reads the Mobile sub-DAO's current- and previous-epoch info to size the deployer
   // top-up, so total_rewards is independent of sub-DAO ordering. These are passed as
   // read-only remaining accounts and located on-chain by PDA.
-  let mobile_sub_dao_key = ctx.accounts.mobile_sub_dao.key();
-  let mobile_curr_epoch_info = sub_dao_epoch_info_pda(&mobile_sub_dao_key, curr_epoch);
-  let mobile_prev_epoch_info = sub_dao_epoch_info_pda(&mobile_sub_dao_key, prev_epoch);
+  let mobile_curr_epoch_info = sub_dao_epoch_info_pda(mobile_sub_dao, curr_epoch);
+  let mobile_prev_epoch_info = sub_dao_epoch_info_pda(mobile_sub_dao, prev_epoch);
 
-  // Add all calculate instructions
-  for (_, sub_dao_key, prev_sub_dao_epoch_info, sub_dao_epoch_info) in sub_dao_infos.iter() {
-    let mut accounts = CalculateUtilityScoreV0 {
-      payer: ctx.accounts.payer.key(),
-      registrar: ctx.accounts.dao.registrar,
+  for sub_dao in sub_daos.iter() {
+    // Sized for the struct's own accounts plus the two Mobile epoch infos appended below.
+    // Pushing onto the Vec that to_account_metas returns at exact capacity reallocs and copies
+    // the whole thing, which measures 2,040 bytes per instruction against 1,530 pre-sized. On a
+    // bump-allocated heap that copy is never reclaimed.
+    let base = CalculateUtilityScoreV0 {
+      payer: *payer,
+      registrar: *registrar,
       dao: dao_key,
       hnt_mint,
-      sub_dao: *sub_dao_key,
+      sub_dao: sub_dao.key,
       prev_dao_epoch_info,
       dao_epoch_info,
-      sub_dao_epoch_info: *sub_dao_epoch_info,
+      sub_dao_epoch_info: sub_dao_epoch_info_pda(&sub_dao.key, curr_epoch),
       system_program: system_program::ID,
       token_program: spl_token::ID,
       circuit_breaker_program: CIRCUIT_BREAKER_PROGRAM,
-      prev_sub_dao_epoch_info: *prev_sub_dao_epoch_info,
-      not_emitted_counter: Pubkey::find_program_address(
-        &[b"not_emitted_counter", hnt_mint.as_ref()],
-        &no_emit::ID,
-      )
-      .0,
+      prev_sub_dao_epoch_info: sub_dao_epoch_info_pda(&sub_dao.key, prev_epoch),
+      not_emitted_counter,
       no_emit_program: no_emit::ID,
-      hnt_price_oracle: Some(ctx.accounts.hnt_price_oracle.key()),
+      hnt_price_oracle: Some(*hnt_price_oracle),
     }
     .to_account_metas(None);
+    let mut accounts = Vec::with_capacity(base.len() + 2);
+    accounts.extend(base);
     accounts.push(AccountMeta::new_readonly(mobile_curr_epoch_info, false));
     accounts.push(AccountMeta::new_readonly(mobile_prev_epoch_info, false));
     ixs.push(Instruction {
@@ -165,50 +184,51 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     });
   }
 
-  // Add all issue instructions
-  for (sub_dao, sub_dao_key, prev_sub_dao_epoch_info, sub_dao_epoch_info) in sub_dao_infos.iter() {
+  for sub_dao in sub_daos.iter() {
     ixs.push(Instruction {
       program_id: helium_sub_daos::ID,
       accounts: helium_sub_daos::accounts::IssueRewardsV0 {
         dao: dao_key,
         hnt_mint,
-        sub_dao: *sub_dao_key,
+        sub_dao: sub_dao.key,
         dao_epoch_info,
-        sub_dao_epoch_info: *sub_dao_epoch_info,
+        sub_dao_epoch_info: sub_dao_epoch_info_pda(&sub_dao.key, curr_epoch),
         system_program: system_program::ID,
         token_program: spl_token::ID,
         circuit_breaker_program: CIRCUIT_BREAKER_PROGRAM,
-        prev_sub_dao_epoch_info: *prev_sub_dao_epoch_info,
+        prev_sub_dao_epoch_info: sub_dao_epoch_info_pda(&sub_dao.key, prev_epoch),
         hnt_circuit_breaker,
         dnt_mint: sub_dao.dnt_mint,
         treasury: sub_dao.treasury,
-        rewards_escrow: ctx.accounts.dao.rewards_escrow,
-        delegator_pool: ctx.accounts.dao.delegator_pool,
-        // HIP 149 Decision 2 supplement vault + Decision 4 Council fanout. None while the
-        // supplement window is inactive (the default). At patch-time activation, set these to
-        // the Receiving Entity vault's HNT ATA and the Council fanout's HNT token account
-        // before rescheduling the cron.
-        supplement_vault: None,
-        council_vault: None,
+        rewards_escrow: *rewards_escrow,
+        delegator_pool: *delegator_pool,
+        // HIP 149 Decision 2 supplement vault + Decision 4 Council fanout, read from the
+        // helium-sub-daos constants so the two programs cannot disagree about the destinations.
+        // `issue_rewards_v0` requires them only while a supplement window is open, but a task
+        // is queued one epoch before it runs, so window state at queue time says nothing about
+        // window state at execution: both are forwarded whenever the constants are real, or the
+        // first epoch of a window would settle against a task built without them and fail
+        // closed, stopping the self-rescheduling chain.
+        //
+        // A placeholder constant is withheld instead, because Anchor deserializes a forwarded
+        // account as a `TokenAccount` regardless of window state and the placeholder is the
+        // system program id.
+        supplement_vault: supplement_account(SUPPLEMENT_VAULT_TOKEN_ACCOUNT),
+        council_vault: supplement_account(COUNCIL_FANOUT_TOKEN_ACCOUNT),
       }
       .to_account_metas(None),
       data: reward_args.data(),
     });
   }
 
-  // Add no_emit instruction
   let no_emit_wallet = Pubkey::find_program_address(&[b"not_emitted"], &no_emit::ID).0;
   ixs.push(Instruction {
     program_id: no_emit::ID,
     accounts: no_emit::accounts::NoEmitV0 {
-      system_program: ctx.accounts.system_program.key(),
-      payer: ctx.accounts.payer.key(),
+      system_program: system_program::ID,
+      payer: *payer,
       no_emit_wallet,
-      not_emitted_counter: Pubkey::find_program_address(
-        &[b"not_emitted_counter", hnt_mint.as_ref()],
-        &no_emit::ID,
-      )
-      .0,
+      not_emitted_counter,
       token_account: spl_associated_token_account::get_associated_token_address(
         &no_emit_wallet,
         &hnt_mint,
@@ -220,9 +240,50 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     data: no_emit::instruction::NoEmitV0.data(),
   });
 
+  ixs
+}
+
+pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
+  let prev_epoch = ctx.accounts.epoch_tracker.epoch;
+  let curr_epoch = prev_epoch + 1;
+  ctx.accounts.epoch_tracker.epoch = curr_epoch;
+
+  msg!("Queueing epoch {}", curr_epoch);
+
+  let ixs = end_epoch_ixs(&EndEpochInputs {
+    payer: ctx.accounts.payer.key(),
+    registrar: ctx.accounts.dao.registrar,
+    dao: ctx.accounts.dao.key(),
+    hnt_mint: ctx.accounts.dao.hnt_mint,
+    rewards_escrow: ctx.accounts.dao.rewards_escrow,
+    delegator_pool: ctx.accounts.dao.delegator_pool,
+    hnt_price_oracle: ctx.accounts.hnt_price_oracle.key(),
+    mobile_sub_dao: ctx.accounts.mobile_sub_dao.key(),
+    sub_daos: [
+      SubDaoInputs {
+        key: ctx.accounts.iot_sub_dao.key(),
+        dnt_mint: ctx.accounts.iot_sub_dao.dnt_mint,
+        treasury: ctx.accounts.iot_sub_dao.treasury,
+      },
+      SubDaoInputs {
+        key: ctx.accounts.mobile_sub_dao.key(),
+        dnt_mint: ctx.accounts.mobile_sub_dao.dnt_mint,
+        treasury: ctx.accounts.mobile_sub_dao.treasury,
+      },
+    ],
+    prev_epoch,
+    curr_epoch,
+  });
+
+  // This handler runs inside tuktuk's `run_task` under a 32KB heap, which the two compiled
+  // transactions below dominate, and it has overflowed in production once already. The SBF
+  // heap is a bump allocator whose `dealloc` is a no-op, so what has to stay bounded is the
+  // total bytes ever allocated, not the peak live: dropping a value early buys nothing, and
+  // only never allocating does. Hence rebuilding the seeds rather than cloning them, and
+  // moving the account metas rather than copying them.
   let bump = ctx.bumps.payer;
-  let seeds = vec![vec![b"helium".to_vec(), bump.to_le_bytes().to_vec()]];
-  let (compiled_tx, _) = compile_transaction(ixs, seeds.clone())?;
+  let seeds = || vec![vec![b"helium".to_vec(), bump.to_le_bytes().to_vec()]];
+  let (compiled_tx, _) = compile_transaction(ixs, seeds())?;
 
   let reschedule_ix = Instruction {
     program_id: crate::ID,
@@ -237,11 +298,10 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
       task_queue: ctx.accounts.task_queue.to_account_info(),
       epoch_tracker: ctx.accounts.epoch_tracker.to_account_info(),
     }
-    .to_account_metas(None)
-    .to_vec(),
+    .to_account_metas(None),
     data: crate::instruction::QueueEndEpoch.data(),
   };
-  let (compiled_reschedule_tx, _) = compile_transaction(vec![reschedule_ix], seeds).unwrap();
+  let (compiled_reschedule_tx, _) = compile_transaction(vec![reschedule_ix], seeds()).unwrap();
 
   let end_of_epoch_trigger = TriggerV0::Timestamp(max(
     Clock::get()?.unix_timestamp,
@@ -283,4 +343,134 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     tasks: vec![],
     accounts: return_accounts,
   })
+}
+
+/// Tallies every allocation on the calling thread, mirroring how the SBF heap behaves: its
+/// `dealloc` is a no-op, so a program is bounded by the total bytes it ever allocates rather
+/// than by its peak live set. Freeing is therefore deliberately not subtracted here.
+///
+/// The counter is thread-local because the test harness runs each test on its own thread, and a
+/// process-wide counter would pick up every other test's allocations. `Cell` with a const
+/// initialiser keeps the TLS access itself allocation-free.
+#[cfg(test)]
+mod alloc_tally {
+  use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    cell::Cell,
+  };
+
+  thread_local! {
+    static BYTES: Cell<usize> = const { Cell::new(0) };
+  }
+
+  pub struct Tallying;
+
+  unsafe impl GlobalAlloc for Tallying {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+      BYTES.with(|b| b.set(b.get().saturating_add(layout.size())));
+      System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+      System.dealloc(ptr, layout)
+    }
+  }
+
+  /// Total bytes allocated on this thread while `f` ran.
+  pub fn bytes_allocated_by<T>(f: impl FnOnce() -> T) -> usize {
+    let before = BYTES.with(|b| b.get());
+    let out = f();
+    let after = BYTES.with(|b| b.get());
+    drop(out);
+    after - before
+  }
+}
+
+#[cfg(test)]
+#[global_allocator]
+static TALLYING_ALLOCATOR: alloc_tally::Tallying = alloc_tally::Tallying;
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn test_inputs() -> EndEpochInputs {
+    EndEpochInputs {
+      payer: Pubkey::new_unique(),
+      registrar: Pubkey::new_unique(),
+      dao: Pubkey::new_unique(),
+      hnt_mint: Pubkey::new_unique(),
+      rewards_escrow: Pubkey::new_unique(),
+      delegator_pool: Pubkey::new_unique(),
+      hnt_price_oracle: Pubkey::new_unique(),
+      mobile_sub_dao: Pubkey::new_unique(),
+      sub_daos: [
+        SubDaoInputs {
+          key: Pubkey::new_unique(),
+          dnt_mint: Pubkey::new_unique(),
+          treasury: Pubkey::new_unique(),
+        },
+        SubDaoInputs {
+          key: Pubkey::new_unique(),
+          dnt_mint: Pubkey::new_unique(),
+          treasury: Pubkey::new_unique(),
+        },
+      ],
+      prev_epoch: 20_667,
+      curr_epoch: 20_668,
+    }
+  }
+
+  fn build_and_compile(inputs: &EndEpochInputs) {
+    let ixs = end_epoch_ixs(inputs);
+    let seeds = vec![vec![b"helium".to_vec(), 255u8.to_le_bytes().to_vec()]];
+    compile_transaction(ixs, seeds).expect("compile end-epoch transaction");
+  }
+
+  /// The end-epoch task has already exhausted the 32KB SBF heap in production, and the localnet
+  /// regression test only reports that after an anchor build and a running validator. This runs
+  /// in milliseconds and yields a number, so growth is visible while there is still headroom
+  /// rather than only once it has been spent.
+  ///
+  /// The heap is shared rather than ours alone: `run_task_v0` spends part of it deserializing
+  /// the task and building account metas before this handler is reached at CPI depth 2, so the
+  /// figure below is a fraction of the real budget, not all of it. It is also calibrated against
+  /// the host allocator, which is not the SBF one, so treat it as a drift detector on the delta
+  /// rather than a literal 32KB assertion. The localnet test remains the ground truth.
+  #[test]
+  fn end_epoch_instruction_set_stays_within_its_allocation_budget() {
+    // Measured at 23,444 bytes today. The budget leaves ~1KB of room: enough that an incidental
+    // change does not trip it, tight enough that anything structural does.
+    const BUDGET: usize = 24_500;
+
+    let inputs = test_inputs();
+    // The first measured region on a thread also captures one-time initialisation, which is
+    // worth ~1.5KB here and would make the figure depend on test ordering. Warm it up first.
+    build_and_compile(&inputs);
+
+    let bytes = alloc_tally::bytes_allocated_by(|| build_and_compile(&inputs));
+
+    println!("end-epoch instruction set + compile allocated {bytes} bytes");
+    assert!(
+      bytes <= BUDGET,
+      "end-epoch build allocated {bytes} bytes, over the {BUDGET} budget. The SBF heap never \
+       reuses freed memory, so this is what the 32KB limit is spent on, and the task has been \
+       within ~136 bytes of that limit. Reclaim allocations or reduce what the task carries; \
+       shaving incidental clones will not create durable headroom."
+    );
+  }
+
+  #[test]
+  fn placeholder_supplement_destination_is_not_forwarded() {
+    // Anchor deserializes a forwarded account as a TokenAccount regardless of whether a
+    // supplement window is open, so forwarding the pre-activation placeholder would fail
+    // every epoch. Pubkey::default() is the system program id the constants ship with.
+    assert_eq!(supplement_account(Pubkey::default()), None);
+  }
+
+  #[test]
+  fn configured_supplement_destination_is_forwarded() {
+    let configured = Pubkey::new_unique();
+    assert_eq!(supplement_account(configured), Some(configured));
+  }
 }

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -87,8 +87,13 @@ fn sub_dao_epoch_info_pda(sub_dao: &Pubkey, epoch: u64) -> Pubkey {
 /// writable, then read-only, with `num_rw_signers` / `num_ro_signers` / `num_rw` describing the
 /// boundaries so the crank turner can reconstruct each account's privileges. Indices are resolved
 /// against the list built here, so self-consistency is what correctness requires, not matching the
-/// order upstream would have produced. Within a priority group this is insertion order, which is
-/// deterministic; upstream's is HashMap iteration order, which is not.
+/// order upstream would have produced.
+///
+/// Getting the boundaries wrong makes a task unexecutable rather than over-privileged.
+/// `run_task_v0` takes signer privilege from `signer_seeds` under a forced
+/// `[b"custom", task_queue]` prefix and never from these counts, and writability is capped by the
+/// crank turner's outer transaction, which it builds from these same counts. The failure mode is
+/// a stuck epoch.
 fn compile_task_transaction(
   instructions: Vec<Instruction>,
   signer_seeds: Vec<Vec<Vec<u8>>>,
@@ -118,6 +123,12 @@ fn compile_task_transaction(
     }
   }
 
+  // Account indices and the three privilege counts are all u8. Past 255 accounts the indices
+  // would truncate silently and point instructions at the wrong accounts, and the counts would
+  // overflow, so refuse before either can happen. The end-epoch set uses 32; this is a bound,
+  // not a limit anything approaches.
+  require_gte!(u8::MAX as usize, keys.len(), ErrorCode::TooManyAccounts);
+
   fn rank(privileges: (bool, bool)) -> u8 {
     match privileges {
       (true, true) => 0,
@@ -143,10 +154,6 @@ fn compile_task_transaction(
   }
 
   let accounts: Vec<Pubkey> = order.iter().map(|i| keys[*i]).collect();
-  // Indices and the three counts are u8. Past 255 accounts they would truncate silently and
-  // point instructions at the wrong accounts, rather than failing, so refuse instead. The
-  // end-epoch set uses 32; this is a bound, not a limit anything approaches.
-  require_gte!(u8::MAX as usize, accounts.len(), ErrorCode::TooManyAccounts);
   let index_of = |key: &Pubkey| {
     accounts
       .iter()
@@ -174,34 +181,34 @@ fn compile_task_transaction(
 }
 
 /// One sub-DAO's contribution to the end-epoch instruction set.
-pub struct SubDaoInputs {
-  pub key: Pubkey,
-  pub dnt_mint: Pubkey,
-  pub treasury: Pubkey,
+struct SubDaoInputs {
+  key: Pubkey,
+  dnt_mint: Pubkey,
+  treasury: Pubkey,
 }
 
 /// The plain values the end-epoch instruction set is built from, lifted out of the Anchor
 /// context so it can be built, and its allocation cost measured, without one.
-pub struct EndEpochInputs {
-  pub payer: Pubkey,
-  pub registrar: Pubkey,
-  pub dao: Pubkey,
-  pub hnt_mint: Pubkey,
-  pub rewards_escrow: Pubkey,
-  pub delegator_pool: Pubkey,
-  pub hnt_price_oracle: Pubkey,
-  pub mobile_sub_dao: Pubkey,
+struct EndEpochInputs {
+  payer: Pubkey,
+  registrar: Pubkey,
+  dao: Pubkey,
+  hnt_mint: Pubkey,
+  rewards_escrow: Pubkey,
+  delegator_pool: Pubkey,
+  hnt_price_oracle: Pubkey,
+  mobile_sub_dao: Pubkey,
   /// IoT first, then Mobile, matching the order the handler passes them.
-  pub sub_daos: [SubDaoInputs; 2],
-  pub prev_epoch: u64,
-  pub curr_epoch: u64,
+  sub_daos: [SubDaoInputs; 2],
+  prev_epoch: u64,
+  curr_epoch: u64,
 }
 
 /// Builds the calculate/issue/no-emit instruction set the end-epoch task executes.
 ///
 /// Separate from the handler because its allocation cost is what has to stay inside the 32KB
 /// heap, and measuring that needs to be cheaper than standing up a localnet.
-pub fn end_epoch_ixs(inputs: &EndEpochInputs) -> Vec<Instruction> {
+fn end_epoch_ixs(inputs: &EndEpochInputs) -> Vec<Instruction> {
   let EndEpochInputs {
     payer,
     registrar,
@@ -308,9 +315,10 @@ pub fn end_epoch_ixs(inputs: &EndEpochInputs) -> Vec<Instruction> {
         // helium-sub-daos constants so the two programs cannot disagree about the destinations.
         // `issue_rewards_v0` requires them only while a supplement window is open, but a task
         // is queued one epoch before it runs, so window state at queue time says nothing about
-        // window state at execution: both are forwarded whenever the constants are real, or the
-        // first epoch of a window would settle against a task built without them and fail
-        // closed, stopping the self-rescheduling chain.
+        // window state at execution: both are forwarded whenever the constants are real. Were
+        // they withheld until a window was observed open, the first epoch of that window would
+        // settle against a task built without them and fail closed, leaving that epoch to be
+        // settled by hand through the `end-epoch` CLI.
         //
         // A placeholder constant is withheld instead, because Anchor deserializes a forwarded
         // account as a `TokenAccount` regardless of window state and the placeholder is the
@@ -606,8 +614,13 @@ mod tests {
   /// handler actually compiles: the five-instruction end-epoch set and the single-instruction
   /// reschedule. Ordering within a priority group differs by construction, so this asserts the
   /// properties `run_task_v0` and the crank turner rely on: the same accounts, the same privilege
-  /// boundaries, and every index resolving to the same account. Those decide which accounts a
-  /// task may write, so they are what is worth guarding rather than byte equality.
+  /// boundaries, and every index resolving to the same account.
+  ///
+  /// The third shape carries no handler traffic. It covers the signer half of the
+  /// cross-instruction privilege accumulation, which neither real shape reaches: in both, every
+  /// account either holds the same privileges everywhere it appears or gains only writability.
+  /// An account has to appear read-only *before* it appears as a signer for that accumulation to
+  /// be load-bearing, which is the order `escalating` is passed in.
   #[test]
   fn presized_compile_matches_upstream() {
     let inputs = test_inputs();
@@ -633,9 +646,58 @@ mod tests {
       }]
     };
 
+    // An account whose privileges rise between instructions: read-only non-signer on first
+    // sight, writable signer on second. The compiled result must call it a writable signer.
+    let escalating = fixed_key(200);
+    let privilege_escalation = vec![
+      Instruction {
+        program_id: crate::ID,
+        accounts: vec![
+          AccountMeta::new_readonly(escalating, false),
+          AccountMeta::new(fixed_key(201), false),
+        ],
+        data: vec![1u8; 8],
+      },
+      Instruction {
+        program_id: crate::ID,
+        accounts: vec![
+          AccountMeta::new(escalating, true),
+          AccountMeta::new_readonly(fixed_key(202), true),
+        ],
+        data: vec![2u8; 8],
+      },
+    ];
+
     let end_epoch = end_epoch_ixs(&inputs);
 
-    for (label, ixs) in [("end-epoch", &end_epoch), ("reschedule", &reschedule)] {
+    {
+      let ours =
+        compile_task_transaction(privilege_escalation.clone(), seeds()).expect("presized compile");
+      let index = ours
+        .accounts
+        .iter()
+        .position(|k| *k == escalating)
+        .expect("escalating account is in the compiled set");
+      assert_eq!(
+        index, 0,
+        "an account that is a writable signer in any instruction belongs in the writable-signer \
+         group, which sorts first"
+      );
+      assert_eq!(
+        ours.num_rw_signers, 1,
+        "the escalating account is the only writable signer"
+      );
+      assert_eq!(
+        ours.num_ro_signers, 1,
+        "fixed_key(202) is a read-only signer"
+      );
+    }
+
+    for (label, ixs) in [
+      ("end-epoch", &end_epoch),
+      ("reschedule", &reschedule),
+      ("privilege-escalation", &privilege_escalation),
+    ] {
       let (upstream, _) =
         tuktuk_program::compile_transaction(ixs.clone(), seeds()).expect("upstream compile");
       let ours = compile_task_transaction(ixs.clone(), seeds()).expect("presized compile");
@@ -719,5 +781,50 @@ mod tests {
   fn configured_supplement_destination_is_forwarded() {
     let configured = Pubkey::new_unique();
     assert_eq!(supplement_account(configured), Some(configured));
+  }
+
+  /// Both sides of the u8 bound. Above it an account index would truncate and point an
+  /// instruction at the wrong account, so the compile has to refuse; at it the compile has to
+  /// still work, or the refusal is a lower ceiling than it claims to be.
+  #[test]
+  fn compile_refuses_more_accounts_than_a_u8_index_can_address() {
+    // 16 bits of entropy, because these fixtures need more than the 256 keys `fixed_key` spans.
+    fn wide_key(n: u16) -> Pubkey {
+      let mut bytes = [0u8; 32];
+      bytes[0..2].copy_from_slice(&n.to_le_bytes());
+      Pubkey::new_from_array(bytes)
+    }
+
+    // One instruction contributes its own program id, so n accounts means n + 1 distinct keys.
+    let ix_with = |n: u16| {
+      vec![Instruction {
+        program_id: crate::ID,
+        accounts: (0..n)
+          .map(|i| AccountMeta::new_readonly(wide_key(i + 1), false))
+          .collect(),
+        data: vec![0u8; 8],
+      }]
+    };
+    let seeds = || vec![vec![b"helium".to_vec(), vec![255u8]]];
+
+    let at_limit = compile_task_transaction(ix_with(254), seeds())
+      .expect("255 accounts is addressable and must compile");
+    assert_eq!(at_limit.accounts.len(), 255);
+    // Every index still resolves to the account it was built from, which is the property the
+    // bound exists to protect.
+    let resolved: Vec<Pubkey> = at_limit.instructions[0]
+      .accounts
+      .iter()
+      .map(|i| at_limit.accounts[*i as usize])
+      .collect();
+    assert_eq!(
+      resolved,
+      (0..254).map(|i| wide_key(i + 1)).collect::<Vec<_>>()
+    );
+
+    assert!(
+      compile_task_transaction(ix_with(255), seeds()).is_err(),
+      "256 accounts must be refused, not silently truncated into a u8 index"
+    );
   }
 }

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -14,7 +14,7 @@ use tuktuk_program::{
   RunTaskReturnV0, TaskReturnV0, TransactionSourceV0, TriggerV0,
 };
 
-use crate::{hpl_crons::CIRCUIT_BREAKER_PROGRAM, EpochTrackerV0, EPOCH_LENGTH};
+use crate::{error::ErrorCode, hpl_crons::CIRCUIT_BREAKER_PROGRAM, EpochTrackerV0, EPOCH_LENGTH};
 
 /// A HIP 149 supplement destination to forward into `issue_rewards_v0`, or `None` while the
 /// constant still holds its pre-activation placeholder (the system program id, which is also
@@ -92,7 +92,7 @@ fn sub_dao_epoch_info_pda(sub_dao: &Pubkey, epoch: u64) -> Pubkey {
 fn compile_task_transaction(
   instructions: Vec<Instruction>,
   signer_seeds: Vec<Vec<Vec<u8>>>,
-) -> CompiledTransactionV0 {
+) -> Result<CompiledTransactionV0> {
   // Upper bound: every account of every instruction, plus each instruction's program id.
   let slots: usize = instructions.iter().map(|ix| ix.accounts.len() + 1).sum();
   let mut keys: Vec<Pubkey> = Vec::with_capacity(slots);
@@ -143,6 +143,10 @@ fn compile_task_transaction(
   }
 
   let accounts: Vec<Pubkey> = order.iter().map(|i| keys[*i]).collect();
+  // Indices and the three counts are u8. Past 255 accounts they would truncate silently and
+  // point instructions at the wrong accounts, rather than failing, so refuse instead. The
+  // end-epoch set uses 32; this is a bound, not a limit anything approaches.
+  require_gte!(u8::MAX as usize, accounts.len(), ErrorCode::TooManyAccounts);
   let index_of = |key: &Pubkey| {
     accounts
       .iter()
@@ -159,14 +163,14 @@ fn compile_task_transaction(
     })
     .collect();
 
-  CompiledTransactionV0 {
+  Ok(CompiledTransactionV0 {
     num_ro_signers,
     num_rw_signers,
     num_rw,
     instructions: compiled,
     signer_seeds,
     accounts,
-  }
+  })
 }
 
 /// One sub-DAO's contribution to the end-epoch instruction set.
@@ -381,7 +385,7 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
   // moving the account metas rather than copying them.
   let bump = ctx.bumps.payer;
   let seeds = || vec![vec![b"helium".to_vec(), bump.to_le_bytes().to_vec()]];
-  let compiled_tx = compile_task_transaction(ixs, seeds());
+  let compiled_tx = compile_task_transaction(ixs, seeds())?;
 
   let reschedule_ix = Instruction {
     program_id: crate::ID,
@@ -399,7 +403,7 @@ pub fn handler(ctx: Context<QueueEndEpoch>) -> Result<RunTaskReturnV0> {
     .to_account_metas(None),
     data: crate::instruction::QueueEndEpoch.data(),
   };
-  let compiled_reschedule_tx = compile_task_transaction(vec![reschedule_ix], seeds());
+  let compiled_reschedule_tx = compile_task_transaction(vec![reschedule_ix], seeds())?;
 
   let end_of_epoch_trigger = TriggerV0::Timestamp(max(
     Clock::get()?.unix_timestamp,
@@ -492,26 +496,33 @@ static TALLYING_ALLOCATOR: alloc_tally::Tallying = alloc_tally::Tallying;
 mod tests {
   use super::*;
 
+  /// Fixed keys, not `Pubkey::new_unique()`. That helper is a process-global counter, so a
+  /// fixture built from it depends on what ran before, which made the allocation figure move by
+  /// ~1.7KB with test ordering. A measurement fixture has to be a constant.
+  fn fixed_key(seed: u8) -> Pubkey {
+    Pubkey::new_from_array([seed; 32])
+  }
+
   fn test_inputs() -> EndEpochInputs {
     EndEpochInputs {
-      payer: Pubkey::new_unique(),
-      registrar: Pubkey::new_unique(),
-      dao: Pubkey::new_unique(),
-      hnt_mint: Pubkey::new_unique(),
-      rewards_escrow: Pubkey::new_unique(),
-      delegator_pool: Pubkey::new_unique(),
-      hnt_price_oracle: Pubkey::new_unique(),
-      mobile_sub_dao: Pubkey::new_unique(),
+      payer: fixed_key(1),
+      registrar: fixed_key(2),
+      dao: fixed_key(3),
+      hnt_mint: fixed_key(4),
+      rewards_escrow: fixed_key(5),
+      delegator_pool: fixed_key(6),
+      hnt_price_oracle: fixed_key(7),
+      mobile_sub_dao: fixed_key(8),
       sub_daos: [
         SubDaoInputs {
-          key: Pubkey::new_unique(),
-          dnt_mint: Pubkey::new_unique(),
-          treasury: Pubkey::new_unique(),
+          key: fixed_key(9),
+          dnt_mint: fixed_key(10),
+          treasury: fixed_key(11),
         },
         SubDaoInputs {
-          key: Pubkey::new_unique(),
-          dnt_mint: Pubkey::new_unique(),
-          treasury: Pubkey::new_unique(),
+          key: fixed_key(8),
+          dnt_mint: fixed_key(12),
+          treasury: fixed_key(13),
         },
       ],
       prev_epoch: 20_667,
@@ -522,7 +533,7 @@ mod tests {
   fn build_and_compile(inputs: &EndEpochInputs) {
     let ixs = end_epoch_ixs(inputs);
     let seeds = vec![vec![b"helium".to_vec(), 255u8.to_le_bytes().to_vec()]];
-    compile_task_transaction(ixs, seeds);
+    compile_task_transaction(ixs, seeds).expect("compile end-epoch transaction");
   }
 
   /// The end-epoch task has already exhausted the 32KB SBF heap in production, and the localnet
@@ -537,7 +548,7 @@ mod tests {
   /// rather than a literal 32KB assertion. The localnet test remains the ground truth.
   #[test]
   fn end_epoch_instruction_set_stays_within_its_allocation_budget() {
-    // Measured at 15,000 bytes carrying both supplement destinations, against 24,464 for the
+    // Measured at 14,968 bytes carrying both supplement destinations, against 24,464 for the
     // same work before the pre-sized compile and metas Vec. The two destinations cost 136 of
     // that, so the margin is now measured in kilobytes rather than bytes. The budget leaves
     // ~1KB: enough that an incidental change does not trip it, tight enough that anything
@@ -591,77 +602,108 @@ mod tests {
     }
   }
 
-  /// Pins the pre-sized compile against the upstream one it replaces. Ordering within a
-  /// priority group differs by construction, so this asserts the properties the crank turner
-  /// and `run_task_v0` actually rely on: the same accounts, the same privilege boundaries, and
-  /// every instruction index resolving to the same account. Anything that changes those changes
-  /// which accounts a task can write, so this is the guard that matters.
+  /// Pins the pre-sized compile against the upstream one it replaces, for every shape this
+  /// handler actually compiles: the five-instruction end-epoch set and the single-instruction
+  /// reschedule. Ordering within a priority group differs by construction, so this asserts the
+  /// properties `run_task_v0` and the crank turner rely on: the same accounts, the same privilege
+  /// boundaries, and every index resolving to the same account. Those decide which accounts a
+  /// task may write, so they are what is worth guarding rather than byte equality.
   #[test]
   fn presized_compile_matches_upstream() {
     let inputs = test_inputs();
     let seeds = || vec![vec![b"helium".to_vec(), vec![255u8]]];
 
-    let (upstream, _) = tuktuk_program::compile_transaction(end_epoch_ixs(&inputs), seeds())
-      .expect("upstream compile");
-    let ours = compile_task_transaction(end_epoch_ixs(&inputs), seeds());
+    // Built once: regenerating these per call would hand the two compilers different keys.
+    let reschedule = {
+      vec![Instruction {
+        program_id: crate::ID,
+        accounts: (0..9)
+          .map(|i| {
+            let key = fixed_key(100 + i as u8);
+            if i == 0 {
+              AccountMeta::new(key, true)
+            } else if i % 2 == 0 {
+              AccountMeta::new(key, false)
+            } else {
+              AccountMeta::new_readonly(key, false)
+            }
+          })
+          .collect(),
+        data: vec![0u8; 8],
+      }]
+    };
 
-    let mut a = upstream.accounts.clone();
-    let mut b = ours.accounts.clone();
-    a.sort();
-    b.sort();
-    assert_eq!(a, b, "same account set");
-    assert_eq!(
-      (
-        upstream.num_rw_signers,
-        upstream.num_ro_signers,
-        upstream.num_rw
-      ),
-      (ours.num_rw_signers, ours.num_ro_signers, ours.num_rw),
-      "same privilege boundaries"
-    );
-    assert_eq!(upstream.instructions.len(), ours.instructions.len());
-    assert_eq!(upstream.signer_seeds, ours.signer_seeds);
+    let end_epoch = end_epoch_ixs(&inputs);
 
-    for (u, o) in upstream.instructions.iter().zip(ours.instructions.iter()) {
-      assert_eq!(u.data, o.data, "instruction data preserved");
+    for (label, ixs) in [("end-epoch", &end_epoch), ("reschedule", &reschedule)] {
+      let (upstream, _) =
+        tuktuk_program::compile_transaction(ixs.clone(), seeds()).expect("upstream compile");
+      let ours = compile_task_transaction(ixs.clone(), seeds()).expect("presized compile");
+
+      let mut a = upstream.accounts.clone();
+      let mut b = ours.accounts.clone();
+      a.sort();
+      b.sort();
+      assert_eq!(a, b, "{label}: same account set");
       assert_eq!(
-        upstream.accounts[u.program_id_index as usize], ours.accounts[o.program_id_index as usize],
-        "program id resolves the same"
+        (
+          upstream.num_rw_signers,
+          upstream.num_ro_signers,
+          upstream.num_rw
+        ),
+        (ours.num_rw_signers, ours.num_ro_signers, ours.num_rw),
+        "{label}: same privilege boundaries"
       );
-      let resolved_u: Vec<Pubkey> = u
-        .accounts
-        .iter()
-        .map(|i| upstream.accounts[*i as usize])
-        .collect();
-      let resolved_o: Vec<Pubkey> = o
-        .accounts
-        .iter()
-        .map(|i| ours.accounts[*i as usize])
-        .collect();
-      assert_eq!(
-        resolved_u, resolved_o,
-        "indices resolve to the same accounts"
-      );
-    }
+      assert_eq!(upstream.instructions.len(), ours.instructions.len());
+      assert_eq!(upstream.signer_seeds, ours.signer_seeds);
 
-    // The boundaries must describe the ordering, or the crank turner grants the wrong
-    // privileges: every account before num_rw_signers is a writable signer, and so on.
-    let rw_signers = ours.num_rw_signers as usize;
-    let signers = rw_signers + ours.num_ro_signers as usize;
-    let writable = signers + ours.num_rw as usize;
-    assert!(writable <= ours.accounts.len());
-    for (i, key) in ours.accounts.iter().enumerate() {
-      let expected_signer = i < signers;
-      let expected_writable = i < rw_signers || (i >= signers && i < writable);
-      let (signer, wr) = end_epoch_ixs(&inputs)
-        .iter()
-        .flat_map(|ix| ix.accounts.iter())
-        .filter(|a| a.pubkey == *key)
-        .fold((false, false), |acc, a| {
-          (acc.0 || a.is_signer, acc.1 || a.is_writable)
-        });
-      assert_eq!(signer, expected_signer, "signer boundary for account {i}");
-      assert_eq!(wr, expected_writable, "writable boundary for account {i}");
+      for (u, o) in upstream.instructions.iter().zip(ours.instructions.iter()) {
+        assert_eq!(u.data, o.data, "{label}: instruction data preserved");
+        assert_eq!(
+          upstream.accounts[u.program_id_index as usize],
+          ours.accounts[o.program_id_index as usize],
+          "{label}: program id resolves the same"
+        );
+        let resolved_u: Vec<Pubkey> = u
+          .accounts
+          .iter()
+          .map(|i| upstream.accounts[*i as usize])
+          .collect();
+        let resolved_o: Vec<Pubkey> = o
+          .accounts
+          .iter()
+          .map(|i| ours.accounts[*i as usize])
+          .collect();
+        assert_eq!(
+          resolved_u, resolved_o,
+          "{label}: indices resolve to the same accounts"
+        );
+      }
+
+      // The boundaries must describe the ordering, or the crank turner grants the wrong
+      // privileges: everything before num_rw_signers is a writable signer, and so on.
+      let rw_signers = ours.num_rw_signers as usize;
+      let signers = rw_signers + ours.num_ro_signers as usize;
+      let writable = signers + ours.num_rw as usize;
+      assert!(
+        writable <= ours.accounts.len(),
+        "{label}: boundaries in range"
+      );
+      for (i, key) in ours.accounts.iter().enumerate() {
+        let (signer, wr) = ixs
+          .iter()
+          .flat_map(|ix| ix.accounts.iter())
+          .filter(|a| a.pubkey == *key)
+          .fold((false, false), |acc, a| {
+            (acc.0 || a.is_signer, acc.1 || a.is_writable)
+          });
+        assert_eq!(signer, i < signers, "{label}: signer boundary at {i}");
+        assert_eq!(
+          wr,
+          i < rw_signers || (i >= signers && i < writable),
+          "{label}: writable boundary at {i}"
+        );
+      }
     }
   }
 

--- a/programs/hpl-crons/src/instructions/queue_end_epoch.rs
+++ b/programs/hpl-crons/src/instructions/queue_end_epoch.rs
@@ -439,8 +439,10 @@ mod tests {
   /// rather than a literal 32KB assertion. The localnet test remains the ground truth.
   #[test]
   fn end_epoch_instruction_set_stays_within_its_allocation_budget() {
-    // Measured at 23,444 bytes today. The budget leaves ~1KB of room: enough that an incidental
-    // change does not trip it, tight enough that anything structural does.
+    // Measured at 24,104 bytes carrying both supplement destinations, against 24,464 on the
+    // pre-HIP-149 baseline: pre-sizing the metas Vec more than pays for the 136 bytes the two
+    // destinations add. The budget leaves a few hundred bytes: enough that an incidental change
+    // does not trip it, tight enough that anything structural does.
     const BUDGET: usize = 24_500;
 
     let inputs = test_inputs();
@@ -458,6 +460,36 @@ mod tests {
        within ~136 bytes of that limit. Reclaim allocations or reduce what the task carries; \
        shaving incidental clones will not create durable headroom."
     );
+  }
+
+  /// Pins what the task actually carries, so a lost account shows up here rather than as a
+  /// failed epoch. Five instructions: a calculate and an issue per sub-DAO, plus no-emit.
+  #[test]
+  fn end_epoch_forwards_both_supplement_destinations() {
+    let ixs = end_epoch_ixs(&test_inputs());
+    assert_eq!(ixs.len(), 5);
+
+    let issue_ixs: Vec<_> = ixs
+      .iter()
+      .filter(|ix| {
+        ix.data
+          == IssueRewardsV0 {
+            args: IssueRewardsArgsV0 { epoch: 20_668 },
+          }
+          .data()
+      })
+      .collect();
+    assert_eq!(issue_ixs.len(), 2);
+
+    for ix in issue_ixs {
+      for destination in [SUPPLEMENT_VAULT_TOKEN_ACCOUNT, COUNCIL_FANOUT_TOKEN_ACCOUNT] {
+        assert!(
+          ix.accounts.iter().any(|a| a.pubkey == destination),
+          "issue_rewards_v0 must carry {destination}, or the first epoch of a supplement \
+           window settles without it and the cron chain stops"
+        );
+      }
+    }
   }
 
   #[test]

--- a/tests/hpl-crons.ts
+++ b/tests/hpl-crons.ts
@@ -195,10 +195,19 @@ describe("hpl-crons", () => {
     // only safe while the compute side stays clear of its own ceiling, so measure it here
     // rather than reasoning about it: the crank turner sets the limit, and a regression that
     // pushes past it fails the epoch exactly as an overflow would.
-    const executed = await provider.connection.getTransaction(sig, {
-      commitment: "confirmed",
-      maxSupportedTransactionVersion: 0,
-    });
+    // A confirmed signature is not immediately queryable on a busy RPC, so getTransaction can
+    // return null for a transaction that landed. Retry, or this measures RPC timing rather than
+    // compute and fails as a flake instead of as a regression.
+    let executed: Awaited<
+      ReturnType<typeof provider.connection.getTransaction>
+    > = null;
+    for (let i = 0; i < 10 && !executed; i++) {
+      executed = await provider.connection.getTransaction(sig, {
+        commitment: "confirmed",
+        maxSupportedTransactionVersion: 0,
+      });
+      if (!executed) await new Promise((r) => setTimeout(r, 500));
+    }
     const consumed = executed?.meta?.computeUnitsConsumed;
     console.log(`    queue_end_epoch consumed ${consumed} compute units`);
     expect(consumed, "compute units should be reported").to.be.a("number");

--- a/tests/hpl-crons.ts
+++ b/tests/hpl-crons.ts
@@ -180,7 +180,7 @@ describe("hpl-crons", () => {
     // This is the step that OOMed on mainnet: RunTaskV0 CPIs into
     // queue_end_epoch, which compiles the 5-instruction end-epoch transaction
     // plus its own reschedule and writes both into the task return account.
-    await sendInstructions(provider, [
+    const sig = await sendInstructions(provider, [
       ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
       ...(await runTask({
         program: tuktukProgram,
@@ -188,6 +188,25 @@ describe("hpl-crons", () => {
         crankTurner: me,
       })),
     ]);
+
+    // queue_end_epoch trades allocation for computation: it dedupes and indexes accounts by
+    // linear scan rather than by hashing, because the 32KB heap is the scarcer budget and a
+    // bump allocator never reclaims what a HashMap's growth chain leaves behind. That trade is
+    // only safe while the compute side stays clear of its own ceiling, so measure it here
+    // rather than reasoning about it: the crank turner sets the limit, and a regression that
+    // pushes past it fails the epoch exactly as an overflow would.
+    const executed = await provider.connection.getTransaction(sig, {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 0,
+    });
+    const consumed = executed?.meta?.computeUnitsConsumed;
+    console.log(`    queue_end_epoch consumed ${consumed} compute units`);
+    expect(consumed, "compute units should be reported").to.be.a("number");
+    expect(
+      consumed!,
+      "queue_end_epoch compute has regressed; the linear scans that keep the heap down are the " +
+        "likely cause, and the crank turner's limit is what this has to stay under"
+    ).to.be.lessThan(900000);
 
     const epochAfter = (
       await program.account.epochTrackerV0.fetch(epochTracker)


### PR DESCRIPTION
Activates the HIP 149 operations-and-growth supplement, and fixes the 32KB heap problem that
activating it exposed.

## Activation

`INFLATION_START = 1785931200` (2026-08-05T12:00:00Z), so the first supplement mint lands at the
2026-08-06T00:00:00Z epoch crank. The value sits between two crank boundaries rather than on one, so
neither clock drift nor a late crank changes which epoch mints first, and the windows come to exactly
360 and 720 cranks. Under `TESTING` it stays at the dormant sentinel, because an open window makes
both destination accounts mandatory and every localnet test closes epochs without them.

| | Address |
|---|---|
| Receiving Entity vault (Squads v4 `2g7qF5d3…`, index 0) | `Cuy6WiVdHE6Wznqos86AUwLpA4zPfPABYq3qszMa6E6A` |
| `SUPPLEMENT_VAULT_TOKEN_ACCOUNT` | `AGPDcgpXan5RB2Y9usHvdJmmJHpyyYqcQm8KouRkK6f4` |
| Council fanout (5 seated members, equal shares) | `2pCpQYrUmQor9igsF4cY7tkmd3jBQzHFEB75gtpjdWA2` |
| `COUNCIL_FANOUT_TOKEN_ACCOUNT` | `EYbAXgLq1aRr9a9y55DbjfMdXNrZuMa69WXN9c1UR6eK` |

Both exist on chain. Each is derived in a test rather than restated: the vault one from the vault and
the HNT mint, the Council one through the whole chain that produced it — mini_fanout program id,
creating wallet as namespace, seed, fanout PDA, then its associated token account. Repointing either
means changing one of those inputs deliberately, and mutating the address or the namespace fails the
suite.

The deployed rate and window are pinned the same way, against the amounts and dates HIP 149
publishes rather than against the constants themselves: 98,000 HNT per sub-DAO per epoch, the
196,000 HNT/day total, the taper opening at the flat rate, 360 flat cranks then 720 tapering, and
which crank is the first to mint. The two window ends are `INFLATION_START + N * EPOCH_LENGTH`, so
what is pinned is `N` and the rate each crank sees; restating the derived timestamps would only
duplicate arithmetic the compiler already does.

`hpl-crons` forwards both destinations into the queued `issue_rewards_v0`. A task is queued an epoch
before it runs, so window state at queue time says nothing about window state at execution: were the
accounts withheld until a window was observed open, the first epoch of that window would settle
against a task built without them and fail closed, leaving that epoch to be settled by hand through
the `end-epoch` CLI. (The reschedule is a separate task on the same trigger, so the self-rescheduling
chain survives a failed settlement; what does not survive is `queue_end_epoch` itself failing, which
is what the heap work below is about.) A placeholder constant is withheld instead, since Anchor
deserializes a forwarded account as a `TokenAccount` regardless of window state.

## The heap, and why this nearly shipped broken

`queue_end_epoch` runs at CPI depth 2 under `run_task_v0`, sharing one 32KB heap with it, and it has
exhausted that heap in production once already (#1215). Forwarding the two destinations costs **136
bytes**. That was enough to overflow it, because the task was already within roughly that much of the
limit. The localnet regression test caught it before deploy; deployed, it would have failed the
end-epoch cron every epoch, which halts all rewards.

The only signal for how close the task sat was that localnet test, which needs an anchor build and a
running validator to return a boolean. So a unit test now measures it. The instruction set builds
from plain values instead of the Anchor context, and a thread-local tally wraps `System`, counting
allocations and ignoring frees — `BumpAllocator::dealloc` is literally `// I'm a bump allocator, I
don't free`, so a program is bounded by bytes ever allocated, not peak live. It warms up first,
because the first measured region on a thread also captures ~1.5KB of one-time initialisation.

Having a number made the fixes findable, and there are two.

The larger one is the compile itself. `tuktuk_program::compile_transaction` builds two HashMaps that
grow from empty by doubling, plus a `remaining_accounts` Vec this caller discards; on a bump
allocator every intermediate table stays resident for the life of the instruction. Compiling the
same instructions with buffers sized from the known slot count, and a linear scan in place of the
hashing, saves **~8,600 bytes**. At this scale, ~73 slots over ~31 distinct accounts, the scan is
cheaper than the allocations it avoids, and `tests/hpl-crons.ts` now asserts the compute side stays
clear of the crank turner's limit so that trade cannot silently invert.

The smaller one: each calculate instruction appends two Mobile epoch infos to the Vec
`to_account_metas` returns at exact capacity, so every push reallocs and copies the whole thing.
Pre-sizing both returns **1,020 bytes**, 7.5x what the destinations cost.

| | Bytes |
|---|---|
| develop today | 24,464 |
| + pre-sizing the account-metas Vec | 23,444 |
| + carrying both destinations | 24,104 |
| **this branch, also replacing `compile_transaction`** | **14,968** |

The handler allocates ~9.5KB less while carrying the destinations than develop does without them.
The 14,968 figure is what the unit test asserts, against a 16,000 budget. The localnet heap test
passes.

Two caveats on that figure: it is a fraction of the real budget, since `run_task_v0` spends part of
the shared heap before this handler runs, and it is measured with the host allocator rather than the
SBF one, so it detects drift rather than asserting 32KB. The localnet test stays the ground truth.

Things that did **not** help, measured rather than assumed: splitting the task in one invocation
costs +1,219 bytes because each compiled transaction carries its own copy of the shared account set;
moving `no_emit` out costs +4,031; dropping a value early reclaims nothing on a bump allocator; and
rebuilding the signer seeds instead of cloning them is a wash at 158 bytes either way. Address lookup
tables do not apply — `CompiledTransactionV0.accounts` stores full pubkeys, and tuktuk's
`lookup_tables` serve the crank turner's outer transaction against the 1232-byte size cap, a
different limit.

Indices and the privilege counts in a compiled transaction are `u8`. Past 255 accounts they would
truncate silently and point instructions at the wrong accounts rather than failing, so the compile
refuses that case, ahead of the counting loop so the counters cannot overflow first. The end-epoch
set uses 32.

Getting the privilege boundaries wrong makes a task unexecutable rather than over-privileged:
`run_task_v0` derives signer privilege from `signer_seeds` under a forced `[b"custom", task_queue]`
prefix and never from these counts, and writability is capped by the crank turner's outer
transaction, which it builds from these same counts. The failure mode is a stuck epoch, which is
what `presized_compile_matches_upstream` guards, across three shapes: the two the handler compiles,
plus one that passes an account read-only before passing it as a writable signer, since neither real
shape exercises the signer half of the cross-instruction privilege accumulation.

## CLI

`create-council-fanout` could not create a fanout at all: `schedule_task_v0` declares `has_one` on
the fanout for `task_queue`, `next_task` and `next_pre_task`, and Anchor's resolver satisfies those by
fetching an account the previous instruction creates in the same transaction, so resolution exhausted
its depth before anything was sent. Those accounts are known ahead of time and are now passed. It also
passes the payer as the rent refund, since `initialize_mini_fanout_v0` stores the payer and ignores
the account given under that name.

`end-epoch` takes both destinations as flags, so the permissionless fallback can still close an epoch
inside a supplement window. Each is pinned on chain to its constant, so a wrong value fails the
instruction rather than misrouting a mint.

## Scope of the pinned addresses

`COUNCIL_FANOUT_TOKEN_ACCOUNT` fixes where the carve-out is minted, not where it ends up. The
fanout's `owner` is the governance multisig vault and never the Receiving Entity, so the seated-member
set changes only through a multisig action; but a seated member can point their own share at a
delegate under their own signature, and the owner can close the fanout, sweeping its balance and
freeing the PDA for re-initialisation by the namespace keypair. Monitoring belongs on the fanout's
shares, not only on the address.

## Deploy

Both programs ship together: a `helium-sub-daos` with a real start alongside an `hpl-crons` that
forwards nothing halts every epoch of the window. Already-queued tasks were compiled without the two
accounts, so the cron needs the same re-bootstrap the backstop rollout used. Before the boundary,
decode the queued `end epoch` task and confirm the `issue_rewards_v0` instruction carries both
accounts.

Preconditions to confirm at deploy, both outside this diff: the HNT mint circuit breaker
(`3QqEkX1juz4bW8mCQBMJLWjEpHqYawvbEUvpc6iwYom3`) is Absolute at 350,000 HNT/day, which clears the
196,000 supplement plus current draw; and HIP 149 sets mint start at Council seating + 2 weeks, with
any delay extending it equally, so `INFLATION_START` encodes a seating date on or before
2026-07-22.
