### PR TITLE
Constrain a mini-fanout pre task to one of two shapes

### DIFF
--- a/.changeset/mini-fanout-pre-task-shape.md
+++ b/.changeset/mini-fanout-pre-task-shape.md
@@ -2,6 +2,6 @@
 "@helium/idls": patch
 ---
 
-`mini-fanout` holds a pre task to one of two shapes — a remote transaction the Helium oracle
-signs, or a compiled transaction carrying no signer seeds — and gains an `InvalidPreTask` error
-for anything else.
+`mini-fanout` queues a pre task only when it is one of two shapes: a remote transaction the
+Helium oracle signs, or a compiled transaction carrying no signer seeds. Anything else fails
+with a new `InvalidPreTask` error.

--- a/.changeset/mini-fanout-pre-task-shape.md
+++ b/.changeset/mini-fanout-pre-task-shape.md
@@ -5,3 +5,14 @@
 `mini-fanout` queues a pre task only when it is one of two shapes: a remote transaction the
 Helium oracle signs, or a compiled transaction carrying no signer seeds. Anything else fails
 with a new `InvalidPreTask` error.
+
+`mini-fanout` also reserves a new fanout the space its contents need. The arithmetic covered
+seven of the account's eight pubkeys and undercounted a compiled pre task, so a new fanout is
+32 bytes larger than before plus what its pre task takes. Existing accounts are unaffected.
+
+`welcome-pack` holds a claim approval to a maximum window of 30 days, with a new
+`ClaimApprovalTooLong` error. An approval expiring further out than that is refused at claim
+time; the owner signs a fresh one.
+
+`hpl-crons` derives a cron job's transaction records under the cron program, which is where
+they live, so `requeue_entity_claim_cron_v0` names the accounts that exist.

--- a/.changeset/mini-fanout-pre-task-shape.md
+++ b/.changeset/mini-fanout-pre-task-shape.md
@@ -2,13 +2,14 @@
 "@helium/idls": patch
 ---
 
-`mini-fanout` queues a pre task only when it is one of two shapes: a remote transaction the
-Helium oracle signs, or a compiled transaction carrying no signer seeds. Anything else fails
-with a new `InvalidPreTask` error.
+`mini-fanout` stores and queues a pre task only when it is one of two shapes: a remote
+transaction the Helium oracle signs, or a compiled transaction carrying no signer seeds.
+Anything else fails with a new `InvalidPreTask` error.
 
 `mini-fanout` also reserves a new fanout the space its contents need. The arithmetic covered
-seven of the account's eight pubkeys and undercounted a compiled pre task, so a new fanout is
-32 bytes larger than before plus what its pre task takes. Existing accounts are unaffected.
+seven of the account's eight pubkeys and undercounted a compiled pre task, so a new fanout
+carrying a pre task is 32 bytes larger than before plus what that pre task takes, and one
+carrying none is 31. Existing accounts are unaffected.
 
 `welcome-pack` holds a claim approval to a maximum window of 30 days, with a new
 `ClaimApprovalTooLong` error. An approval expiring further out than that is refused at claim

--- a/.changeset/mini-fanout-pre-task-shape.md
+++ b/.changeset/mini-fanout-pre-task-shape.md
@@ -1,0 +1,7 @@
+---
+"@helium/idls": patch
+---
+
+`mini-fanout` holds a pre task to one of two shapes — a remote transaction the Helium oracle
+signs, or a compiled transaction carrying no signer seeds — and gains an `InvalidPreTask` error
+for anything else.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "hpl-crons"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "welcome-pack"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "account-compression-cpi",
  "anchor-lang",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "mini-fanout"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/packages/blockchain-api-client/src/contracts/reward-contract.ts
+++ b/packages/blockchain-api-client/src/contracts/reward-contract.ts
@@ -104,7 +104,7 @@ export const rewardContract = oc
                 z.object({
                     entityPubKey: HeliumPublicKeySchema.describe("The public key of the hotspot entity"),
                     signerWalletAddress: WalletAddressSchema.describe("The wallet address of the caller"),
-                    expirationDays: z.number().int().positive().max(365).default(7).describe("Number of days until the invite expires"),
+                    expirationDays: z.number().int().positive().max(14).default(3).describe("Number of days until the invite expires"),
                 })
             )
             .errors({

--- a/packages/blockchain-api-client/src/schemas/welcome-packs.ts
+++ b/packages/blockchain-api-client/src/schemas/welcome-packs.ts
@@ -41,7 +41,9 @@ export const WelcomePackClaimInputSchema = z.object({
 export const WelcomePackInviteInputSchema = z.object({
   packAddress: z.string().min(32),
   walletAddress: WalletAddressSchema,
-  expirationDays: z.number().int().positive().max(365).default(7),
+  // An invite is approved by a signature over the pack and this expiry, and that signature is
+  // good for whatever window it names. An invite is acted on in hours, so the window is days.
+  expirationDays: z.number().int().positive().max(14).default(3),
 });
 
 export const WelcomePackSchema = z.object({

--- a/packages/blockchain-api/src/components/InviteModal.tsx
+++ b/packages/blockchain-api/src/components/InviteModal.tsx
@@ -27,7 +27,7 @@ export default function InviteModal({
   onClose,
   pack,
 }: InviteModalProps) {
-  const [expirationDays, setExpirationDays] = useState("7");
+  const [expirationDays, setExpirationDays] = useState("3");
   const [inviteUrl, setInviteUrl] = useState<string>();
   const { user, connectWallet } = usePrivy();
   const walletAddress = useWalletAddress();

--- a/programs/hpl-crons/Cargo.toml
+++ b/programs/hpl-crons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hpl-crons"
-version = "0.1.7"
+version = "0.1.8"
 # Trigger deployment - timestamp: 03-31-2025 #3
 description = "Created with Anchor"
 edition = "2021"

--- a/programs/hpl-crons/src/instructions/requeue_entity_claim_cron_v0.rs
+++ b/programs/hpl-crons/src/instructions/requeue_entity_claim_cron_v0.rs
@@ -79,21 +79,26 @@ pub struct RequeueEntityClaimCronV0<'info> {
   pub cron_program: Program<'info, Cron>,
 }
 
+/// The address of one of a cron job's transaction records. The records belong to the cron
+/// program, so they are derived under it -- the same address `add_entity_to_cron_v0` reaches
+/// with `seeds::program = cron_program`.
+fn cron_job_transaction_key(cron_job: &Pubkey, index: u32) -> Pubkey {
+  Pubkey::find_program_address(
+    &[
+      b"cron_job_transaction",
+      cron_job.as_ref(),
+      &index.to_le_bytes(),
+    ],
+    &tuktuk_program::cron::ID,
+  )
+  .0
+}
+
 pub fn handler(ctx: Context<RequeueEntityClaimCronV0>) -> Result<()> {
   let remaining_accounts = (ctx.accounts.cron_job.current_transaction_id
     ..ctx.accounts.cron_job.current_transaction_id
       + ctx.accounts.cron_job.num_tasks_per_queue_call as u32)
-    .map(|i| {
-      Pubkey::find_program_address(
-        &[
-          b"cron_job_transaction",
-          ctx.accounts.cron_job.key().as_ref(),
-          &i.to_le_bytes(),
-        ],
-        &crate::ID,
-      )
-      .0
-    })
+    .map(|i| cron_job_transaction_key(&ctx.accounts.cron_job.key(), i))
     .collect::<Vec<Pubkey>>();
   let (queue_tx, _) = compile_transaction(
     vec![Instruction {
@@ -152,4 +157,35 @@ pub fn handler(ctx: Context<RequeueEntityClaimCronV0>) -> Result<()> {
   )?;
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn a_transaction_record_is_derived_under_the_cron_program() {
+    let cron_job = Pubkey::new_unique();
+
+    for index in [0u32, 1, 7, 999] {
+      let seeds = [
+        b"cron_job_transaction".as_ref(),
+        cron_job.as_ref(),
+        &index.to_le_bytes(),
+      ];
+      let key = cron_job_transaction_key(&cron_job, index);
+
+      assert_eq!(
+        key,
+        Pubkey::find_program_address(&seeds, &tuktuk_program::cron::ID).0,
+        "index {index}"
+      );
+      // Pinned against this program's id, the other one these seeds could be derived under.
+      assert_ne!(
+        key,
+        Pubkey::find_program_address(&seeds, &crate::ID).0,
+        "index {index}"
+      );
+    }
+  }
 }

--- a/programs/hpl-crons/src/instructions/requeue_entity_claim_cron_v0.rs
+++ b/programs/hpl-crons/src/instructions/requeue_entity_claim_cron_v0.rs
@@ -94,12 +94,20 @@ fn cron_job_transaction_key(cron_job: &Pubkey, index: u32) -> Pubkey {
   .0
 }
 
+/// The records a schedule run reads: one per transaction the run will queue, starting where the
+/// job's execution left off.
+fn records_to_queue(cron_job: &Pubkey, from: u32, count: u8) -> Vec<Pubkey> {
+  (from..from + count as u32)
+    .map(|i| cron_job_transaction_key(cron_job, i))
+    .collect()
+}
+
 pub fn handler(ctx: Context<RequeueEntityClaimCronV0>) -> Result<()> {
-  let remaining_accounts = (ctx.accounts.cron_job.current_transaction_id
-    ..ctx.accounts.cron_job.current_transaction_id
-      + ctx.accounts.cron_job.num_tasks_per_queue_call as u32)
-    .map(|i| cron_job_transaction_key(&ctx.accounts.cron_job.key(), i))
-    .collect::<Vec<Pubkey>>();
+  let remaining_accounts = records_to_queue(
+    &ctx.accounts.cron_job.key(),
+    ctx.accounts.cron_job.current_transaction_id,
+    ctx.accounts.cron_job.num_tasks_per_queue_call,
+  );
   let (queue_tx, _) = compile_transaction(
     vec![Instruction {
       program_id: tuktuk_program::cron::ID,
@@ -162,6 +170,36 @@ pub fn handler(ctx: Context<RequeueEntityClaimCronV0>) -> Result<()> {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn a_schedule_run_reads_the_records_its_execution_left_off_at() {
+    let cron_job = Pubkey::new_unique();
+
+    let records = records_to_queue(&cron_job, 3, 4);
+
+    assert_eq!(records.len(), 4, "one record per transaction to queue");
+    assert_eq!(
+      records,
+      (3..7)
+        .map(|i| cron_job_transaction_key(&cron_job, i))
+        .collect::<Vec<_>>(),
+      "the records are ids 3..7, in order"
+    );
+    // Named against the derivation rather than against the helper, so the list is pinned to the
+    // cron program even if the helper stops deriving it there.
+    assert_eq!(
+      records[0],
+      Pubkey::find_program_address(
+        &[
+          b"cron_job_transaction",
+          cron_job.as_ref(),
+          &3u32.to_le_bytes()
+        ],
+        &tuktuk_program::cron::ID,
+      )
+      .0
+    );
+  }
 
   #[test]
   fn a_transaction_record_is_derived_under_the_cron_program() {

--- a/programs/mini-fanout/Cargo.toml
+++ b/programs/mini-fanout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mini-fanout"
-version = "0.1.3"
+version = "0.1.4"
 # Trigger deployment - timestamp: 03-31-2025 #4
 description = "Created with Anchor"
 edition = "2021"

--- a/programs/mini-fanout/Cargo.toml
+++ b/programs/mini-fanout/Cargo.toml
@@ -11,7 +11,7 @@ name = "mini_fanout"
 
 [features]
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
-devnet = []
+devnet = ["shared-utils/devnet"]
 no-genesis = []
 no-entrypoint = []
 no-idl = []

--- a/programs/mini-fanout/src/errors.rs
+++ b/programs/mini-fanout/src/errors.rs
@@ -24,4 +24,6 @@ pub enum ErrorCode {
   PreTaskNotRun,
   #[msg("Invalid CPI context - must be called via tuktuk for next_task")]
   InvalidCpiContext,
+  #[msg("Invalid pre task")]
+  InvalidPreTask,
 }

--- a/programs/mini-fanout/src/instructions/distribute_v0.rs
+++ b/programs/mini-fanout/src/instructions/distribute_v0.rs
@@ -261,7 +261,7 @@ pub fn handler<'info>(
     free_tasks: 2,
     description: format!("dist {}", &mini_fanout.key().to_string()[..(32 - 9)]),
   }];
-  if let Some(pre_task) = mini_fanout.pre_task.clone() {
+  if let Some(pre_task) = mini_fanout.pre_task_to_queue()? {
     tasks.push(TaskReturnV0 {
       trigger: TriggerV0::Timestamp(next_time - 1),
       transaction: pre_task,

--- a/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
+++ b/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
@@ -71,8 +71,8 @@ impl MiniFanoutV0 {
   pub fn size(args: &InitializeMiniFanoutArgsV0) -> usize {
     // Discriminator
     let mut size = 8;
-    // Pubkey fields: authority, mint, token_account, next_task, rent_refund (5 * 32)
-    size += 7 * 32;
+    // owner, namespace, mint, token_account, task_queue, next_task, rent_refund, next_pre_task
+    size += 8 * 32;
     // bump: u8
     size += 1;
     // schedule: String (4 bytes len + string bytes)
@@ -83,26 +83,34 @@ impl MiniFanoutV0 {
     size += 4 + args.shares.len() * MiniFanoutShareV0::size();
     // seed: Vec<u8> (4 bytes len + seed bytes)
     size += 4 + args.seed.len();
-    // Option<TransactionSourceV0> and enum in TransactionSourceV0
-    size += 2;
+    // pre_task: the Option tag, and for Some the TransactionSourceV0 enum discriminant
+    size += 1;
     if let Some(pre_task) = &args.pre_task {
+      size += 1;
       match pre_task {
         TransactionSourceV0::CompiledV0(compiled) => {
+          // num_rw_signers, num_ro_signers, num_rw
+          size += 3;
+          // accounts: Vec<Pubkey>
+          size += 4 + 32 * compiled.accounts.len();
+          // instructions: Vec<CompiledInstructionV0>, each a program_id_index and two Vec<u8>
           size += 4
-            + 3
-            + 4
-            + 32 * compiled.accounts.len()
-            + 1 // option
-            + 4 // Vec<>
             + compiled
               .instructions
               .iter()
-              .map(|i| i.accounts.len() + i.data.len() + 4)
-              .sum::<usize>()
-            + compiled.signer_seeds.iter().map(|s| s.len()).sum::<usize>();
+              .map(|i| 1 + 4 + i.accounts.len() + 4 + i.data.len())
+              .sum::<usize>();
+          // signer_seeds: Vec<Vec<Vec<u8>>>
+          size += 4
+            + compiled
+              .signer_seeds
+              .iter()
+              .map(|group| 4 + group.iter().map(|seed| 4 + seed.len()).sum::<usize>())
+              .sum::<usize>();
         }
-        TransactionSourceV0::RemoteV0 { url, .. } => {
-          size += 4 + 32 + url.len();
+        TransactionSourceV0::RemoteV0 { url, signer: _ } => {
+          // url: String, signer: Pubkey
+          size += 4 + url.len() + 32;
         }
       }
     }
@@ -162,4 +170,127 @@ pub fn handler(
   });
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use tuktuk_program::{CompiledInstructionV0, CompiledTransactionV0};
+
+  use super::*;
+
+  const RESERVE: usize = 60;
+
+  /// The account `handler` writes for these args, so what `size` reserves can be measured
+  /// against what storing it actually costs.
+  fn stored(args: &InitializeMiniFanoutArgsV0) -> MiniFanoutV0 {
+    MiniFanoutV0 {
+      owner: Pubkey::new_unique(),
+      namespace: Pubkey::new_unique(),
+      mint: Pubkey::new_unique(),
+      token_account: Pubkey::new_unique(),
+      task_queue: Pubkey::new_unique(),
+      next_task: Pubkey::new_unique(),
+      rent_refund: Pubkey::new_unique(),
+      bump: 255,
+      schedule: args.schedule.clone(),
+      queue_authority_bump: 254,
+      shares: args
+        .shares
+        .iter()
+        .map(|s| MiniFanoutShareV0 {
+          wallet: s.wallet,
+          share: s.share.clone(),
+          delegate: Pubkey::default(),
+          total_dust: 0,
+          total_owed: 0,
+        })
+        .collect(),
+      seed: args.seed.clone(),
+      next_pre_task: Pubkey::new_unique(),
+      pre_task: args.pre_task.clone(),
+    }
+  }
+
+  fn args(pre_task: Option<TransactionSourceV0>) -> InitializeMiniFanoutArgsV0 {
+    InitializeMiniFanoutArgsV0 {
+      schedule: "0 0 * * * *".to_string(),
+      // Fixed rather than Share, which is the narrower of the two variants MiniFanoutShareV0
+      // reserves for, so a share costs exactly what it reserves.
+      shares: vec![
+        MiniFanoutShareArgV0 {
+          wallet: Pubkey::new_unique(),
+          share: Share::Fixed { amount: 1 },
+        };
+        MAX_SHARES
+      ],
+      seed: b"a-fanout-seed".to_vec(),
+      pre_task,
+    }
+  }
+
+  fn compiled(instructions: usize, signer_seeds: Vec<Vec<Vec<u8>>>) -> TransactionSourceV0 {
+    TransactionSourceV0::CompiledV0(CompiledTransactionV0 {
+      num_rw_signers: 1,
+      num_ro_signers: 0,
+      num_rw: 2,
+      accounts: vec![Pubkey::new_unique(); 5],
+      instructions: (0..instructions)
+        .map(|i| CompiledInstructionV0 {
+          program_id_index: 4,
+          accounts: vec![0, 1, 2],
+          data: vec![i as u8; 17],
+        })
+        .collect(),
+      signer_seeds,
+    })
+  }
+
+  #[test]
+  fn the_space_reserved_is_the_space_the_account_needs() {
+    let cases = [
+      ("none", None),
+      (
+        "remote",
+        Some(TransactionSourceV0::RemoteV0 {
+          url: "https://hnt-rewards.oracle.helium.io/v1/tuktuk/asset/1".to_string(),
+          signer: Pubkey::new_unique(),
+        }),
+      ),
+      ("one instruction", Some(compiled(1, vec![]))),
+      ("twenty instructions", Some(compiled(20, vec![]))),
+      // Queuing is what holds a pre task to a shape, so init reserves space for one carrying
+      // seed groups of any width even though such a fanout never reaches distribution.
+      (
+        "seed groups",
+        Some(compiled(
+          2,
+          vec![
+            vec![b"helium".to_vec(), vec![253]],
+            vec![],
+            vec![b"a".to_vec(), b"much-longer-seed".to_vec(), vec![1, 2, 3]],
+          ],
+        )),
+      ),
+    ];
+
+    for (name, pre_task) in cases {
+      let args = args(pre_task);
+      let reserved = MiniFanoutV0::size(&args);
+      let needed = 8
+        + stored(&args)
+          .try_to_vec()
+          .expect("serialize the account")
+          .len();
+
+      assert!(
+        reserved >= needed,
+        "{name}: reserved {reserved} < needed {needed}"
+      );
+      assert_eq!(
+        reserved - needed,
+        RESERVE,
+        "{name}: reserved {reserved}, needed {needed}"
+      );
+    }
+  }
 }

--- a/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
+++ b/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
@@ -12,6 +12,9 @@ use crate::{errors::ErrorCode, state::*};
 
 pub const MAX_SHARES: usize = 6;
 
+/// Reserved beyond what the account's contents need, so a later field fits without a resize.
+const RESERVE: usize = 60;
+
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
 pub struct InitializeMiniFanoutArgsV0 {
   pub schedule: String,
@@ -114,7 +117,7 @@ impl MiniFanoutV0 {
         }
       }
     }
-    size + 60 // extra space for future fields
+    size + RESERVE
   }
 }
 
@@ -169,6 +172,10 @@ pub fn handler(
     pre_task: args.pre_task,
   });
 
+  if let Some(pre_task) = &mini_fanout.pre_task {
+    validate_pre_task(pre_task)?;
+  }
+
   Ok(())
 }
 
@@ -177,8 +184,6 @@ mod tests {
   use tuktuk_program::{CompiledInstructionV0, CompiledTransactionV0};
 
   use super::*;
-
-  const RESERVE: usize = 60;
 
   /// The account `handler` writes for these args, so what `size` reserves can be measured
   /// against what storing it actually costs.

--- a/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
+++ b/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
@@ -132,6 +132,9 @@ pub fn handler(
     msg!("Invalid schedule {}", e);
     crate::errors::ErrorCode::InvalidSchedule
   })?;
+  if let Some(pre_task) = &args.pre_task {
+    validate_pre_task(pre_task)?;
+  }
 
   let mini_fanout = &mut ctx.accounts.mini_fanout;
   mini_fanout.set_inner(MiniFanoutV0 {

--- a/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
+++ b/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
@@ -212,14 +212,16 @@ mod tests {
   }
 
   fn args(pre_task: Option<TransactionSourceV0>) -> InitializeMiniFanoutArgsV0 {
+    args_with(pre_task, Share::Fixed { amount: 1 })
+  }
+
+  fn args_with(pre_task: Option<TransactionSourceV0>, share: Share) -> InitializeMiniFanoutArgsV0 {
     InitializeMiniFanoutArgsV0 {
       schedule: "0 0 * * * *".to_string(),
-      // Fixed rather than Share, which is the narrower of the two variants MiniFanoutShareV0
-      // reserves for, so a share costs exactly what it reserves.
       shares: vec![
         MiniFanoutShareArgV0 {
           wallet: Pubkey::new_unique(),
-          share: Share::Fixed { amount: 1 },
+          share,
         };
         MAX_SHARES
       ],
@@ -243,6 +245,23 @@ mod tests {
         .collect(),
       signer_seeds,
     })
+  }
+
+  #[test]
+  fn a_narrower_share_is_reserved_for_the_wider_one() {
+    // MiniFanoutShareV0 reserves for the wider of the two Share variants, so a fanout of the
+    // narrower one costs less than is set aside for it and never more.
+    let args = args_with(None, Share::Share { amount: 1 });
+    let reserved = MiniFanoutV0::size(&args);
+    let needed = 8
+      + stored(&args)
+        .try_to_vec()
+        .expect("serialize the account")
+        .len();
+
+    assert!(reserved >= needed, "reserved {reserved} < needed {needed}");
+    // Four bytes per share wider than Fixed, on top of the space held back for future fields.
+    assert_eq!(reserved - needed, RESERVE + 4 * MAX_SHARES);
   }
 
   #[test]

--- a/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
+++ b/programs/mini-fanout/src/instructions/initialize_mini_fanout_v0.rs
@@ -132,9 +132,6 @@ pub fn handler(
     msg!("Invalid schedule {}", e);
     crate::errors::ErrorCode::InvalidSchedule
   })?;
-  if let Some(pre_task) = &args.pre_task {
-    validate_pre_task(pre_task)?;
-  }
 
   let mini_fanout = &mut ctx.accounts.mini_fanout;
   mini_fanout.set_inner(MiniFanoutV0 {

--- a/programs/mini-fanout/src/instructions/schedule_task_v0.rs
+++ b/programs/mini-fanout/src/instructions/schedule_task_v0.rs
@@ -135,7 +135,7 @@ pub fn schedule_impl(ctx: &mut ScheduleTaskV0, args: ScheduleTaskArgsV0) -> Resu
   mini_fanout.next_task = ctx.task.key();
 
   // CPI to tuktuk to queue the tasks
-  if let Some(pre_task) = mini_fanout.pre_task.clone() {
+  if let Some(pre_task) = mini_fanout.pre_task_to_queue()? {
     mini_fanout.next_pre_task = ctx.pre_task.key();
     queue_task_v0(
       CpiContext::new_with_signer(

--- a/programs/mini-fanout/src/state.rs
+++ b/programs/mini-fanout/src/state.rs
@@ -32,7 +32,7 @@ pub struct MiniFanoutV0 {
 
 /// The two shapes a pre task may take: a remote transaction the Helium oracle signs, or a
 /// compiled transaction carrying no signer seeds.
-pub fn validate_pre_task(pre_task: &TransactionSourceV0) -> Result<()> {
+fn validate_pre_task(pre_task: &TransactionSourceV0) -> Result<()> {
   match pre_task {
     TransactionSourceV0::RemoteV0 { signer, .. } => {
       require_keys_eq!(*signer, ORACLE_SIGNER, ErrorCode::InvalidPreTask)
@@ -46,9 +46,8 @@ pub fn validate_pre_task(pre_task: &TransactionSourceV0) -> Result<()> {
 }
 
 impl MiniFanoutV0 {
-  /// The pre task to queue this cycle, checked against the rule every pre task must satisfy.
-  /// Queuing reads it through here rather than off the field, so a stored pre task is held to
-  /// the same rule as one being stored.
+  /// The pre task to queue this cycle. Every path that queues one reads it through here rather
+  /// than off the field, so the rule holds whenever the pre task was stored.
   pub fn pre_task_to_queue(&self) -> Result<Option<TransactionSourceV0>> {
     let Some(pre_task) = &self.pre_task else {
       return Ok(None);

--- a/programs/mini-fanout/src/state.rs
+++ b/programs/mini-fanout/src/state.rs
@@ -1,5 +1,8 @@
 use anchor_lang::prelude::*;
+use shared_utils::ORACLE_SIGNER;
 use tuktuk_program::TransactionSourceV0;
+
+use crate::errors::ErrorCode;
 
 // ["fanout", hash(name)]
 #[account]
@@ -25,6 +28,35 @@ pub struct MiniFanoutV0 {
   pub seed: Vec<u8>,
   pub next_pre_task: Pubkey,
   pub pre_task: Option<TransactionSourceV0>,
+}
+
+/// The two shapes a pre task may take: a remote transaction the Helium oracle signs, or a
+/// compiled transaction carrying no signer seeds.
+pub fn validate_pre_task(pre_task: &TransactionSourceV0) -> Result<()> {
+  match pre_task {
+    TransactionSourceV0::RemoteV0 { signer, .. } => {
+      require_keys_eq!(*signer, ORACLE_SIGNER, ErrorCode::InvalidPreTask)
+    }
+    TransactionSourceV0::CompiledV0(compiled) => {
+      require!(compiled.signer_seeds.is_empty(), ErrorCode::InvalidPreTask)
+    }
+  }
+
+  Ok(())
+}
+
+impl MiniFanoutV0 {
+  /// The pre task to queue this cycle, checked against the rule every pre task must satisfy.
+  /// Queuing reads it through here rather than off the field, so a stored pre task is held to
+  /// the same rule as one being stored.
+  pub fn pre_task_to_queue(&self) -> Result<Option<TransactionSourceV0>> {
+    let Some(pre_task) = &self.pre_task else {
+      return Ok(None);
+    };
+    validate_pre_task(pre_task)?;
+
+    Ok(Some(pre_task.clone()))
+  }
 }
 
 #[account]
@@ -78,4 +110,66 @@ macro_rules! queue_authority_seeds {
   ($fanout:expr) => {
     &[b"queue_authority", &[$fanout.queue_authority_bump]]
   };
+}
+
+#[cfg(test)]
+mod tests {
+  use tuktuk_program::CompiledTransactionV0;
+
+  use super::*;
+
+  fn remote(signer: Pubkey) -> TransactionSourceV0 {
+    TransactionSourceV0::RemoteV0 {
+      url: "https://hnt-rewards.oracle.helium.io/v1/tuktuk/asset/1".to_string(),
+      signer,
+    }
+  }
+
+  fn compiled(signer_seeds: Vec<Vec<Vec<u8>>>) -> TransactionSourceV0 {
+    TransactionSourceV0::CompiledV0(CompiledTransactionV0 {
+      signer_seeds,
+      ..Default::default()
+    })
+  }
+
+  #[test]
+  fn a_pre_task_is_oracle_signed_or_carries_no_seeds() {
+    validate_pre_task(&remote(ORACLE_SIGNER)).expect("the oracle's remote transaction");
+    validate_pre_task(&compiled(vec![])).expect("a compiled transaction with no seeds");
+
+    assert!(validate_pre_task(&remote(Pubkey::new_unique())).is_err());
+    assert!(validate_pre_task(&compiled(vec![vec![b"helium".to_vec(), vec![253]]])).is_err());
+    // An empty group is still a group.
+    assert!(validate_pre_task(&compiled(vec![vec![]])).is_err());
+  }
+
+  #[test]
+  fn queuing_holds_a_stored_pre_task_to_the_same_rule() {
+    let stored = |pre_task| MiniFanoutV0 {
+      pre_task,
+      ..Default::default()
+    };
+
+    assert!(stored(None)
+      .pre_task_to_queue()
+      .expect("no pre task")
+      .is_none());
+    assert!(stored(Some(remote(ORACLE_SIGNER)))
+      .pre_task_to_queue()
+      .expect("the oracle's remote transaction")
+      .is_some());
+    assert!(stored(Some(compiled(vec![])))
+      .pre_task_to_queue()
+      .expect("a compiled transaction with no seeds")
+      .is_some());
+
+    assert!(stored(Some(remote(Pubkey::new_unique())))
+      .pre_task_to_queue()
+      .is_err());
+    assert!(
+      stored(Some(compiled(vec![vec![b"helium".to_vec(), vec![253]]])))
+        .pre_task_to_queue()
+        .is_err()
+    );
+  }
 }

--- a/programs/mini-fanout/src/state.rs
+++ b/programs/mini-fanout/src/state.rs
@@ -31,8 +31,10 @@ pub struct MiniFanoutV0 {
 }
 
 /// The two shapes a pre task may take: a remote transaction the Helium oracle signs, or a
-/// compiled transaction carrying no signer seeds.
-fn validate_pre_task(pre_task: &TransactionSourceV0) -> Result<()> {
+/// compiled transaction carrying no signer seeds. Storing one holds it to this rule so the
+/// mistake is refused where it is made; queuing holds it again, which is what covers a pre
+/// task already on an account.
+pub(crate) fn validate_pre_task(pre_task: &TransactionSourceV0) -> Result<()> {
   match pre_task {
     TransactionSourceV0::RemoteV0 { signer, .. } => {
       require_keys_eq!(*signer, ORACLE_SIGNER, ErrorCode::InvalidPreTask)

--- a/programs/welcome-pack/Cargo.toml
+++ b/programs/welcome-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "welcome-pack"
-version = "0.0.3"
+version = "0.0.4"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/programs/welcome-pack/src/error.rs
+++ b/programs/welcome-pack/src/error.rs
@@ -18,4 +18,6 @@ pub enum ErrorCode {
   InvalidRewardsSplit,
   #[msg("Invalid schedule")]
   InvalidSchedule,
+  #[msg("Claim approval expires too far out")]
+  ClaimApprovalTooLong,
 }

--- a/programs/welcome-pack/src/instructions/claim_welcome_pack_v0.rs
+++ b/programs/welcome-pack/src/instructions/claim_welcome_pack_v0.rs
@@ -32,14 +32,13 @@ use crate::{error::ErrorCode, welcome_pack_seeds, WelcomePackV0, ATA_SIZE, FANOU
 /// is ever live for longer than this. Measured from the claim rather than from the signature,
 /// which carries no issuance time. The client offers a shorter window; this is the bound every
 /// approval is held to whatever offered it.
-pub const MAX_CLAIM_APPROVAL_SECONDS: i64 = 30 * 24 * 60 * 60;
+const MAX_CLAIM_APPROVAL_SECONDS: i64 = 30 * 24 * 60 * 60;
 
 /// An approval is claimable while its expiry is ahead of now and no further ahead than the
 /// window allows.
 fn check_approval_window(expiration_timestamp: i64, now: i64) -> Result<()> {
   require_gt!(expiration_timestamp, now, ErrorCode::ClaimApprovalExpired);
-  // Saturating here would put the bound at the end of time and admit everything, so a clock that
-  // leaves no room for the window refuses instead.
+  // The end of the window has to be representable, so a clock leaving no room for one refuses.
   let latest = now
     .checked_add(MAX_CLAIM_APPROVAL_SECONDS)
     .ok_or(error!(ErrorCode::ClaimApprovalTooLong))?;

--- a/programs/welcome-pack/src/instructions/claim_welcome_pack_v0.rs
+++ b/programs/welcome-pack/src/instructions/claim_welcome_pack_v0.rs
@@ -28,9 +28,29 @@ use tuktuk_program::{tuktuk::program::Tuktuk, TransactionSourceV0};
 
 use crate::{error::ErrorCode, welcome_pack_seeds, WelcomePackV0, ATA_SIZE, FANOUT_FUNDING_AMOUNT};
 
-/// The longest an invite approval may be good for. The client offers a shorter window than this;
-/// this is the outer bound every approval is held to, whatever offered it.
+/// How much of an approval's window may still be ahead of it when it is claimed, so no approval
+/// is ever live for longer than this. Measured from the claim rather than from the signature,
+/// which carries no issuance time. The client offers a shorter window; this is the bound every
+/// approval is held to whatever offered it.
 pub const MAX_CLAIM_APPROVAL_SECONDS: i64 = 30 * 24 * 60 * 60;
+
+/// An approval is claimable while its expiry is ahead of now and no further ahead than the
+/// window allows.
+fn check_approval_window(expiration_timestamp: i64, now: i64) -> Result<()> {
+  require_gt!(expiration_timestamp, now, ErrorCode::ClaimApprovalExpired);
+  // Saturating here would put the bound at the end of time and admit everything, so a clock that
+  // leaves no room for the window refuses instead.
+  let latest = now
+    .checked_add(MAX_CLAIM_APPROVAL_SECONDS)
+    .ok_or(error!(ErrorCode::ClaimApprovalTooLong))?;
+  require_gte!(
+    latest,
+    expiration_timestamp,
+    ErrorCode::ClaimApprovalTooLong
+  );
+
+  Ok(())
+}
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct ClaimWelcomePackArgsV0 {
@@ -124,20 +144,10 @@ pub fn handler<'info>(
   ctx: Context<'_, '_, '_, 'info, ClaimWelcomePackV0<'info>>,
   args: ClaimWelcomePackArgsV0,
 ) -> Result<()> {
-  let now = Clock::get()?.unix_timestamp;
-  require_gt!(
+  check_approval_window(
     args.approval_expiration_timestamp,
-    now,
-    ErrorCode::ClaimApprovalExpired
-  );
-  // An approval names its own expiry, so how long one lasts is settled here rather than by the
-  // client that offered it. An invite is acted on in days; the owner signs a fresh one whenever
-  // they need to.
-  require_gte!(
-    now + MAX_CLAIM_APPROVAL_SECONDS,
-    args.approval_expiration_timestamp,
-    ErrorCode::ClaimApprovalTooLong
-  );
+    Clock::get()?.unix_timestamp,
+  )?;
   let msg = format!(
     "Approve invite {} expiring {}",
     ctx.accounts.welcome_pack.unique_id, args.approval_expiration_timestamp
@@ -327,4 +337,25 @@ pub fn handler<'info>(
   }
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn an_approval_is_claimable_inside_its_window_only() {
+    let now = 1_800_000_000;
+
+    check_approval_window(now + 1, now).expect("a second of window left");
+    check_approval_window(now + MAX_CLAIM_APPROVAL_SECONDS, now).expect("the whole window");
+
+    // Expired, and expiring exactly now, which is no window at all.
+    assert!(check_approval_window(now, now).is_err());
+    assert!(check_approval_window(now - 1, now).is_err());
+    // Further ahead than the window reaches.
+    assert!(check_approval_window(now + MAX_CLAIM_APPROVAL_SECONDS + 1, now).is_err());
+    // A clock near the end of time still refuses rather than wrapping into acceptance.
+    assert!(check_approval_window(i64::MAX, i64::MAX - 1).is_err());
+  }
 }

--- a/programs/welcome-pack/src/instructions/claim_welcome_pack_v0.rs
+++ b/programs/welcome-pack/src/instructions/claim_welcome_pack_v0.rs
@@ -28,6 +28,10 @@ use tuktuk_program::{tuktuk::program::Tuktuk, TransactionSourceV0};
 
 use crate::{error::ErrorCode, welcome_pack_seeds, WelcomePackV0, ATA_SIZE, FANOUT_FUNDING_AMOUNT};
 
+/// The longest an invite approval may be good for. The client offers a shorter window than this;
+/// this is the outer bound every approval is held to, whatever offered it.
+pub const MAX_CLAIM_APPROVAL_SECONDS: i64 = 30 * 24 * 60 * 60;
+
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct ClaimWelcomePackArgsV0 {
   pub data_hash: [u8; 32],
@@ -120,10 +124,19 @@ pub fn handler<'info>(
   ctx: Context<'_, '_, '_, 'info, ClaimWelcomePackV0<'info>>,
   args: ClaimWelcomePackArgsV0,
 ) -> Result<()> {
+  let now = Clock::get()?.unix_timestamp;
   require_gt!(
     args.approval_expiration_timestamp,
-    Clock::get()?.unix_timestamp,
+    now,
     ErrorCode::ClaimApprovalExpired
+  );
+  // An approval names its own expiry, so how long one lasts is settled here rather than by the
+  // client that offered it. An invite is acted on in days; the owner signs a fresh one whenever
+  // they need to.
+  require_gte!(
+    now + MAX_CLAIM_APPROVAL_SECONDS,
+    args.approval_expiration_timestamp,
+    ErrorCode::ClaimApprovalTooLong
   );
   let msg = format!(
     "Approve invite {} expiring {}",

--- a/tests/mini-fanout-bankrun.ts
+++ b/tests/mini-fanout-bankrun.ts
@@ -1,9 +1,37 @@
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
-import { PublicKey } from "@solana/web3.js";
+import { Tuktuk } from "@helium/tuktuk-idls/lib/types/tuktuk";
+import {
+  compileTransaction,
+  init as initTuktuk,
+  nextAvailableTaskIds,
+  runTask,
+  taskKey,
+  taskQueueKey,
+  taskQueueNameMappingKey,
+  tuktukConfigKey,
+} from "@helium/tuktuk-sdk";
+import { createMemoInstruction } from "@solana/spl-memo";
+import {
+  AccountLayout,
+  createAssociatedTokenAccountIdempotentInstruction,
+  createInitializeMint2Instruction,
+  createMintToInstruction,
+  getAssociatedTokenAddressSync,
+  MINT_SIZE,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
 import { BankrunProvider } from "anchor-bankrun";
 import { ProgramTestContext } from "solana-bankrun";
 import { expect } from "chai";
+import { queueAuthorityKey } from "../packages/mini-fanout-sdk/src";
 import { MiniFanout } from "../target/types/mini_fanout";
 import {
   ensureCloned,
@@ -11,19 +39,102 @@ import {
   overwriteAccountData,
   readAccount,
   startBankrun,
-  warpBy,
+  warpTo,
 } from "./utils/bankrun";
 
 const MINI_FANOUT = new PublicKey("mfanLprNnaiP4RX9Zz1BMcDosYHCqnG24H1fMEbi9Gn");
 const TUKTUK = new PublicKey("tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA");
-// The queue mini-fanout runs on, cloned so a fanout can be created against real state.
-const TASK_QUEUE = new PublicKey("H39gEszvsi6AT4rYBiJTuZHJSF5hMHy6CKGTd7wzhsg7");
+// tuktuk's config, and the IDL account `initTuktuk` reads to build its Program. Both are what
+// `Anchor.toml` clones for the localnet suites, so both suites run against the same tuktuk.
+const TUKTUK_CONFIG = tuktukConfigKey()[0];
+const TUKTUK_IDL = new PublicKey(
+  "GkUxZMcw2RbwZ64VL3MvBtYNV8zim3y7UfzabFTybAUJ"
+);
+
+const FANOUT_AMOUNT = 1000000000;
+// No cron string can be "two seconds from now" without racing the run that reads it. Under
+// bankrun the trigger is reached by moving the clock, so the schedule is an ordinary one.
+const HOURLY = "0 0 * * * *";
+
+/** The logs of a failed transaction, which is where an Anchor error names itself. */
+async function programErrorLogs(run: Promise<unknown>): Promise<string> {
+  try {
+    await run;
+  } catch (e: any) {
+    return [String(e.message ?? e), ...(e.logs ?? [])].join("\n");
+  }
+  throw new Error("expected the transaction to fail, and it succeeded");
+}
+
+async function tokenAmount(
+  ctx: ProgramTestContext,
+  address: PublicKey
+): Promise<bigint> {
+  const data = await readAccount(ctx, address);
+  if (!data) {
+    throw new Error(`no token account at ${address.toBase58()}`);
+  }
+  return AccountLayout.decode(data).amount;
+}
 
 describe("mini-fanout under bankrun", () => {
   let ctx: ProgramTestContext;
   let provider: BankrunProvider;
   let program: Program<MiniFanout>;
+  let tuktukProgram: Program<Tuktuk>;
   let me: PublicKey;
+  let mint: PublicKey;
+  let taskQueue: PublicKey;
+
+  const queueAuthority = queueAuthorityKey()[0];
+
+  // compileTransaction hands the account list back separately so it can ride as remaining
+  // accounts on queue_task_v0, which merges them in. A pre task is stored on the fanout
+  // instead, so it has to carry its own accounts for program_id_index to resolve against.
+  const memoPreTask = (() => {
+    const { transaction, remainingAccounts } = compileTransaction(
+      [createMemoInstruction("HELLO!", [])],
+      []
+    );
+    return { ...transaction, accounts: remainingAccounts.map((a) => a.pubkey) };
+  })();
+
+  const send = (instructions: anchor.web3.TransactionInstruction[]) =>
+    provider.sendAndConfirm(new Transaction().add(...instructions));
+
+  async function createMint(): Promise<PublicKey> {
+    const mintKeypair = Keypair.generate();
+    const lamports = await provider.connection.getMinimumBalanceForRentExemption(
+      MINT_SIZE
+    );
+    await provider.sendAndConfirm(
+      new Transaction().add(
+        SystemProgram.createAccount({
+          fromPubkey: me,
+          newAccountPubkey: mintKeypair.publicKey,
+          space: MINT_SIZE,
+          lamports,
+          programId: TOKEN_PROGRAM_ID,
+        }),
+        createInitializeMint2Instruction(mintKeypair.publicKey, 8, me, me)
+      ),
+      [mintKeypair]
+    );
+    return mintKeypair.publicKey;
+  }
+
+  /** The wallet's ATA, created if absent and credited with `amount`. */
+  async function ataWith(owner: PublicKey, amount: number, allowOwnerOffCurve = false) {
+    const ata = getAssociatedTokenAddressSync(mint, owner, allowOwnerOffCurve);
+    const instructions = [
+      createAssociatedTokenAccountIdempotentInstruction(me, ata, owner, mint),
+    ];
+    if (amount > 0) {
+      instructions.push(createMintToInstruction(mint, ata, me, amount));
+    }
+    await send(instructions);
+    return ata;
+  }
 
   before(async () => {
     ensureDumped("tuktuk", TUKTUK);
@@ -32,80 +143,255 @@ describe("mini-fanout under bankrun", () => {
         { name: "mini_fanout", programId: MINI_FANOUT },
         { name: "tuktuk", programId: TUKTUK },
       ],
-      [ensureCloned("task_queue_h39", TASK_QUEUE)]
+      [
+        ensureCloned("tuktuk_config", TUKTUK_CONFIG),
+        ensureCloned("tuktuk_idl", TUKTUK_IDL),
+      ]
     );
     provider = new BankrunProvider(ctx);
     program = new Program<MiniFanout>(
       require("../target/idl/mini_fanout.json"),
       provider
     );
+    tuktukProgram = await initTuktuk(provider);
     me = provider.wallet.publicKey;
+    mint = await createMint();
+
+    const name = "bankrun";
+    const { nextTaskQueueId } = await tuktukProgram.account.tuktukConfigV0.fetch(
+      TUKTUK_CONFIG
+    );
+    taskQueue = taskQueueKey(TUKTUK_CONFIG, nextTaskQueueId)[0];
+    await tuktukProgram.methods
+      .initializeTaskQueueV0({
+        name,
+        minCrankReward: new anchor.BN(1),
+        capacity: 1000,
+        lookupTables: [],
+        staleTaskAge: 10000,
+      })
+      .accounts({
+        tuktukConfig: TUKTUK_CONFIG,
+        payer: me,
+        updateAuthority: me,
+        taskQueue,
+        taskQueueNameMapping: taskQueueNameMappingKey(TUKTUK_CONFIG, name)[0],
+      })
+      .rpc();
+    await tuktukProgram.methods
+      .addQueueAuthorityV0()
+      .accounts({ payer: me, queueAuthority, taskQueue })
+      .rpc();
   });
 
-  it("runs both programs against cloned mainnet state", async () => {
-    for (const id of [MINI_FANOUT, TUKTUK]) {
-      const account = await ctx.banksClient.getAccount(id);
-      expect(account, id.toBase58()).to.not.be.null;
-      expect(account!.executable, id.toBase58()).to.be.true;
+  /**
+   * A fanout with its distribution scheduled: the same state the localnet suite reaches by
+   * waiting for a cron string two seconds out, minus the wait and the race.
+   */
+  async function scheduledFanout({
+    seed,
+    shares,
+    funding = FANOUT_AMOUNT,
+    preTask = { compiledV0: [memoPreTask as any] } as any,
+  }: {
+    seed: string;
+    shares: any[];
+    funding?: number;
+    preTask?: any;
+  }) {
+    const {
+      pubkeys: { miniFanout },
+    } = await program.methods
+      .initializeMiniFanoutV0({
+        seed: Buffer.from(seed, "utf-8"),
+        shares,
+        schedule: HOURLY,
+        preTask,
+      })
+      .accounts({ payer: me, owner: me, taskQueue, rentRefund: me, mint })
+      .rpcAndKeys();
+
+    // The crank reward comes out of the fanout's own lamports; without it distribute_v0
+    // unschedules itself instead of re-queuing, and never reads the pre task.
+    await send([
+      SystemProgram.transfer({
+        fromPubkey: me,
+        toPubkey: miniFanout!,
+        lamports: 1000000000,
+      }),
+    ]);
+
+    const { taskBitmap } = await tuktukProgram.account.taskQueueV0.fetch(taskQueue);
+    const [preTaskId, taskId] = nextAvailableTaskIds(taskBitmap, 2, false);
+    await program.methods
+      .scheduleTaskV0({ taskId, preTaskId })
+      .preInstructions([
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
+      ])
+      .accounts({
+        payer: me,
+        miniFanout: miniFanout!,
+        task: taskKey(taskQueue, taskId)[0],
+        preTask: taskKey(taskQueue, preTaskId)[0],
+      })
+      .rpc();
+
+    if (funding > 0) {
+      await ataWith(miniFanout!, funding, true);
     }
-    const queue = await ctx.banksClient.getAccount(TASK_QUEUE);
-    expect(queue).to.not.be.null;
-    expect(new PublicKey(queue!.owner).toBase58()).to.equal(TUKTUK.toBase58());
+    return {
+      miniFanout: miniFanout!,
+      task: taskKey(taskQueue, taskId)[0],
+      preTask: taskKey(taskQueue, preTaskId)[0],
+    };
+  }
+
+  const crank = async (task: PublicKey) =>
+    send([
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
+      ...(await runTask({ program: tuktukProgram, task, crankTurner: me })),
+    ]);
+
+  /**
+   * Run the pre task, then move the clock to the distribution's trigger. distribute_v0 refuses
+   * to run while the pre task account still exists, so the order is the chain's, not a choice.
+   */
+  async function reachDistribution(task: PublicKey, preTask: PublicKey) {
+    const { trigger } = await tuktukProgram.account.taskV0.fetch(task);
+    await warpTo(ctx, BigInt(trigger.timestamp![0].toString()));
+    await crank(preTask);
+    return () => crank(task);
+  }
+
+  const shareOf = (wallet: PublicKey, amount: number) => ({
+    wallet,
+    share: { share: { amount } },
   });
 
-  it("moves the clock, so a timestamp trigger does not have to be waited for", async () => {
-    const before = (await ctx.banksClient.getClock()).unixTimestamp;
-    await warpBy(ctx, 86_400n);
-    const after = (await ctx.banksClient.getClock()).unixTimestamp;
-    expect(after - before).to.equal(86_400n);
+  it("distributes to wallets when the clock reaches the trigger", async () => {
+    const [wallet1, wallet2, wallet3] = [
+      Keypair.generate(),
+      Keypair.generate(),
+      Keypair.generate(),
+    ];
+    // wallet2 gets no ATA on purpose: its payout has nowhere to go and must be recorded as
+    // owed rather than silently dropped.
+    const wallet1Ata = await ataWith(wallet1.publicKey, 0);
+    const wallet3Ata = await ataWith(wallet3.publicKey, 0);
+
+    const { miniFanout, task, preTask } = await scheduledFanout({
+      seed: "distributes",
+      shares: [
+        shareOf(wallet1.publicKey, 50),
+        shareOf(wallet2.publicKey, 50),
+        { wallet: wallet3.publicKey, share: { fixed: { amount: new anchor.BN(100000000) } } },
+      ],
+    });
+    const fanoutAta = getAssociatedTokenAddressSync(mint, miniFanout, true);
+
+    const distribute = await reachDistribution(task, preTask);
+    await distribute();
+
+    expect(Number(await tokenAmount(ctx, fanoutAta))).to.equal(450000000);
+    expect(Number(await tokenAmount(ctx, wallet1Ata))).to.equal(450000000);
+    expect(Number(await tokenAmount(ctx, wallet3Ata))).to.equal(100000000);
+
+    const acc = await program.account.miniFanoutV0.fetch(miniFanout);
+    // There was no ATA for this wallet, so the total owed is the amount we couldn't transfer
+    expect(acc.shares[1].totalOwed.toNumber()).to.equal(450000000);
+
+    // distribute_v0 re-queues both tasks every cycle, so this is the read-through at that call
+    // site: the stored pre task reaches the queue, and it carries no free tasks, which is what
+    // keeps a pre task from spawning children of its own.
+    expect(await tuktukProgram.account.taskV0.fetch(acc.nextTask)).to.not.be.null;
+    const nextPreTask = await tuktukProgram.account.taskV0.fetch(acc.nextPreTask);
+    expect(nextPreTask.freeTasks).to.equal(0);
+    expect(nextPreTask.transaction.compiledV0![0].instructions.length).to.equal(1);
+    expect(nextPreTask.transaction.compiledV0![0].signerSeeds).to.deep.equal([]);
+  });
+
+  it("distributes to 6 wallets in one transaction", async () => {
+    const wallets = Array.from({ length: 6 }, () => Keypair.generate());
+    const atas = [];
+    for (const w of wallets) {
+      atas.push(await ataWith(w.publicKey, 0));
+    }
+
+    const { miniFanout, task, preTask } = await scheduledFanout({
+      seed: "six-wallets",
+      shares: wallets.map((w) => shareOf(w.publicKey, 10)),
+      funding: 600000000,
+    });
+    const fanoutAta = getAssociatedTokenAddressSync(mint, miniFanout, true);
+
+    const distribute = await reachDistribution(task, preTask);
+    await distribute();
+
+    expect(Number(await tokenAmount(ctx, fanoutAta))).to.equal(0);
+    for (const ata of atas) {
+      expect(Number(await tokenAmount(ctx, ata))).to.equal(100000000);
+    }
+  });
+
+  it("refuses to re-queue a stored pre task that does not satisfy the rule", async () => {
+    const wallet = Keypair.generate();
+    await ataWith(wallet.publicKey, 0);
+
+    const { miniFanout, task, preTask } = await scheduledFanout({
+      seed: "stored-before",
+      shares: [shareOf(wallet.publicKey, 100)],
+    });
+
+    // A fanout whose stored pre task the program would not write today: scheduled while it
+    // still conformed, then rewritten underneath. Only bankrun can produce it, and it is the
+    // only way distribute_v0's read of the pre task is reached with anything to refuse.
+    const acc = await program.account.miniFanoutV0.fetch(miniFanout);
+    const encoded = await program.coder.accounts.encode("miniFanoutV0", {
+      ...acc,
+      preTask: {
+        compiledV0: [
+          {
+            ...acc.preTask!.compiledV0![0],
+            signerSeeds: [[Buffer.from("helium", "utf-8"), Buffer.from([253])]],
+          },
+        ],
+      },
+    });
+    const original = await readAccount(ctx, miniFanout);
+    expect(encoded.length).to.be.at.most(original!.length);
+    const rewritten = Buffer.alloc(original!.length);
+    encoded.copy(rewritten);
+    await overwriteAccountData(ctx, miniFanout, rewritten);
+
+    // The rewrite has to have taken, or the refusal below would be asserting nothing.
+    const stored = await program.account.miniFanoutV0.fetch(miniFanout);
+    expect(stored.preTask!.compiledV0![0].signerSeeds.length).to.equal(1);
+
+    const distribute = await reachDistribution(task, preTask);
+    expect(await programErrorLogs(distribute())).to.match(
+      /Error Code: InvalidPreTask\. Error Number: 6011\./
+    );
   });
 
   it("rewrites an account the programs would not produce", async () => {
-    // The capability the localnet suites lack. A guard that only fires on data a program
-    // refuses to write is unreachable without this.
-    const original = await readAccount(ctx, TASK_QUEUE);
+    // The capability the localnet suites lack, checked directly: a guard that only fires on
+    // data a program refuses to write is unreachable without it.
+    const original = await readAccount(ctx, taskQueue);
     expect(original).to.not.be.null;
 
     const scrambled = Buffer.from(original!);
     scrambled[scrambled.length - 1] ^= 0xff;
-    await overwriteAccountData(ctx, TASK_QUEUE, scrambled);
+    await overwriteAccountData(ctx, taskQueue, scrambled);
 
-    const readBack = await readAccount(ctx, TASK_QUEUE);
+    const readBack = await readAccount(ctx, taskQueue);
     expect(readBack!.equals(scrambled)).to.be.true;
     expect(readBack!.equals(original!)).to.be.false;
 
     // Owner and executable survive the rewrite, or later instructions fail for the wrong reason.
-    const account = await ctx.banksClient.getAccount(TASK_QUEUE);
+    const account = await ctx.banksClient.getAccount(taskQueue);
     expect(new PublicKey(account!.owner).toBase58()).to.equal(TUKTUK.toBase58());
 
-    await overwriteAccountData(ctx, TASK_QUEUE, original!);
-    expect((await readAccount(ctx, TASK_QUEUE))!.equals(original!)).to.be.true;
-  });
-
-  it("reaches the program's own error path", async () => {
-    // Proves the whole provider -> build -> sign -> execute path, not just construction:
-    // the failure is the program's, at a named constraint.
-    let message = "";
-    try {
-      await program.methods
-        .initializeMiniFanoutV0({
-          seed: Buffer.from("bankrun"),
-          shares: [{ wallet: PublicKey.default, share: { share: { amount: 1 } } }],
-          schedule: "0 0 * * * *",
-          preTask: null,
-        })
-        .accounts({
-          payer: me,
-          owner: me,
-          taskQueue: PublicKey.default,
-          rentRefund: me,
-          mint: PublicKey.default,
-        })
-        .rpc();
-    } catch (e: any) {
-      message = String(e.message ?? e);
-    }
-    expect(message).to.include("task_queue");
-    expect(message).to.include("AccountOwnedByWrongProgram");
+    await overwriteAccountData(ctx, taskQueue, original!);
+    expect((await readAccount(ctx, taskQueue))!.equals(original!)).to.be.true;
   });
 });

--- a/tests/mini-fanout-bankrun.ts
+++ b/tests/mini-fanout-bankrun.ts
@@ -342,9 +342,9 @@ describe("mini-fanout under bankrun", () => {
       shares: [shareOf(wallet.publicKey, 100)],
     });
 
-    // A fanout whose stored pre task the program would not write today: scheduled while it
-    // still conformed, then rewritten underneath. Only bankrun can produce it, and it is the
-    // only way distribute_v0's read of the pre task is reached with anything to refuse.
+    // A fanout carrying a pre task neither instruction would store: scheduled while it
+    // conformed, then rewritten underneath. Only bankrun can produce it, and it is what
+    // reaches distribute_v0's read of the pre task with something to refuse.
     const acc = await program.account.miniFanoutV0.fetch(miniFanout);
     const encoded = await program.coder.accounts.encode("miniFanoutV0", {
       ...acc,

--- a/tests/mini-fanout.ts
+++ b/tests/mini-fanout.ts
@@ -17,8 +17,7 @@ chai.use(chaiAsPromised);
 export const ANCHOR_PATH = "anchor";
 
 // shared_utils::ORACLE_SIGNER, which the tests build against because `anchor build` here runs
-// without the `devnet` feature. Changing the constant makes these tests fail rather than pass
-// against a stale value.
+// without the `devnet` feature.
 const ORACLE_SIGNER = new PublicKey(
   "orc1TYY5L4B4ZWDEMayTqu99ikPM9bQo9fqzoaCPP5Q"
 );
@@ -189,12 +188,11 @@ describe("mini-fanout", () => {
   });
 
   describe("pre task shapes", () => {
-    // Distinct per case so each lands on its own fanout PDA rather than colliding with a
-    // previous one and failing for the wrong reason.
-    let caseId = 0;
+    const ORACLE_URL = "https://hnt-rewards.oracle.helium.io/v1/tuktuk/asset/1"
+
     const initWith = (preTask: any) =>
       program.methods.initializeMiniFanoutV0({
-        seed: Buffer.from(`${fanoutName}-shape-${caseId++}`, "utf-8"),
+        seed: Buffer.from(fanoutName, "utf-8"),
         shares,
         schedule: "0 0 * * * *",
         preTask,
@@ -208,54 +206,70 @@ describe("mini-fanout", () => {
         })
         .rpcAndKeys()
 
+    const scheduleFor = async (miniFanout: PublicKey) => {
+      const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(taskQueue)
+      const [preTaskId, taskId] = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 2, true)
+      return program.methods.scheduleTaskV0({ taskId, preTaskId })
+        .preInstructions([ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 })])
+        .accounts({
+          payer: me,
+          miniFanout,
+          task: taskKey(taskQueue, taskId)[0],
+          preTask: taskKey(taskQueue, preTaskId)[0],
+        })
+        .rpc()
+    }
+
     const refused = /Error Code: InvalidPreTask\. Error Number: 6011\./
 
-    it("stores a remote pre task the oracle signs", async () => {
+    it("queues a remote pre task the oracle signs", async () => {
       const { pubkeys: { miniFanout } } = await initWith({
-        remoteV0: {
-          url: "https://hnt-rewards.oracle.helium.io/v1/tuktuk/asset/1",
-          signer: ORACLE_SIGNER,
-        },
+        remoteV0: { url: ORACLE_URL, signer: ORACLE_SIGNER },
       })
 
       const acc = await program.account.miniFanoutV0.fetch(miniFanout)
       expect(acc.preTask!.remoteV0!.signer.toBase58()).to.equal(ORACLE_SIGNER.toBase58())
+      await scheduleFor(miniFanout)
     })
 
-    it("refuses a remote pre task signed by anyone else", async () => {
-      await expect(initWith({
-        remoteV0: {
-          url: "https://hnt-rewards.oracle.helium.io/v1/tuktuk/asset/1",
-          signer: Keypair.generate().publicKey,
-        },
-      })).to.eventually.be.rejectedWith(refused)
-    })
-
-    it("stores a compiled pre task carrying no seeds", async () => {
+    it("queues a compiled pre task carrying no seeds", async () => {
       const { pubkeys: { miniFanout } } = await initWith({
         compiledV0: [memoPreTask as any],
       })
 
-      // The instruction has to survive the round trip, or a refusal below could be passing
+      // The instruction has to survive the round trip, or the refusals below could be passing
       // because the transaction arrived empty rather than because it was refused.
       const acc = await program.account.miniFanoutV0.fetch(miniFanout)
       expect(acc.preTask!.compiledV0![0].instructions.length).to.equal(1)
       expect(acc.preTask!.compiledV0![0].signerSeeds).to.deep.equal([])
+      await scheduleFor(miniFanout)
     })
 
-    it("refuses a compiled pre task carrying signer seeds", async () => {
-      await expect(initWith({
+    it("refuses to queue a remote pre task signed by anyone else", async () => {
+      const { pubkeys: { miniFanout } } = await initWith({
+        remoteV0: { url: ORACLE_URL, signer: Keypair.generate().publicKey },
+      })
+
+      await expect(scheduleFor(miniFanout)).to.eventually.be.rejectedWith(refused)
+    })
+
+    it("refuses to queue a compiled pre task carrying signer seeds", async () => {
+      const { pubkeys: { miniFanout } } = await initWith({
         compiledV0: [{
           ...(memoPreTask as any),
           signerSeeds: [[Buffer.from("helium", "utf-8"), Buffer.from([253])]],
         }],
-      })).to.eventually.be.rejectedWith(refused)
+      })
+
+      await expect(scheduleFor(miniFanout)).to.eventually.be.rejectedWith(refused)
     })
 
-    it("refuses a compiled pre task carrying an empty seed group", async () => {
-      await expect(initWith({
+    it("refuses to queue a compiled pre task carrying an empty seed group", async () => {
+      const { pubkeys: { miniFanout } } = await initWith({
         compiledV0: [{ ...(memoPreTask as any), signerSeeds: [[]] }],
-      })).to.eventually.be.rejectedWith(refused)
+      })
+
+      await expect(scheduleFor(miniFanout)).to.eventually.be.rejectedWith(refused)
     })
   })
 

--- a/tests/mini-fanout.ts
+++ b/tests/mini-fanout.ts
@@ -6,12 +6,22 @@ import { compileTransaction, init as initTuktuk, nextAvailableTaskIds, runTask, 
 import { getAccount, getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { createMemoInstruction } from "@solana/spl-memo";
 import { ComputeBudgetProgram, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
-import { expect } from "chai";
+import chai, { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { execSync } from "child_process";
 import { init, PROGRAM_ID, queueAuthorityKey } from "../packages/mini-fanout-sdk/src";
 import { MiniFanout } from "../target/types/mini_fanout";
 
+chai.use(chaiAsPromised);
+
 export const ANCHOR_PATH = "anchor";
+
+// shared_utils::ORACLE_SIGNER, which the tests build against because `anchor build` here runs
+// without the `devnet` feature. Changing the constant makes these tests fail rather than pass
+// against a stale value.
+const ORACLE_SIGNER = new PublicKey(
+  "orc1TYY5L4B4ZWDEMayTqu99ikPM9bQo9fqzoaCPP5Q"
+);
 
 export async function ensureIdls() {
   let programs = [
@@ -56,13 +66,16 @@ describe("mini-fanout", () => {
   const queueAuthority = queueAuthorityKey()[0]
   const FANOUT_AMOUNT = 1000000000
 
-  const memoPreTask = compileTransaction([
-    createMemoInstruction(
-      "HELLO!",
+  // compileTransaction hands the account list back separately so it can ride as remaining
+  // accounts on queue_task_v0, which merges them in. A pre task is stored on the fanout
+  // instead, so it has to carry its own accounts for program_id_index to resolve against.
+  const memoPreTask = (() => {
+    const { transaction, remainingAccounts } = compileTransaction(
+      [createMemoInstruction("HELLO!", [])],
       []
-    ),
-  ],
-    [])
+    )
+    return { ...transaction, accounts: remainingAccounts.map((a) => a.pubkey) }
+  })()
 
   let taskQueue: PublicKey;
   before(async () => {
@@ -147,7 +160,7 @@ describe("mini-fanout", () => {
       seed: Buffer.from(fanoutName, "utf-8"),
       shares,
       schedule: "0 0 * * * *",
-      preTask: { compiledV0: memoPreTask.transaction as any }
+      preTask: { compiledV0: [memoPreTask as any] }
     })
       .accounts({
         payer: me,
@@ -175,6 +188,77 @@ describe("mini-fanout", () => {
     }
   });
 
+  describe("pre task shapes", () => {
+    // Distinct per case so each lands on its own fanout PDA rather than colliding with a
+    // previous one and failing for the wrong reason.
+    let caseId = 0;
+    const initWith = (preTask: any) =>
+      program.methods.initializeMiniFanoutV0({
+        seed: Buffer.from(`${fanoutName}-shape-${caseId++}`, "utf-8"),
+        shares,
+        schedule: "0 0 * * * *",
+        preTask,
+      })
+        .accounts({
+          payer: me,
+          owner: me,
+          taskQueue,
+          rentRefund: me,
+          mint,
+        })
+        .rpcAndKeys()
+
+    const refused = /Error Code: InvalidPreTask\. Error Number: 6011\./
+
+    it("stores a remote pre task the oracle signs", async () => {
+      const { pubkeys: { miniFanout } } = await initWith({
+        remoteV0: {
+          url: "https://hnt-rewards.oracle.helium.io/v1/tuktuk/asset/1",
+          signer: ORACLE_SIGNER,
+        },
+      })
+
+      const acc = await program.account.miniFanoutV0.fetch(miniFanout)
+      expect(acc.preTask!.remoteV0!.signer.toBase58()).to.equal(ORACLE_SIGNER.toBase58())
+    })
+
+    it("refuses a remote pre task signed by anyone else", async () => {
+      await expect(initWith({
+        remoteV0: {
+          url: "https://hnt-rewards.oracle.helium.io/v1/tuktuk/asset/1",
+          signer: Keypair.generate().publicKey,
+        },
+      })).to.eventually.be.rejectedWith(refused)
+    })
+
+    it("stores a compiled pre task carrying no seeds", async () => {
+      const { pubkeys: { miniFanout } } = await initWith({
+        compiledV0: [memoPreTask as any],
+      })
+
+      // The instruction has to survive the round trip, or a refusal below could be passing
+      // because the transaction arrived empty rather than because it was refused.
+      const acc = await program.account.miniFanoutV0.fetch(miniFanout)
+      expect(acc.preTask!.compiledV0![0].instructions.length).to.equal(1)
+      expect(acc.preTask!.compiledV0![0].signerSeeds).to.deep.equal([])
+    })
+
+    it("refuses a compiled pre task carrying signer seeds", async () => {
+      await expect(initWith({
+        compiledV0: [{
+          ...(memoPreTask as any),
+          signerSeeds: [[Buffer.from("helium", "utf-8"), Buffer.from([253])]],
+        }],
+      })).to.eventually.be.rejectedWith(refused)
+    })
+
+    it("refuses a compiled pre task carrying an empty seed group", async () => {
+      await expect(initWith({
+        compiledV0: [{ ...(memoPreTask as any), signerSeeds: [[]] }],
+      })).to.eventually.be.rejectedWith(refused)
+    })
+  })
+
   describe("with a fanout", () => {
     let fanout: PublicKey;
     let cronJob: PublicKey;
@@ -194,7 +278,7 @@ describe("mini-fanout", () => {
         // Run in 2 seconds
         schedule: `${nextSeconds} ${nextMinutes} * * * *`,
         shares,
-        preTask: { compiledV0: memoPreTask.transaction as any }
+        preTask: { compiledV0: [memoPreTask as any] }
       })
         .accounts({
           payer: me,
@@ -417,7 +501,7 @@ describe("mini-fanout", () => {
         seed: Buffer.from(fanoutName + 'big', "utf-8"),
         schedule: `${nextSeconds} ${nextMinutes} * * * *`,
         shares,
-        preTask: { compiledV0: memoPreTask.transaction as any }
+        preTask: { compiledV0: [memoPreTask as any] }
       })
         .accounts({
           payer: me,

--- a/tests/mini-fanout.ts
+++ b/tests/mini-fanout.ts
@@ -22,6 +22,12 @@ const ORACLE_SIGNER = new PublicKey(
   "orc1TYY5L4B4ZWDEMayTqu99ikPM9bQo9fqzoaCPP5Q"
 );
 
+// A schedule whose next occurrence is always a second away, however long the setup before it
+// took. A cron string built from `now + 2 seconds` is only correct if the transactions that
+// follow it land inside those two seconds; when they don't, the next occurrence is an hour
+// out and the run fails on balances rather than on the thing under test.
+const EVERY_SECOND = "* * * * * *";
+
 export async function ensureIdls() {
   let programs = [
     {
@@ -275,22 +281,13 @@ describe("mini-fanout", () => {
 
   describe("with a fanout", () => {
     let fanout: PublicKey;
-    let cronJob: PublicKey;
     beforeEach(async () => {
       const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(taskQueue)
       const [nextPreTask, nextTask] = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 2, true)
 
-      const now = new Date()
-      let nextSeconds = now.getSeconds() + 2
-      let nextMinutes = now.getMinutes()
-      if (nextSeconds > 59) {
-        nextSeconds = 0 + (nextSeconds - 59)
-        nextMinutes = now.getMinutes() + 1
-      }
       const { pubkeys: { miniFanout: fanoutK } } = await program.methods.initializeMiniFanoutV0({
         seed: Buffer.from(fanoutName, "utf-8"),
-        // Run in 2 seconds
-        schedule: `${nextSeconds} ${nextMinutes} * * * *`,
+        schedule: EVERY_SECOND,
         shares,
         preTask: { compiledV0: [memoPreTask as any] }
       })
@@ -445,61 +442,10 @@ describe("mini-fanout", () => {
       }
     }
 
-    it("should distribute tokens to wallets", async () => {
-      await new Promise(resolve => setTimeout(resolve, 2000))
-      const wallet1TokenAccountBefore = await getAccount(
-        // @ts-ignore
-        provider.connection,
-        getAssociatedTokenAddressSync(mint, wallet1.publicKey)
-      );
-      const wallet3TokenAccountBefore = await getAccount(
-        // @ts-ignore
-        provider.connection,
-        getAssociatedTokenAddressSync(mint, wallet3.publicKey)
-      );
-      await runAllTasks()
-
-      // Verify the claims were processed
-      const fanoutTokenAccount = await getAccount(
-        // @ts-ignore
-        provider.connection,
-        getAssociatedTokenAddressSync(mint, fanout, true)
-      );
-      const wallet1TokenAccount = await getAccount(
-        // @ts-ignore
-        provider.connection,
-        getAssociatedTokenAddressSync(mint, wallet1.publicKey)
-      );
-      const wallet3TokenAccount = await getAccount(
-        // @ts-ignore
-        provider.connection,
-        getAssociatedTokenAddressSync(mint, wallet3.publicKey)
-      );
-
-      const miniFanoutAcc = await program.account.miniFanoutV0.fetch(fanout);
-      expect(Number(fanoutTokenAccount.amount)).to.equal(450000000);
-      expect(Number(wallet1TokenAccount.amount) - Number(wallet1TokenAccountBefore.amount)).to.equal(450000000);
-      // There was no ATA for this wallet, so the total owed is the amount we couldn't transfer
-      expect(Number(miniFanoutAcc.shares[1].totalOwed.toString())).to.equal(450000000);
-      expect(Number(wallet3TokenAccount.amount) - Number(wallet3TokenAccountBefore.amount)).to.equal(100000000);
-
-      // Verify vouchers were updated
-      const nextTask = miniFanoutAcc.nextTask
-      expect(
-        await tuktukProgram.account.taskV0.fetch(nextTask)
-      ).to.not.be.null
-
-      // distribute_v0 re-queues the pre task every cycle, so this is the read-through at that
-      // call site: the stored pre task reaches the queue, and it carries no free tasks, which
-      // is what keeps a pre task from spawning children of its own.
-      const nextPreTaskAcc = await tuktukProgram.account.taskV0.fetch(
-        miniFanoutAcc.nextPreTask
-      )
-      expect(nextPreTaskAcc.freeTasks).to.equal(0)
-      expect(nextPreTaskAcc.transaction.compiledV0![0].instructions.length).to.equal(1)
-      expect(nextPreTaskAcc.transaction.compiledV0![0].signerSeeds).to.deep.equal([])
-    })
-
+    // The widest distribution the program allows, and so the one whose compute cost the CU
+    // table is sized against. It runs against a validator rather than under bankrun because
+    // the sampler that keeps that table honest reads localnet traffic. The narrower cases,
+    // and the ones that need state a program will not write, are in mini-fanout-bankrun.ts.
     it("should distribute tokens to 6 wallets in one tx", async () => {
       const wallets = Array.from({ length: 6 }, () => Keypair.generate())
       const shares = wallets.map(w => ({
@@ -516,18 +462,10 @@ describe("mini-fanout", () => {
       const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(taskQueue)
       const [nextPreTask, nextTask] = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 2, true)
 
-      // Set up a fanout with 10 shares
-      const now = new Date()
-      let nextSeconds = now.getSeconds() + 2
-      let nextMinutes = now.getMinutes()
-      if (nextSeconds > 59) {
-        nextSeconds = 0 + (nextSeconds - 59)
-        nextMinutes = now.getMinutes() + 1
-      }
       console.log("creating fanout")
       const { pubkeys: { miniFanout: fanoutK } } = await program.methods.initializeMiniFanoutV0({
         seed: Buffer.from(fanoutName + 'big', "utf-8"),
-        schedule: `${nextSeconds} ${nextMinutes} * * * *`,
+        schedule: EVERY_SECOND,
         shares,
         preTask: { compiledV0: [memoPreTask as any] }
       })

--- a/tests/mini-fanout.ts
+++ b/tests/mini-fanout.ts
@@ -431,13 +431,17 @@ describe("mini-fanout", () => {
               })]
           );
         }
-      } catch (e) {
-        if (tries < 2) {
-          await new Promise(resolve => setTimeout(resolve, 1000))
-          await runAllTasks(tries + 1)
-        } else {
+      } catch (e: any) {
+        // Retry only what a retry can fix: a task whose trigger had not passed when it was
+        // tried. Retrying every error made a real failure read as intermittent and reported
+        // it three attempts late, against the wrong one of the three.
+        const notReady = String(e.message ?? e).includes("TaskNotReady")
+        if (!notReady || tries >= 2) {
           throw e
         }
+        console.log(`task not ready, retrying (${tries + 1}/2)`)
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        await runAllTasks(tries + 1)
       }
     }
 
@@ -484,6 +488,16 @@ describe("mini-fanout", () => {
       expect(
         await tuktukProgram.account.taskV0.fetch(nextTask)
       ).to.not.be.null
+
+      // distribute_v0 re-queues the pre task every cycle, so this is the read-through at that
+      // call site: the stored pre task reaches the queue, and it carries no free tasks, which
+      // is what keeps a pre task from spawning children of its own.
+      const nextPreTaskAcc = await tuktukProgram.account.taskV0.fetch(
+        miniFanoutAcc.nextPreTask
+      )
+      expect(nextPreTaskAcc.freeTasks).to.equal(0)
+      expect(nextPreTaskAcc.transaction.compiledV0![0].instructions.length).to.equal(1)
+      expect(nextPreTaskAcc.transaction.compiledV0![0].signerSeeds).to.deep.equal([])
     })
 
     it("should distribute tokens to 6 wallets in one tx", async () => {
@@ -524,7 +538,7 @@ describe("mini-fanout", () => {
           rentRefund: me,
           mint,
         })
-        .rpcAndKeys({ skipPreflight: true })
+        .rpcAndKeys()
 
       console.log("transferring")
       await sendInstructions(provider, [SystemProgram.transfer({
@@ -578,7 +592,7 @@ describe("mini-fanout", () => {
           miniFanout: fanout,
           taskRentRefund: me,
         })
-        .rpc({ skipPreflight: true })
+        .rpc()
     })
   })
 });

--- a/tests/mini-fanout.ts
+++ b/tests/mini-fanout.ts
@@ -251,31 +251,28 @@ describe("mini-fanout", () => {
       await scheduleFor(miniFanout)
     })
 
-    it("refuses to queue a remote pre task signed by anyone else", async () => {
-      const { pubkeys: { miniFanout } } = await initWith({
+    // Storing is refused, so these never reach a schedule. A pre task already on an account is
+    // held to the same rule when it is queued, which mini-fanout-bankrun.ts drives by writing
+    // one the program will not store.
+    it("refuses to store a remote pre task signed by anyone else", async () => {
+      await expect(initWith({
         remoteV0: { url: ORACLE_URL, signer: Keypair.generate().publicKey },
-      })
-
-      await expect(scheduleFor(miniFanout)).to.eventually.be.rejectedWith(refused)
+      })).to.eventually.be.rejectedWith(refused)
     })
 
-    it("refuses to queue a compiled pre task carrying signer seeds", async () => {
-      const { pubkeys: { miniFanout } } = await initWith({
+    it("refuses to store a compiled pre task carrying signer seeds", async () => {
+      await expect(initWith({
         compiledV0: [{
           ...(memoPreTask as any),
           signerSeeds: [[Buffer.from("helium", "utf-8"), Buffer.from([253])]],
         }],
-      })
-
-      await expect(scheduleFor(miniFanout)).to.eventually.be.rejectedWith(refused)
+      })).to.eventually.be.rejectedWith(refused)
     })
 
-    it("refuses to queue a compiled pre task carrying an empty seed group", async () => {
-      const { pubkeys: { miniFanout } } = await initWith({
+    it("refuses to store a compiled pre task carrying an empty seed group", async () => {
+      await expect(initWith({
         compiledV0: [{ ...(memoPreTask as any), signerSeeds: [[]] }],
-      })
-
-      await expect(scheduleFor(miniFanout)).to.eventually.be.rejectedWith(refused)
+      })).to.eventually.be.rejectedWith(refused)
     })
   })
 

--- a/tests/utils/bankrun.ts
+++ b/tests/utils/bankrun.ts
@@ -1,5 +1,3 @@
-import { Program, Idl } from "@coral-xyz/anchor";
-import { BankrunProvider } from "anchor-bankrun";
 import { Clock, ProgramTestContext, start } from "solana-bankrun";
 import { PublicKey } from "@solana/web3.js";
 import { execFileSync } from "child_process";
@@ -14,7 +12,7 @@ import { join } from "path";
  * there is no preflight to skip.
  */
 
-export const TARGET_DEPLOY = join(__dirname, "..", "..", "target", "deploy");
+const TARGET_DEPLOY = join(__dirname, "..", "..", "target", "deploy");
 
 // An SBF program is an ELF, and a truncated download is the failure this guards: a
 // present-but-unusable file would otherwise be taken for a cached one.
@@ -111,17 +109,6 @@ export async function startBankrun(
   return start(programs, accounts);
 }
 
-export function providerFor(ctx: ProgramTestContext): BankrunProvider {
-  return new BankrunProvider(ctx);
-}
-
-export function programFor<T extends Idl>(
-  idl: T,
-  provider: BankrunProvider
-): Program<T> {
-  return new Program<T>(idl, provider);
-}
-
 /**
  * Move the clock to `unixTimestamp`. `Clock` exposes getters only, so assigning to the value
  * returned by `getClock()` changes nothing and `setClock` then writes the original back --
@@ -142,11 +129,6 @@ export async function warpTo(ctx: ProgramTestContext, unixTimestamp: bigint) {
   if (now !== unixTimestamp) {
     throw new Error(`clock did not move: asked for ${unixTimestamp}, got ${now}`);
   }
-}
-
-export async function warpBy(ctx: ProgramTestContext, seconds: bigint) {
-  const { unixTimestamp } = await ctx.banksClient.getClock();
-  await warpTo(ctx, unixTimestamp + seconds);
 }
 
 /** The account's raw bytes, or null. Fails loudly rather than returning empty on a miss. */

--- a/tests/voter-stake-registry.ts
+++ b/tests/voter-stake-registry.ts
@@ -835,9 +835,13 @@ describe("voter-stake-registry", () => {
       });
 
       it("should not allow me to vote twice", async () => {
-        let error: any;
-        try {
-          await program.methods
+        // The refusal is what this test reads, so it runs preflight rather than taking the
+        // file's skipPreflight. Simulation returns the program's logs with the response, so
+        // Anchor raises an AnchorError naming the code; a sent transaction reports through
+        // confirmation instead, whose shape varies and which carries no code when it times
+        // out. Matching the message pins the name and the number together.
+        await expect(
+          program.methods
             .voteV0({
               choice: 0,
             })
@@ -849,17 +853,10 @@ describe("voter-stake-registry", () => {
               stateController: me,
               onVoteHook: PublicKey.default,
             })
-            .rpc({ skipPreflight: true });
-        } catch (e: any) {
-          error = e;
-        }
-        expect(error, "Expected vote to fail").to.exist;
-        // The error surfaces as an AnchorError, a raw InstructionError, or a
-        // confirmation result ({ err, slot, confirmations }) depending on
-        // whether it arrives via simulation or websocket
-        const code =
-          error.code ?? (error.err ?? error).InstructionError?.[1]?.Custom;
-        expect(code).to.eq(6044);
+            .rpc()
+        ).to.eventually.be.rejectedWith(
+          /Error Code: NftAlreadyVoted\. Error Number: 6044\./
+        );
       });
 
       it("doesn't allow transferring", async () => {


### PR DESCRIPTION
A `pre_task` stored on a `MiniFanoutV0` is one of two shapes: a remote transaction the Helium
oracle signs, or a compiled transaction carrying no signer seeds. Anything else fails with a new
`InvalidPreTask` error (6011, appended).

The rule is applied where a pre task is queued — `schedule_task_v0::schedule_impl` and
`distribute_v0` — both through `MiniFanoutV0::pre_task_to_queue`, so it has a single home.

All 47 live fanouts already satisfy it: 38 remote on the oracle signer, 8 compiled with no seeds,
1 none. `welcome-pack` hardcodes `ORACLE_SIGNER` when it CPIs `initialize_mini_fanout_v0`, and no
TypeScript path builds a compiled pre task.

### `devnet` feature forwarding

`mini-fanout`'s `devnet` feature did not forward to `shared-utils/devnet`, which `ORACLE_SIGNER`
is gated on. This is the first code in the program to read that constant, so a devnet build would
have resolved the mainnet key. Measured: `cargo tree -p mini-fanout --features devnet` gave
`shared-utils FEATURES=[default]`, where `hpl-crons` and `welcome-pack` both give
`[default,devnet]` — they are the only other programs reading it, and both already forward.

Devnet has 15 fanouts, 12 with a remote pre task: 7 on the devnet signer and 5 on the mainnet
signer, so some devnet fanouts will stop scheduling either way. `close_mini_fanout_v0` does not
route through the check, so owners retain an exit. Mainnet is unaffected.

### Test fixture

The suite was passing a pre task that never reached the chain intact, so the pre-task path was
untested. `CompiledV0` is a tuple variant, so `{compiledV0: tx}` encodes an **empty** transaction
rather than the memo; and `compileTransaction` returns the account list separately for
`queue_task_v0` to merge, so a pre task stored on the fanout has to carry its own accounts. With
both corrected the memo pre task actually runs, which is what makes `distribute_v0`'s
`PreTaskNotRun` gate mean anything.

`tests/hpl-crons.ts` and `start-cron.ts` already use the array form, so mini-fanout was the only
offender.

mini-fanout 0.1.3 → 0.1.4.
