### PR TITLE
Fund queue-returned tasks at the task queue's minimum crank reward

### DIFF
--- a/.changeset/quiet-donkeys-repeat.md
+++ b/.changeset/quiet-donkeys-repeat.md
@@ -1,0 +1,7 @@
+---
+"@helium/idls": patch
+---
+
+Queue-returned tasks carry the task queue's minimum crank reward. `hpl-crons`
+gains a `TooManyFreeTasks` error, and `tuktuk-dca` drops `crank_reward` from
+`InitializeDcaArgsV0` and from the `DcaV0` account.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "dc-auto-top"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "hpl-crons"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "tuktuk-dca"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/packages/helium-admin-cli/src/initialize-tuktuk-dca.ts
+++ b/packages/helium-admin-cli/src/initialize-tuktuk-dca.ts
@@ -76,11 +76,6 @@ export async function run(args: any = process.argv) {
       describe: "URL of the DCA service",
       required: true,
     },
-    crankReward: {
-      type: "number",
-      describe: "Crank reward in lamports",
-      default: 20000,
-    },
     multisig: {
       type: 'string',
       describe:
@@ -162,7 +157,6 @@ export async function run(args: any = process.argv) {
       taskId: nextTask,
       dcaSigner,
       dcaUrl: argv.dcaUrl,
-      crankReward: new anchor.BN(argv.crankReward),
     })
     .accountsPartial({
       core: {

--- a/programs/dc-auto-top/Cargo.toml
+++ b/programs/dc-auto-top/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dc-auto-top"
-version = "0.0.8"
+version = "0.0.9"
 # Trigger deployment - timestamp: 03-31-2025 #3
 description = "Created with Anchor"
 edition = "2021"

--- a/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
+++ b/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
@@ -331,7 +331,6 @@ pub fn handler<'info>(
           // This isn't actually used, since we're running in tuktuk it doesn't need to queue.
           dca_signer,
           dca_url,
-          crank_reward: 20000,
         },
       )?;
 

--- a/programs/hpl-crons/Cargo.toml
+++ b/programs/hpl-crons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hpl-crons"
-version = "0.1.6"
+version = "0.1.7"
 # Trigger deployment - timestamp: 03-31-2025 #3
 description = "Created with Anchor"
 edition = "2021"

--- a/programs/hpl-crons/src/error.rs
+++ b/programs/hpl-crons/src/error.rs
@@ -14,4 +14,6 @@ pub enum ErrorCode {
   InvalidTaskForPyth,
   #[msg("Too many accounts to index a compiled transaction")]
   TooManyAccounts,
+  #[msg("Free tasks exceeds the maximum for this instruction")]
+  TooManyFreeTasks,
 }

--- a/programs/hpl-crons/src/instructions/requeue_entity_claim_v0.rs
+++ b/programs/hpl-crons/src/instructions/requeue_entity_claim_v0.rs
@@ -21,7 +21,7 @@ pub fn handler(ctx: Context<RequeueEntityClaimV0>) -> Result<RunTaskReturnV0> {
         ),
         signer: ORACLE_SIGNER,
       },
-      crank_reward: Some(20000),
+      crank_reward: None,
       free_tasks: 0,
       description,
     }],

--- a/programs/hpl-crons/src/instructions/requeue_entity_claim_v1.rs
+++ b/programs/hpl-crons/src/instructions/requeue_entity_claim_v1.rs
@@ -26,7 +26,7 @@ pub fn handler(ctx: Context<RequeueEntityClaimV1>) -> Result<RunTaskReturnV0> {
         ),
         signer: ORACLE_SIGNER,
       },
-      crank_reward: Some(20000),
+      crank_reward: None,
       free_tasks: 0,
       description,
     }],

--- a/programs/hpl-crons/src/instructions/return_pyth_task_v0.rs
+++ b/programs/hpl-crons/src/instructions/return_pyth_task_v0.rs
@@ -30,6 +30,11 @@ pub fn handler(
   ctx: Context<ReturnPythTaskV0>,
   args: ReturnPythTaskArgsV0,
 ) -> Result<RunTaskReturnV0> {
+  // A pyth verification chain hands the next step back to the queue one step at a time, so a
+  // single returned task is all this instruction ever needs.
+  const MAX_FREE_TASKS: u8 = 1;
+  require_gte!(MAX_FREE_TASKS, args.free_tasks, ErrorCode::TooManyFreeTasks);
+
   let (signer, base_url) = match &ctx.accounts.task.transaction {
     TransactionSourceV0::CompiledV0(_) => return Err(ErrorCode::InvalidTaskForPyth.into()),
     TransactionSourceV0::RemoteV0 { signer, url } => (signer, url.split("?").next().unwrap()),

--- a/programs/hpl-crons/src/instructions/return_pyth_task_v0.rs
+++ b/programs/hpl-crons/src/instructions/return_pyth_task_v0.rs
@@ -13,7 +13,9 @@ use crate::error::ErrorCode;
 #[derive(Accounts)]
 pub struct ReturnPythTaskV0<'info> {
   pub task_queue: Account<'info, TaskQueueV0>,
-  #[account(has_one = task_queue)]
+  // The handler funds the returned task by transferring into this account, so it must be
+  // writable even for direct (non-run_task) invocations built from the IDL.
+  #[account(mut, has_one = task_queue)]
   pub task: Account<'info, TaskV0>,
   #[account(mut)]
   pub payer: Signer<'info>,

--- a/programs/tuktuk-dca/Cargo.toml
+++ b/programs/tuktuk-dca/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk-dca"
-version = "0.0.1"
+version = "0.0.2"
 # Trigger deployment - timestamp: 03-31-2025 #3
 description = "Created with Anchor"
 edition = "2021"

--- a/programs/tuktuk-dca/src/instructions/check_repay_v0.rs
+++ b/programs/tuktuk-dca/src/instructions/check_repay_v0.rs
@@ -179,7 +179,7 @@ pub fn handler(ctx: Context<CheckRepayV0>, _args: CheckRepayArgsV0) -> Result<Ru
           signer: dca.dca_signer,
           url: format!("{}/{}", dca_url, dca_key),
         },
-        crank_reward: Some(dca.crank_reward),
+        crank_reward: None,
         free_tasks: 1,
         description: format!("dca {}", &dca_key.to_string()[..(32 - 4)]),
       }],

--- a/programs/tuktuk-dca/src/instructions/initialize_dca_v0.rs
+++ b/programs/tuktuk-dca/src/instructions/initialize_dca_v0.rs
@@ -25,7 +25,6 @@ pub struct InitializeDcaArgsV0 {
   pub task_id: u16,
   pub dca_signer: Pubkey,
   pub dca_url: String,
-  pub crank_reward: u64,
 }
 
 // Shared accounts for both nested and non-nested versions
@@ -154,7 +153,6 @@ pub fn initialize_dca_impl(
     initial_num_orders: args.num_orders,
     num_orders: args.num_orders,
     swap_amount_per_order: args.swap_amount_per_order,
-    crank_reward: args.crank_reward,
     interval_seconds: args.interval_seconds,
     next_task: task_key,
     slippage_bps_from_oracle: args.slippage_bps_from_oracle,
@@ -173,7 +171,7 @@ pub fn initialize_dca_impl(
       signer: args.dca_signer,
       url: format!("{}/{}", args.dca_url, core.dca.key()),
     },
-    crank_reward: Some(args.crank_reward),
+    crank_reward: None,
     free_tasks: 1,
     description: format!("dca {}", &dca_key.to_string()[..(32 - 4)]),
   })

--- a/programs/tuktuk-dca/src/state.rs
+++ b/programs/tuktuk-dca/src/state.rs
@@ -27,7 +27,6 @@ pub struct DcaV0 {
   pub dca_signer: Pubkey,
   pub dca_url: [u8; 128],
   pub rent_refund: Pubkey,
-  pub crank_reward: u64,
 }
 
 #[macro_export]

--- a/tests/dc-auto-topoff.ts
+++ b/tests/dc-auto-topoff.ts
@@ -663,6 +663,20 @@ describe("dc-auto-topoff", () => {
       // Run the topoff task which should initialize the DCA
       await runAllTasks();
 
+      // The DCA task the topoff just handed back is funded by the queue, so it carries the
+      // queue's minimum crank reward, as does every other task queued here.
+      const queueAcc = await tuktukProgram.account.taskQueueV0.fetch(taskQueue);
+      const queuedTasks = await tuktukProgram.account.taskV0.all([
+        { memcmp: { offset: 8, bytes: taskQueue.toBase58() } },
+      ]);
+      expect(queuedTasks.length, "topoff should have queued tasks").to.be.greaterThan(0);
+      for (const queued of queuedTasks) {
+        expect(
+          queued.account.crankReward.toString(),
+          `task ${queued.publicKey.toBase58()} (${queued.account.description})`
+        ).to.eq(queueAcc.minCrankReward.toString());
+      }
+
       await new Promise((resolve) => setTimeout(resolve, 1500));
 
       // Run first DCA swap

--- a/tests/hpl-crons.ts
+++ b/tests/hpl-crons.ts
@@ -224,4 +224,60 @@ describe("hpl-crons", () => {
       epochBefore.add(new anchor.BN(1)).toString()
     );
   });
+
+  // A pyth verification chain advances one step at a time, so the task it hands back carries a
+  // fixed spawn budget rather than a caller-chosen one.
+  describe("return_pyth_task_v0", () => {
+    const taskId = 20;
+    let task: PublicKey;
+
+    before(async () => {
+      const [customWallet, bump] = customSignerKey(taskQueue, [
+        Buffer.from("pyth", "utf-8"),
+      ]);
+      const bumpBuffer = Buffer.alloc(1);
+      bumpBuffer.writeUint8(bump);
+      const { transaction, remainingAccounts } = compileTransaction(
+        [
+          SystemProgram.transfer({
+            fromPubkey: customWallet,
+            toPubkey: me,
+            lamports: 1,
+          }),
+        ],
+        [[Buffer.from("pyth", "utf-8"), bumpBuffer]]
+      );
+
+      task = taskKey(taskQueue, taskId)[0];
+      await tuktukProgram.methods
+        .queueTaskV0({
+          id: taskId,
+          trigger: { now: {} },
+          crankReward: null,
+          freeTasks: 1,
+          transaction: { compiledV0: [transaction] },
+          description: "pyth bounds",
+        })
+        .accountsPartial({ task, taskQueue })
+        .remainingAccounts(remainingAccounts)
+        .rpc({ skipPreflight: true });
+    });
+
+    async function returnPythTask(freeTasks: number) {
+      let code: string | undefined;
+      try {
+        await program.methods
+          .returnPythTaskV0({ index: 0, freeTasks })
+          .accountsPartial({ task, taskQueue, payer: me })
+          .rpc();
+      } catch (e: any) {
+        code = e?.error?.errorCode?.code ?? JSON.stringify(e);
+      }
+      return code;
+    }
+
+    it("rejects a free task count above the bound", async () => {
+      expect(await returnPythTask(2)).to.eq("TooManyFreeTasks");
+    });
+  });
 });

--- a/tests/hpl-crons.ts
+++ b/tests/hpl-crons.ts
@@ -232,21 +232,9 @@ describe("hpl-crons", () => {
     let task: PublicKey;
 
     before(async () => {
-      const [customWallet, bump] = customSignerKey(taskQueue, [
+      const [customWallet] = customSignerKey(taskQueue, [
         Buffer.from("pyth", "utf-8"),
       ]);
-      const bumpBuffer = Buffer.alloc(1);
-      bumpBuffer.writeUint8(bump);
-      const { transaction, remainingAccounts } = compileTransaction(
-        [
-          SystemProgram.transfer({
-            fromPubkey: customWallet,
-            toPubkey: me,
-            lamports: 1,
-          }),
-        ],
-        [[Buffer.from("pyth", "utf-8"), bumpBuffer]]
-      );
 
       task = taskKey(taskQueue, taskId)[0];
       await tuktukProgram.methods
@@ -255,11 +243,12 @@ describe("hpl-crons", () => {
           trigger: { now: {} },
           crankReward: null,
           freeTasks: 1,
-          transaction: { compiledV0: [transaction] },
+          transaction: {
+            remoteV0: { url: "https://example.com/pyth", signer: customWallet },
+          },
           description: "pyth bounds",
         })
         .accountsPartial({ task, taskQueue })
-        .remainingAccounts(remainingAccounts)
         .rpc({ skipPreflight: true });
     });
 
@@ -271,13 +260,21 @@ describe("hpl-crons", () => {
           .accountsPartial({ task, taskQueue, payer: me })
           .rpc();
       } catch (e: any) {
-        code = e?.error?.errorCode?.code ?? JSON.stringify(e);
+        code = e?.error?.errorCode?.code;
+        // Anything without an anchor error code is an infra failure, not a program verdict.
+        if (!code) throw e;
       }
       return code;
     }
 
     it("rejects a free task count above the bound", async () => {
       expect(await returnPythTask(2)).to.eq("TooManyFreeTasks");
+    });
+
+    // The pyth service always requeues with a single free task; guard the accept side of the
+    // bound so an off-by-one in MAX_FREE_TASKS can't slip past CI.
+    it("accepts a free task count at the bound", async () => {
+      expect(await returnPythTask(1)).to.be.undefined;
     });
   });
 });

--- a/tests/tuktuk-dca.ts
+++ b/tests/tuktuk-dca.ts
@@ -225,7 +225,6 @@ describe("tuktuk-dca", () => {
           taskId,
           dcaSigner: dcaSigner.publicKey,
           dcaUrl: "http://localhost:8123/dca",
-          crankReward: new anchor.BN(15000),
         })
         .accountsPartial({
           core: {


### PR DESCRIPTION
Tasks returned to a task queue are funded by that queue, so the reward they
declare is the queue's `min_crank_reward` rather than a literal or a
caller-chosen amount. This moves every such caller onto that rule.

## Changes

**`hpl-crons`**

- `requeue_entity_claim_v0` / `v1` return `crank_reward: None`, which resolves
  to the queue minimum. `RequeueEntityClaimV1` takes no `task_queue` account,
  and this queue has only ever run at two reward values, so prioritisation is
  not a live mechanism here.
- `return_pyth_task_v0` bounds its `free_tasks` argument. A pyth verification
  chain hands the next step back to the queue one step at a time, so a single
  returned task is all it ever needs; the service only ever passes 0 or 1.

**`tuktuk-dca`**

- `initialize_dca_v0` and `check_repay_v0` both return `None`. The
  `crank_reward` argument and the `DcaV0` field that stored it are removed: a
  DCA's reschedules are queue-funded, so the initial task should not sit at a
  different value from the rest of its cycle.

**`dc-auto-top`**

- `top_off_hnt_v0` no longer passes a reward into the nested DCA at all. The
  `total_crank_reward` calculation above it already transfers exactly
  `min_crank_reward` per task, so the literal it drops also declared more than
  the path funded.

## Deploy notes

- **`dc-auto-top` and `tuktuk-dca` must be upgraded together.** They are
  coupled by the `InitializeDcaArgsV0` layout, so they belong in one
  transaction rather than two sequenced proposals.
- These callers should move off queue-funded rewards before a matching ceiling
  lands in tuktuk, so that no flow is silently rejected in between.
- There is no on-chain signal that the HNT auto-top-off DCA path is
  misconfigured, so confirm `dc-auto-top` is live by version before anyone is
  told they may set `hnt_threshold`.

## Compatibility

Every other task-returning instruction across these programs already uses
`crank_reward: None`, including all four of mini-fanout's return sites, so
those flows are unaffected by construction. Every task currently queued on the
main queue carries a reward equal to that queue's `min_crank_reward`.

## Tests

- `tests/hpl-crons.ts`: `return_pyth_task_v0` rejects a free task count above
  the bound.
- `tests/dc-auto-topoff.ts`: after the topoff runs, every task the queue holds
  carries the queue's `min_crank_reward`. Reverting the reward to a literal
  makes this fail, so it pins the value rather than assuming it.
- `tests/tuktuk-dca.ts` and `tests/mini-fanout.ts` pass unchanged apart from
  the dropped argument.
