### PR TITLE
Build program errors only where they are raised

### DIFF
--- a/.changeset/lazy-error-construction.md
+++ b/.changeset/lazy-error-construction.md
@@ -1,0 +1,8 @@
+---
+"@helium/idls": patch
+---
+
+`helium-sub-daos`, `mini-fanout`, `helium-entity-manager` and `welcome-pack` build their errors
+only where they are raised. An `AnchorError` owns its name and message as `String`s, so passing
+one to `ok_or` allocates on every call rather than only on the ones that fail, and the heap a
+program runs on never gives that memory back.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,10 @@ jobs:
           key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build --locked
       - run: cargo fmt -- --check
-      - run: cargo clippy --all-targets -- -D warnings -A clippy::result_large_err -A clippy::too_many_arguments -A clippy::uninlined-format-args -A clippy::manual_is_multiple_of -A ambiguous_glob_reexports -A unexpected-cfgs
+      # or_fun_call is on because `ok_or(error!(..))` builds the error on the success path too,
+      # and an AnchorError owns two Strings. The heap a program gets is a bump allocator that
+      # never frees, so errors that are never returned still consume it.
+      - run: cargo clippy --all-targets -- -D warnings -D clippy::or_fun_call -A clippy::result_large_err -A clippy::too_many_arguments -A clippy::uninlined-format-args -A clippy::manual_is_multiple_of -A ambiguous_glob_reexports -A unexpected-cfgs
 
   check-idls-changeset:
     name: Check @helium/idls Changeset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "helium-entity-manager"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "account-compression-cpi",
  "anchor-lang",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "helium-sub-daos"
-version = "0.2.44"
+version = "0.2.45"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "mini-fanout"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "welcome-pack"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "account-compression-cpi",
  "anchor-lang",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
     "clean": "npx shx rm -rf {.,packages/*}/{node_modules,lib,dist}",
     "fmt": "cargo fmt --check",
-    "clippy": "cargo clippy --all-targets -- -D warnings -A clippy::result_large_err -A clippy::too_many_arguments -A ambiguous_glob_reexports -A unexpected-cfgs",
+    "clippy": "cargo clippy --all-targets -- -D warnings -D clippy::or_fun_call -A clippy::result_large_err -A clippy::too_many_arguments -A clippy::uninlined-format-args -A clippy::manual_is_multiple_of -A ambiguous_glob_reexports -A unexpected-cfgs",
     "generate-idl-docs": "ts-node -T scripts/generate-idl-docs.ts",
     "changeset": "changeset",
     "version-packages": "changeset version",

--- a/programs/helium-entity-manager/Cargo.toml
+++ b/programs/helium-entity-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helium-entity-manager"
-version = "0.3.8"
+version = "0.3.9"
 # Trigger deployment - timestamp: 03-31-2025 #3
 description = "Created with Anchor"
 edition = "2021"

--- a/programs/helium-entity-manager/src/instructions/onboard_data_only_mobile_hotspot_v0.rs
+++ b/programs/helium-entity-manager/src/instructions/onboard_data_only_mobile_hotspot_v0.rs
@@ -166,7 +166,7 @@ pub fn handler<'info>(
     .rewardable_entity_config
     .settings
     .mobile_device_fees(MobileDeviceTypeV0::WifiDataOnly)
-    .ok_or(error!(ErrorCode::InvalidDeviceType))?;
+    .ok_or_else(|| error!(ErrorCode::InvalidDeviceType))?;
   let mut dc_fee = fees.dc_onboarding_fee;
   let location_fee = fees.location_staking_fee;
 

--- a/programs/helium-entity-manager/src/instructions/onboard_mobile_hotspot_v0.rs
+++ b/programs/helium-entity-manager/src/instructions/onboard_mobile_hotspot_v0.rs
@@ -173,7 +173,7 @@ pub fn handler<'info>(
     .rewardable_entity_config
     .settings
     .mobile_device_fees(args.device_type)
-    .ok_or(error!(ErrorCode::InvalidDeviceType))?;
+    .ok_or_else(|| error!(ErrorCode::InvalidDeviceType))?;
   let mut dc_fee = fees.dc_onboarding_fee;
   let location_fee = fees.location_staking_fee;
 

--- a/programs/helium-entity-manager/src/instructions/temp_pay_mobile_onboarding_fee_v0.rs
+++ b/programs/helium-entity-manager/src/instructions/temp_pay_mobile_onboarding_fee_v0.rs
@@ -84,7 +84,7 @@ pub fn handler(ctx: Context<TempPayMobileOnboardingFeeV0>) -> Result<()> {
     .rewardable_entity_config
     .settings
     .mobile_device_fees(ctx.accounts.mobile_info.device_type)
-    .ok_or(error!(ErrorCode::InvalidDeviceType))?
+    .ok_or_else(|| error!(ErrorCode::InvalidDeviceType))?
     .dc_onboarding_fee;
   require_eq!(dc_fee, 4000000, ErrorCode::InvalidDcFee);
   require_eq!(

--- a/programs/helium-entity-manager/src/instructions/update_mobile_info_v0.rs
+++ b/programs/helium-entity-manager/src/instructions/update_mobile_info_v0.rs
@@ -130,7 +130,7 @@ pub fn handler<'info>(
     .rewardable_entity_config
     .settings
     .mobile_device_fees(ctx.accounts.mobile_info.device_type)
-    .ok_or(error!(ErrorCode::InvalidDeviceType))?;
+    .ok_or_else(|| error!(ErrorCode::InvalidDeviceType))?;
 
   if let Some(new_location) = args.location {
     if ctx.accounts.mobile_info.location.is_none()

--- a/programs/helium-sub-daos/Cargo.toml
+++ b/programs/helium-sub-daos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helium-sub-daos"
-version = "0.2.44"
+version = "0.2.45"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/programs/helium-sub-daos/src/utils.rs
+++ b/programs/helium-sub-daos/src/utils.rs
@@ -212,7 +212,7 @@ impl PrecisePosition for PositionV0 {
       .checked_add(baseline_vote_weight)
       .unwrap()
       .checked_mul(genesis_multiplier as u128)
-      .ok_or(error!(ErrorCode::ArithmeticError))
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))
   }
 
   /// Vote power contribution from locked funds only.

--- a/programs/mini-fanout/Cargo.toml
+++ b/programs/mini-fanout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mini-fanout"
-version = "0.1.4"
+version = "0.1.5"
 # Trigger deployment - timestamp: 03-31-2025 #4
 description = "Created with Anchor"
 edition = "2021"

--- a/programs/mini-fanout/src/instructions/distribute_v0.rs
+++ b/programs/mini-fanout/src/instructions/distribute_v0.rs
@@ -124,8 +124,7 @@ pub fn handler<'info>(
     .iter()
     .map(|s| s.total_dust as u128)
     .sum::<u128>()
-    .checked_div(DUST_PRECISION)
-    .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
+    / DUST_PRECISION;
   let mut remaining = (token_account.amount as u128).saturating_sub(total_dust);
 
   // 3. Assign fixed payouts in order, saturating if not enough left
@@ -165,28 +164,18 @@ pub fn handler<'info>(
       .ok_or_else(|| error!(ErrorCode::ArithmeticError))?
       .checked_div(total_shares as u128)
       .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
-    let payout = u64::try_from(
-      amount
-        .checked_div(DUST_PRECISION)
-        .ok_or_else(|| error!(ErrorCode::ArithmeticError))?,
-    )
-    .map_err(|_| error!(ErrorCode::ArithmeticError))?;
-    let dust = u64::try_from(
-      amount
-        .checked_rem(DUST_PRECISION)
-        .ok_or_else(|| error!(ErrorCode::ArithmeticError))?,
-    )
-    .map_err(|_| error!(ErrorCode::ArithmeticError))?
-    .checked_add(share.total_dust)
-    .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
+    let payout =
+      u64::try_from(amount / DUST_PRECISION).map_err(|_| error!(ErrorCode::ArithmeticError))?;
+    let dust = u64::try_from(amount % DUST_PRECISION)
+      .map_err(|_| error!(ErrorCode::ArithmeticError))?
+      .checked_add(share.total_dust)
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
     if dust >= DUST_PRECISION as u64 {
       payouts[i] = payout
         .checked_add(1)
         .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
-      new_dusts[i] = dust
-        .checked_sub(DUST_PRECISION as u64)
-        .ok_or_else(|| error!(ErrorCode::ArithmeticError))?
-        .into();
+      // The branch condition is what makes this subtraction safe.
+      new_dusts[i] = (dust - DUST_PRECISION as u64).into();
     } else {
       payouts[i] = payout;
       new_dusts[i] = dust as u128;

--- a/programs/mini-fanout/src/instructions/distribute_v0.rs
+++ b/programs/mini-fanout/src/instructions/distribute_v0.rs
@@ -125,7 +125,7 @@ pub fn handler<'info>(
     .map(|s| s.total_dust as u128)
     .sum::<u128>()
     .checked_div(DUST_PRECISION)
-    .ok_or(error!(ErrorCode::ArithmeticError))?;
+    .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
   let mut remaining = (token_account.amount as u128).saturating_sub(total_dust);
 
   // 3. Assign fixed payouts in order, saturating if not enough left
@@ -160,32 +160,32 @@ pub fn handler<'info>(
     let share_val = share.share.as_u128();
     let amount = remaining
       .checked_mul(share_val)
-      .ok_or(error!(ErrorCode::ArithmeticError))?
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?
       .checked_mul(DUST_PRECISION)
-      .ok_or(error!(ErrorCode::ArithmeticError))?
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?
       .checked_div(total_shares as u128)
-      .ok_or(error!(ErrorCode::ArithmeticError))?;
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
     let payout = u64::try_from(
       amount
         .checked_div(DUST_PRECISION)
-        .ok_or(error!(ErrorCode::ArithmeticError))?,
+        .ok_or_else(|| error!(ErrorCode::ArithmeticError))?,
     )
     .map_err(|_| error!(ErrorCode::ArithmeticError))?;
     let dust = u64::try_from(
       amount
         .checked_rem(DUST_PRECISION)
-        .ok_or(error!(ErrorCode::ArithmeticError))?,
+        .ok_or_else(|| error!(ErrorCode::ArithmeticError))?,
     )
     .map_err(|_| error!(ErrorCode::ArithmeticError))?
     .checked_add(share.total_dust)
-    .ok_or(error!(ErrorCode::ArithmeticError))?;
+    .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
     if dust >= DUST_PRECISION as u64 {
       payouts[i] = payout
         .checked_add(1)
-        .ok_or(error!(ErrorCode::ArithmeticError))?;
+        .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
       new_dusts[i] = dust
         .checked_sub(DUST_PRECISION as u64)
-        .ok_or(error!(ErrorCode::ArithmeticError))?
+        .ok_or_else(|| error!(ErrorCode::ArithmeticError))?
         .into();
     } else {
       payouts[i] = payout;

--- a/programs/mini-fanout/src/instructions/update_mini_fanout_v0.rs
+++ b/programs/mini-fanout/src/instructions/update_mini_fanout_v0.rs
@@ -83,9 +83,7 @@ pub fn handler(ctx: Context<UpdateMiniFanoutV0>, args: UpdateMiniFanoutArgsV0) -
         MiniFanoutShareV0 {
           wallet: s.wallet,
           share: s.share,
-          delegate: existing_share
-            .map(|s| s.delegate)
-            .unwrap_or(Pubkey::default()),
+          delegate: existing_share.map(|s| s.delegate).unwrap_or_default(),
           total_dust: existing_share.map(|s| s.total_dust).unwrap_or(0),
           total_owed: existing_share.map(|s| s.total_owed).unwrap_or(0),
         }

--- a/programs/welcome-pack/Cargo.toml
+++ b/programs/welcome-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "welcome-pack"
-version = "0.0.4"
+version = "0.0.5"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/programs/welcome-pack/src/instructions/claim_welcome_pack_v0.rs
+++ b/programs/welcome-pack/src/instructions/claim_welcome_pack_v0.rs
@@ -41,7 +41,7 @@ fn check_approval_window(expiration_timestamp: i64, now: i64) -> Result<()> {
   // The end of the window has to be representable, so a clock leaving no room for one refuses.
   let latest = now
     .checked_add(MAX_CLAIM_APPROVAL_SECONDS)
-    .ok_or(error!(ErrorCode::ClaimApprovalTooLong))?;
+    .ok_or_else(|| error!(ErrorCode::ClaimApprovalTooLong))?;
   require_gte!(
     latest,
     expiration_timestamp,


### PR DESCRIPTION
An `AnchorError` owns its name and message as `String`s, so `error!()` allocates. Passed to
`ok_or`, it is built on every call, including the calls that succeed. A program's heap is a bump
allocator whose `dealloc` is a no-op, so an error that is never returned still consumes it for the
rest of the instruction.

Sixteen sites, of which one concentration matters: `mini_fanout::distribute_v0` builds eight per
share, inside the loop that assigns share payouts. The largest live fanout account is 4,810 bytes,
around fifty shares, so a distribution there builds roughly four hundred errors it discards. The
remaining sites are one per call.

`mini-fanout` distributions are not failing today — the deepest transaction sampled used 335,374
compute units and none of the recent failures are allocation failures — so this is headroom rather
than a live fault. The same construct in a five-instruction task elsewhere was enough to exhaust a
heap, which is why it is worth removing while the sites are known.

`clippy::or_fun_call` names this pattern and CI now fails on it, so it cannot come back quietly.
Reintroducing one of these fails the lint. `update_mini_fanout_v0` used
`unwrap_or(Pubkey::default())`, which allocates nothing, and becomes `unwrap_or_default()` so the
lint needs no exception.
