### PR TITLE
Install toml-cli against its own lockfile, and refuse an empty program id

### DIFF
--- a/.github/workflows/release-program.yaml
+++ b/.github/workflows/release-program.yaml
@@ -23,7 +23,11 @@ jobs:
           path: |
             ~/.cargo/bin/toml
           key: toml-cli-${{ runner.os }}-v0002
-      - run: (cargo install toml-cli || true)
+      # `--locked` builds against the crate's own lockfile, so a dependency that later requires a
+      # newer rustc than this runner has cannot break the install. A failure here is fatal: the
+      # next step reads the program id with this binary, and an empty id reaches `anchor idl
+      # write-buffer` several steps later as a missing argument.
+      - run: cargo install toml-cli --locked
         if: steps.cache-toml-cli.outputs.cache-hit != 'true'
         shell: bash
 
@@ -35,6 +39,14 @@ jobs:
           VERSION=$(echo $TAG | sed 's/.*-\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\)$/\1/')
           PROGRAM_NAME=${PROGRAM//-/_}  # Substitute dashes with underscores
           PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.localnet.${PROGRAM_NAME} | tr -d '"')
+
+          # An id is what every step below addresses the program by, and an empty one is accepted
+          # until `anchor idl write-buffer` rejects it as a missing argument, several steps away
+          # from the tag that named no program Anchor.toml holds.
+          if [ -z "$PROGRAM_ID" ]; then
+            echo "::error::no program id for '${PROGRAM_NAME}' in Anchor.toml programs.localnet (tag ${TAG})"
+            exit 1
+          fi
 
           echo "Program: $PROGRAM"
           echo "Program: $PROGRAM_ID"


### PR DESCRIPTION
Pre-emptive: this repo's three releases today succeeded, but only because the toml-cli cache hit and the install never ran. The same two lines cost two releases in the tuktuk repo, where the cache missed.

## What the failure looks like

`cargo install toml-cli` re-resolves the crate's dependencies each time, so a dependency that later requires a newer rustc than the runner has breaks the install:

```
rustc 1.82.0 is not supported by the following package:
  unicode-segmentation@1.13.3 requires rustc 1.85.0
```

Two things then hide it:

1. The step is written `(cargo install toml-cli || true)`, so it reports **success** with no binary on disk.
2. `PROGRAM_ID=$(~/.cargo/bin/toml get …)` produces an empty string, which nothing checks.

The run dies several steps later inside `buffer-deploy`:

```
error: the following required arguments were not provided:
  <PROGRAM_ID>
Usage: anchor idl write-buffer --filepath <FILEPATH> ... <PROGRAM_ID>
```

That message names neither the install nor the tag.

## The change

- `cargo install toml-cli --locked` — build what the crate was published with instead of re-resolving.
- Drop `|| true`, so an install failure fails the job.
- Refuse an empty `PROGRAM_ID` where it is read, with a message naming the program and the tag.

Same change as helium/tuktuk#102, which is where this was diagnosed.

## Verified

The `--locked` install was reproduced against a pinned toolchain that the plain install fails on: plain exits 101, `--locked` exits 0 and produces a working binary. The guard was exercised both ways — an empty id exits 1 with the error line, a real id passes through. YAML parses.

Note the cache key is unchanged, so this takes effect on the next cache miss or eviction rather than immediately.