### PR TITLE
Add a bankrun test harness for state a program will not produce

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -347,9 +347,13 @@ jobs:
           TEST: ${{ matrix.test }}
           ANCHOR_PROVIDER_URL: http://localhost:8899
       - name: Check CU table covers test traffic
-        # priority-fees.ts (mocked) and sus.ts (remote RPC) never commit
-        # localnet traffic, so the CU sampler legitimately sees 0 — don't gate them.
-        if: matrix.test != 'tests/priority-fees.ts' && matrix.test != 'tests/sus.ts'
+        # priority-fees.ts (mocked), sus.ts (remote RPC) and the bankrun suites (in-process,
+        # no validator) never commit localnet traffic, so the CU sampler legitimately sees 0 —
+        # don't gate them. A suite added here that does not reach localnet belongs in this list.
+        if: >-
+          matrix.test != 'tests/priority-fees.ts'
+          && matrix.test != 'tests/sus.ts'
+          && !endsWith(matrix.test, '-bankrun.ts')
         run: pnpm run check-cu-table
         working-directory: packages/spl-utils
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -322,6 +322,7 @@ jobs:
           - tests/fanout.ts
           - tests/sus.ts
           - tests/mini-fanout.ts
+          - tests/mini-fanout-bankrun.ts
           - tests/welcome-pack.ts
           - tests/dc-auto-topoff.ts
           - tests/tuktuk-dca.ts

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/mocha": "^9.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "anchor-bankrun": "^0.5.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "chai-http": "^4.3.0",
@@ -66,6 +67,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^2.6.2",
     "shx": "^0.3.4",
+    "solana-bankrun": "^0.4.0",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.4.0",
     "turbo": "^2.3.0",
@@ -84,6 +86,11 @@
       "@helium/crypto": "^4.14.2",
       "@types/bn.js": "^5.2.0",
       "@solana/web3.js": "1.98.2"
+    },
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "anchor-bankrun>@coral-xyz/anchor": "0.31.1"
+      }
     }
   },
   "packageManager": "pnpm@9.15.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      anchor-bankrun:
+        specifier: ^0.5.0
+        version: 0.5.0(@coral-xyz/anchor@0.31.1(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(solana-bankrun@0.4.0(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))
       chai:
         specifier: ^4.3.4
         version: 4.3.8
@@ -154,6 +157,9 @@ importers:
       shx:
         specifier: ^0.3.4
         version: 0.3.4
+      solana-bankrun:
+        specifier: ^0.4.0
+        version: 0.4.0(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
       ts-mocha:
         specifier: ^10.0.0
         version: 10.0.0(mocha@9.2.2)
@@ -174,7 +180,7 @@ importers:
     dependencies:
       '@solana/web3.js':
         specifier: 1.98.2
-        version: 1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
+        version: 1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
     devDependencies:
       git-format-staged:
         specifier: ^2.1.3
@@ -193,7 +199,7 @@ importers:
         version: link:../account-fetch-cache
       '@solana/web3.js':
         specifier: 1.98.2
-        version: 1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react:
         specifier: ^16.8 || ^17 || ^18
         version: 18.2.0
@@ -8893,6 +8899,14 @@ packages:
     resolution: {integrity: sha512-yE5I83Q2s8euVou8Y3feXK08wyZInJWLYXgWO6Xti9jBUEZAGUahyeQ7wSZWkifLWVnQVKEz5RAmBlXG5nqxog==}
     engines: {node: '>= 14.0.0'}
 
+  anchor-bankrun@0.5.0:
+    resolution: {integrity: sha512-cNTRv7pN9dy+kiyJ3UlNVTg9hAXhY2HtNVNXJbP/2BkS9nOdLV0qKWhgW8UR9Go0gYuEOLKuPzrGL4HFAZPsVw==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      '@coral-xyz/anchor': ^0.30.0
+      '@solana/web3.js': 1.98.2
+      solana-bankrun: '>=0.2.0 <0.5.0'
+
   angry-purple-tiger@1.0.5:
     resolution: {integrity: sha512-IhVFyt86Dz1/wbsGsuBM5l5Ea3qe4fVQ3DnA6DkwDsojnA/p99++phO+8ivvbsb3tmxB6CmDpIbuqSd0xDRFOg==}
 
@@ -13631,6 +13645,39 @@ packages:
   socks@2.7.1:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
     engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
+
+  solana-bankrun-darwin-arm64@0.4.0:
+    resolution: {integrity: sha512-6dz78Teoz7ez/3lpRLDjktYLJb79FcmJk2me4/YaB8WiO6W43OdExU4h+d2FyuAryO2DgBPXaBoBNY/8J1HJmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  solana-bankrun-darwin-universal@0.4.0:
+    resolution: {integrity: sha512-zSSw/Jx3KNU42pPMmrEWABd0nOwGJfsj7nm9chVZ3ae7WQg3Uty0hHAkn5NSDCj3OOiN0py9Dr1l9vmRJpOOxg==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  solana-bankrun-darwin-x64@0.4.0:
+    resolution: {integrity: sha512-LWjs5fsgHFtyr7YdJR6r0Ho5zrtzI6CY4wvwPXr8H2m3b4pZe6RLIZjQtabCav4cguc14G0K8yQB2PTMuGub8w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  solana-bankrun-linux-x64-gnu@0.4.0:
+    resolution: {integrity: sha512-SrlVrb82UIxt21Zr/XZFHVV/h9zd2/nP25PMpLJVLD7Pgl2yhkhfi82xj3OjxoQqWe+zkBJ+uszA0EEKr67yNw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  solana-bankrun-linux-x64-musl@0.4.0:
+    resolution: {integrity: sha512-Nv328ZanmURdYfcLL+jwB1oMzX4ZzK57NwIcuJjGlf0XSNLq96EoaO5buEiUTo4Ls7MqqMyLbClHcrPE7/aKyA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  solana-bankrun@0.4.0:
+    resolution: {integrity: sha512-NMmXUipPBkt8NgnyNO3SCnPERP6xT/AMNMBooljGA3+rG6NN8lmXJsKeLqQTiFsDeWD74U++QM/DgcueSWvrIg==}
+    engines: {node: '>= 10'}
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
@@ -23712,6 +23759,12 @@ snapshots:
       '@algolia/requester-fetch': 5.50.0
       '@algolia/requester-node-http': 5.50.0
 
+  anchor-bankrun@0.5.0(@coral-xyz/anchor@0.31.1(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(solana-bankrun@0.4.0(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)):
+    dependencies:
+      '@coral-xyz/anchor': 0.31.1(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      solana-bankrun: 0.4.0(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+
   angry-purple-tiger@1.0.5:
     dependencies:
       md5: 2.3.0
@@ -29504,6 +29557,37 @@ snapshots:
       ip: 2.0.0
       smart-buffer: 4.2.0
     optional: true
+
+  solana-bankrun-darwin-arm64@0.4.0:
+    optional: true
+
+  solana-bankrun-darwin-universal@0.4.0:
+    optional: true
+
+  solana-bankrun-darwin-x64@0.4.0:
+    optional: true
+
+  solana-bankrun-linux-x64-gnu@0.4.0:
+    optional: true
+
+  solana-bankrun-linux-x64-musl@0.4.0:
+    optional: true
+
+  solana-bankrun@0.4.0(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10):
+    dependencies:
+      '@solana/web3.js': 1.98.2(bufferutil@4.0.7)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      bs58: 4.0.1
+    optionalDependencies:
+      solana-bankrun-darwin-arm64: 0.4.0
+      solana-bankrun-darwin-universal: 0.4.0
+      solana-bankrun-darwin-x64: 0.4.0
+      solana-bankrun-linux-x64-gnu: 0.4.0
+      solana-bankrun-linux-x64-musl: 0.4.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
 
   sonic-boom@2.8.0:
     dependencies:

--- a/tests/mini-fanout-bankrun.ts
+++ b/tests/mini-fanout-bankrun.ts
@@ -1,0 +1,111 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { BankrunProvider } from "anchor-bankrun";
+import { ProgramTestContext } from "solana-bankrun";
+import { expect } from "chai";
+import { MiniFanout } from "../target/types/mini_fanout";
+import {
+  ensureCloned,
+  ensureDumped,
+  overwriteAccountData,
+  readAccount,
+  startBankrun,
+  warpBy,
+} from "./utils/bankrun";
+
+const MINI_FANOUT = new PublicKey("mfanLprNnaiP4RX9Zz1BMcDosYHCqnG24H1fMEbi9Gn");
+const TUKTUK = new PublicKey("tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA");
+// The queue mini-fanout runs on, cloned so a fanout can be created against real state.
+const TASK_QUEUE = new PublicKey("H39gEszvsi6AT4rYBiJTuZHJSF5hMHy6CKGTd7wzhsg7");
+
+describe("mini-fanout under bankrun", () => {
+  let ctx: ProgramTestContext;
+  let provider: BankrunProvider;
+  let program: Program<MiniFanout>;
+  let me: PublicKey;
+
+  before(async () => {
+    ensureDumped("tuktuk", TUKTUK);
+    ctx = await startBankrun(
+      [
+        { name: "mini_fanout", programId: MINI_FANOUT },
+        { name: "tuktuk", programId: TUKTUK },
+      ],
+      [ensureCloned("task_queue_h39", TASK_QUEUE)]
+    );
+    provider = new BankrunProvider(ctx);
+    program = new Program<MiniFanout>(
+      require("../target/idl/mini_fanout.json"),
+      provider
+    );
+    me = provider.wallet.publicKey;
+  });
+
+  it("runs both programs against cloned mainnet state", async () => {
+    for (const id of [MINI_FANOUT, TUKTUK]) {
+      const account = await ctx.banksClient.getAccount(id);
+      expect(account, id.toBase58()).to.not.be.null;
+      expect(account!.executable, id.toBase58()).to.be.true;
+    }
+    const queue = await ctx.banksClient.getAccount(TASK_QUEUE);
+    expect(queue).to.not.be.null;
+    expect(new PublicKey(queue!.owner).toBase58()).to.equal(TUKTUK.toBase58());
+  });
+
+  it("moves the clock, so a timestamp trigger does not have to be waited for", async () => {
+    const before = (await ctx.banksClient.getClock()).unixTimestamp;
+    await warpBy(ctx, 86_400n);
+    const after = (await ctx.banksClient.getClock()).unixTimestamp;
+    expect(after - before).to.equal(86_400n);
+  });
+
+  it("rewrites an account the programs would not produce", async () => {
+    // The capability the localnet suites lack. A guard that only fires on data a program
+    // refuses to write is unreachable without this.
+    const original = await readAccount(ctx, TASK_QUEUE);
+    expect(original).to.not.be.null;
+
+    const scrambled = Buffer.from(original!);
+    scrambled[scrambled.length - 1] ^= 0xff;
+    await overwriteAccountData(ctx, TASK_QUEUE, scrambled);
+
+    const readBack = await readAccount(ctx, TASK_QUEUE);
+    expect(readBack!.equals(scrambled)).to.be.true;
+    expect(readBack!.equals(original!)).to.be.false;
+
+    // Owner and executable survive the rewrite, or later instructions fail for the wrong reason.
+    const account = await ctx.banksClient.getAccount(TASK_QUEUE);
+    expect(new PublicKey(account!.owner).toBase58()).to.equal(TUKTUK.toBase58());
+
+    await overwriteAccountData(ctx, TASK_QUEUE, original!);
+    expect((await readAccount(ctx, TASK_QUEUE))!.equals(original!)).to.be.true;
+  });
+
+  it("reaches the program's own error path", async () => {
+    // Proves the whole provider -> build -> sign -> execute path, not just construction:
+    // the failure is the program's, at a named constraint.
+    let message = "";
+    try {
+      await program.methods
+        .initializeMiniFanoutV0({
+          seed: Buffer.from("bankrun"),
+          shares: [{ wallet: PublicKey.default, share: { share: { amount: 1 } } }],
+          schedule: "0 0 * * * *",
+          preTask: null,
+        })
+        .accounts({
+          payer: me,
+          owner: me,
+          taskQueue: PublicKey.default,
+          rentRefund: me,
+          mint: PublicKey.default,
+        })
+        .rpc();
+    } catch (e: any) {
+      message = String(e.message ?? e);
+    }
+    expect(message).to.include("task_queue");
+    expect(message).to.include("AccountOwnedByWrongProgram");
+  });
+});

--- a/tests/utils/bankrun.ts
+++ b/tests/utils/bankrun.ts
@@ -1,0 +1,178 @@
+import { Program, Idl } from "@coral-xyz/anchor";
+import { BankrunProvider } from "anchor-bankrun";
+import { Clock, ProgramTestContext, start } from "solana-bankrun";
+import { PublicKey } from "@solana/web3.js";
+import { execFileSync } from "child_process";
+import { existsSync, statSync } from "fs";
+import { join } from "path";
+
+/**
+ * Programs run in-process against solana-bankrun rather than a validator, which buys three
+ * things the localnet suites cannot have: the clock can be moved, so a task with a timestamp
+ * trigger fires without waiting for it; account bytes can be written directly, so state a
+ * program refuses to produce is still reachable; and every failure carries its logs, since
+ * there is no preflight to skip.
+ */
+
+export const TARGET_DEPLOY = join(__dirname, "..", "..", "target", "deploy");
+
+// An SBF program is an ELF, and a truncated download is the failure this guards: a
+// present-but-unusable file would otherwise be taken for a cached one.
+const ELF_MAGIC = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+
+function looksLikeAProgram(path: string): boolean {
+  if (!existsSync(path) || statSync(path).size < 1024) {
+    return false;
+  }
+  const fd = require("fs").openSync(path, "r");
+  const head = Buffer.alloc(4);
+  require("fs").readSync(fd, head, 0, 4, 0);
+  require("fs").closeSync(fd);
+  return head.equals(ELF_MAGIC);
+}
+
+/**
+ * Put a program this workspace does not build where bankrun looks for it. The localnet suites
+ * get these by cloning mainnet in `Anchor.toml`; bankrun needs the bytes on disk, so fetch
+ * them the same way and from the same place.
+ */
+export function ensureDumped(name: string, programId: PublicKey, cluster = "m") {
+  const path = join(TARGET_DEPLOY, `${name}.so`);
+  if (looksLikeAProgram(path)) {
+    return path;
+  }
+  execFileSync(
+    "solana",
+    ["program", "dump", "-u", cluster, programId.toBase58(), path],
+    { stdio: "inherit" }
+  );
+  if (!looksLikeAProgram(path)) {
+    throw new Error(`dumped ${name} to ${path}, but it is not a program`);
+  }
+  return path;
+}
+
+/**
+ * Clone a mainnet account onto disk so bankrun can start with it, the way `Anchor.toml`'s
+ * `[[test.validator.clone]]` entries do for the localnet suites. Cached under `target/`, so a
+ * run costs one RPC call the first time and nothing after.
+ */
+export function ensureCloned(name: string, address: PublicKey, cluster = "m") {
+  const path = join(TARGET_DEPLOY, `${name}.account.json`);
+  if (!existsSync(path) || statSync(path).size < 2) {
+    execFileSync(
+      "solana",
+      [
+        "account",
+        "-u",
+        cluster,
+        address.toBase58(),
+        "--output",
+        "json",
+        "--output-file",
+        path,
+      ],
+      // `solana account` writes the account to stdout as well as to the file; keep stderr so
+      // a failure is still visible.
+      { stdio: ["ignore", "ignore", "inherit"] }
+    );
+  }
+  const { account } = JSON.parse(require("fs").readFileSync(path, "utf8"));
+  const [data, encoding] = account.data;
+  if (encoding !== "base64") {
+    throw new Error(`${name}: expected base64 account data, got ${encoding}`);
+  }
+  return {
+    address,
+    info: {
+      lamports: account.lamports,
+      data: Buffer.from(data, "base64"),
+      owner: new PublicKey(account.owner),
+      executable: account.executable,
+    },
+  };
+}
+
+export async function startBankrun(
+  programs: { name: string; programId: PublicKey }[],
+  accounts: ReturnType<typeof ensureCloned>[] = []
+): Promise<ProgramTestContext> {
+  process.env.BPF_OUT_DIR = TARGET_DEPLOY;
+  for (const { name, programId } of programs) {
+    const path = join(TARGET_DEPLOY, `${name}.so`);
+    if (!looksLikeAProgram(path)) {
+      throw new Error(
+        `${path} is missing or is not a program. Workspace programs come from ` +
+          `\`TESTING=true anchor build\`; anything else needs ensureDumped().`
+      );
+    }
+    void programId;
+  }
+  return start(programs, accounts);
+}
+
+export function providerFor(ctx: ProgramTestContext): BankrunProvider {
+  return new BankrunProvider(ctx);
+}
+
+export function programFor<T extends Idl>(
+  idl: T,
+  provider: BankrunProvider
+): Program<T> {
+  return new Program<T>(idl, provider);
+}
+
+/**
+ * Move the clock to `unixTimestamp`. `Clock` exposes getters only, so assigning to the value
+ * returned by `getClock()` changes nothing and `setClock` then writes the original back --
+ * a warp that reports success and does not happen. Always build a new one.
+ */
+export async function warpTo(ctx: ProgramTestContext, unixTimestamp: bigint) {
+  const clock = await ctx.banksClient.getClock();
+  ctx.setClock(
+    new Clock(
+      clock.slot,
+      clock.epochStartTimestamp,
+      clock.epoch,
+      clock.leaderScheduleEpoch,
+      unixTimestamp
+    )
+  );
+  const now = (await ctx.banksClient.getClock()).unixTimestamp;
+  if (now !== unixTimestamp) {
+    throw new Error(`clock did not move: asked for ${unixTimestamp}, got ${now}`);
+  }
+}
+
+export async function warpBy(ctx: ProgramTestContext, seconds: bigint) {
+  const { unixTimestamp } = await ctx.banksClient.getClock();
+  await warpTo(ctx, unixTimestamp + seconds);
+}
+
+/** The account's raw bytes, or null. Fails loudly rather than returning empty on a miss. */
+export async function readAccount(ctx: ProgramTestContext, address: PublicKey) {
+  const account = await ctx.banksClient.getAccount(address);
+  return account ? Buffer.from(account.data) : null;
+}
+
+/**
+ * Rewrite one account's data, keeping its owner, lamports and executable flag. This is the
+ * capability the localnet suites lack: it reaches state that a program will not produce,
+ * which is how a guard against pre-existing data gets tested at all.
+ */
+export async function overwriteAccountData(
+  ctx: ProgramTestContext,
+  address: PublicKey,
+  data: Buffer
+) {
+  const existing = await ctx.banksClient.getAccount(address);
+  if (!existing) {
+    throw new Error(`cannot overwrite ${address.toBase58()}: it does not exist`);
+  }
+  ctx.setAccount(address, {
+    lamports: existing.lamports,
+    data,
+    owner: new PublicKey(existing.owner),
+    executable: existing.executable,
+  });
+}


### PR DESCRIPTION
The localnet suites can only reach states the programs themselves will build, and they have to
wait out real time for anything on a schedule. Two consequences: a check that only fires on
pre-existing data has no test that can reach it, and a timestamp-triggered task costs seconds of
wall clock per assertion.

`solana-bankrun` runs the programs in-process, so a test can write account bytes directly, move
the clock, and read logs from every failure — there is no preflight to skip.

- `tests/utils/bankrun.ts` — boots the SVM, dumps programs this workspace does not build
  (tuktuk), and clones accounts the way `Anchor.toml` already clones them for the validator.
  Both cache under `target/`, which is gitignored.
- `tests/mini-fanout-bankrun.ts` — exercises the three capabilities: running against cloned
  mainnet state, moving the clock, and rewriting an account the programs would not produce.

Runs in about 1 second and needs no validator, against ~53s plus validator startup for
`tests/mini-fanout.ts`.

### Notes for review

`anchor-bankrun` declares a peer of `@coral-xyz/anchor ^0.30.0` while this workspace is on
0.31.1. Measured rather than assumed: `BankrunProvider` builds, signs and sends through
`Program.methods` on 0.31.1, and a deliberately wrong account comes back as `AnchorError 3007`
from the program itself. `provider.connection.getAccountInfo` works; `getLatestBlockhash` is not
implemented, and Anchor's provider does not need it. The allowance is recorded in
`pnpm.peerDependencyRules` so it is a decision rather than a standing warning — pnpm does not
fail on it, but plain `npm` needs `--legacy-peer-deps`.

`Clock` exposes getters only, so assigning to the object `getClock()` returns changes nothing and
`setClock` writes the original back — a warp that reports success and does not happen. `warpTo`
builds a new `Clock` and asserts the clock moved. Cached program dumps are checked for the ELF
magic rather than mere existence, since "the file is present" is not the same as "the file is a
program".

This PR adds files only and does not touch `tests/mini-fanout.ts`, so it does not conflict with
work in flight there.