### PR TITLE
Require a program to exist before writing an upgrade buffer

### DIFF
--- a/.github/actions/buffer-deploy/action.yaml
+++ b/.github/actions/buffer-deploy/action.yaml
@@ -46,6 +46,20 @@ runs:
       shell: bash
     - run: ls -l ./target/deploy/
       shell: bash
+    # This action upgrades an existing program: it writes a buffer for the multisig to apply.
+    # Creating a program at a new address needs that address's own keypair, which no workflow
+    # here holds. Check that precondition before spending anything on a buffer.
+    - name: Require the program on the target cluster
+      shell: bash
+      run: |
+        if ! solana program show "$PROGRAM_ID" -u "$NETWORK" > /dev/null 2>&1; then
+          echo "::error title=$PROGRAM is not deployed on the target cluster::$PROGRAM_ID does not exist there, so there is nothing to upgrade. Deploy it once with its program keypair, then re-run."
+          exit 1
+        fi
+      env:
+        PROGRAM: ${{ inputs.program }}
+        PROGRAM_ID: ${{ inputs.program-id }}
+        NETWORK: ${{ inputs.network }}
     - name: Buffer Deploy
       if: steps.cache-buffer.outputs.cache-hit != 'true'
       id: buffer-deploy


### PR DESCRIPTION
`buffer-deploy` upgrades a program that is already on the target cluster: it writes a buffer and hands it to the Squads multisig to apply. Both clusters work this way, with their own multisig (`MULTISIG_VAULT` on mainnet, `DEVNET_MULTISIG_VAULT` on devnet). No workflow in this repo runs `solana program deploy`, so none of them can create a program at a new address, which additionally needs that address's own keypair.

A program missing from the target cluster therefore has nothing to upgrade. This checks that up front.

Today the absence surfaces two steps later, as `anchor idl write-buffer` failing with `Attempt to load a program that does not exist` and retrying through all 50 attempts. Three consequences:

- It reads as an RPC problem rather than a missing program.
- It costs about eleven minutes per run (644,531 ms in run 31832839280).
- `solana program write-buffer` has already succeeded by then, so the buffer is orphaned, and its address is never even captured because `Buffer Deploy Store` is skipped once a step in the composite fails.

The check is a single read-only `solana program show` and takes ~364 ms.

Scope note: this does not give `tuktuk-dca` a devnet deployment. It is the only one of the 19 programs in `Anchor.toml` absent from devnet, and that remains open. This change makes the failure immediate and self-describing instead of slow and misleading, and covers the mainnet and manual-devnet paths too, since all three share this action.