### PR TITLE
Release: harden the program release workflow's toml-cli install

### DIFF
--- a/.github/workflows/release-program.yaml
+++ b/.github/workflows/release-program.yaml
@@ -23,7 +23,11 @@ jobs:
           path: |
             ~/.cargo/bin/toml
           key: toml-cli-${{ runner.os }}-v0002
-      - run: (cargo install toml-cli || true)
+      # `--locked` builds against the crate's own lockfile, so a dependency that later requires a
+      # newer rustc than this runner has cannot break the install. A failure here is fatal: the
+      # next step reads the program id with this binary, and an empty id reaches `anchor idl
+      # write-buffer` several steps later as a missing argument.
+      - run: cargo install toml-cli --locked
         if: steps.cache-toml-cli.outputs.cache-hit != 'true'
         shell: bash
 
@@ -35,6 +39,14 @@ jobs:
           VERSION=$(echo $TAG | sed 's/.*-\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\)$/\1/')
           PROGRAM_NAME=${PROGRAM//-/_}  # Substitute dashes with underscores
           PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.localnet.${PROGRAM_NAME} | tr -d '"')
+
+          # An id is what every step below addresses the program by, and an empty one is accepted
+          # until `anchor idl write-buffer` rejects it as a missing argument, several steps away
+          # from the tag that named no program Anchor.toml holds.
+          if [ -z "$PROGRAM_ID" ]; then
+            echo "::error::no program id for '${PROGRAM_NAME}' in Anchor.toml programs.localnet (tag ${TAG})"
+            exit 1
+          fi
 
           echo "Program: $PROGRAM"
           echo "Program: $PROGRAM_ID"


### PR DESCRIPTION
Brings `develop` to `master`. One file, and it only affects releases.

Program release tags are cut from `master`, and a tag-triggered run uses the workflow file at the tagged commit — so this fix does nothing for this repo's releases until it is on `master`.

## What it changes

`.github/workflows/release-program.yaml`:

- `cargo install toml-cli --locked` — build what the crate was published with. Re-resolving picks up dependencies that can require a newer rustc than the runner has.
- Drop `|| true` from that install, so a failure fails the job instead of reporting success with no binary on disk.
- Refuse an empty `PROGRAM_ID` where it is read, naming the program and the tag.

## Why

Without this, a failed install is silent and `PROGRAM_ID` comes out empty. Nothing checks it, and the run dies several steps later inside `buffer-deploy`:

```
error: the following required arguments were not provided:
  <PROGRAM_ID>
Usage: anchor idl write-buffer --filepath <FILEPATH> ... <PROGRAM_ID>
```

That message names neither the install nor the tag.

This repo's three releases today succeeded only because the toml-cli cache hit and the install never ran. The identical two lines cost two releases in the tuktuk repo, where the cache missed — diagnosed and fixed there in helium/tuktuk#102.

No program, SDK or test changes; every program version is unchanged from `master`.

Note the cache key is untouched, so the new install path takes effect on the next cache miss or eviction rather than immediately.