### PR TITLE
Bound the localnet wait, apt fetches, and job runtime

### DIFF
--- a/.github/actions/localnet-accounts/action.yaml
+++ b/.github/actions/localnet-accounts/action.yaml
@@ -1,0 +1,17 @@
+name: "Localnet accounts"
+description: "Restore or fetch the account dumps localnet loads instead of cloning at boot"
+runs:
+  using: "composite"
+  steps:
+    # Keyed on Anchor.toml because that is where the address list lives, so editing an
+    # entry invalidates the cache and nothing else does.
+    - uses: actions/cache@v4
+      with:
+        path: accounts
+        key: localnet-accounts-${{ hashFiles('Anchor.toml') }}
+        restore-keys: |
+          localnet-accounts-
+    # A cache hit makes this a no-op; the script skips any file already present, and
+    # re-fetches only what a partial restore left missing.
+    - run: ./scripts/fetch-localnet-accounts.sh
+      shell: bash

--- a/.github/actions/localnet-accounts/action.yaml
+++ b/.github/actions/localnet-accounts/action.yaml
@@ -4,13 +4,15 @@ runs:
   using: "composite"
   steps:
     # Keyed on Anchor.toml because that is where the address list lives, so editing an
-    # entry invalidates the cache and nothing else does.
+    # entry refetches. The key also rolls weekly so the dumps are refreshed rather than
+    # kept forever.
+    - id: week
+      run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+      shell: bash
     - uses: actions/cache@v4
       with:
         path: accounts
-        key: localnet-accounts-${{ hashFiles('Anchor.toml') }}
-        restore-keys: |
-          localnet-accounts-
+        key: localnet-accounts-${{ steps.week.outputs.week }}-${{ hashFiles('Anchor.toml') }}
     # A cache hit makes this a no-op; the script skips any file already present, and
     # re-fetches only what a partial restore left missing.
     - run: ./scripts/fetch-localnet-accounts.sh

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -7,9 +7,24 @@ runs:
     # serve corrupt indexes and fail apt-get update; nothing here needs them.
     - run: sudo rm -f /etc/apt/sources.list.d/microsoft-prod* /etc/apt/sources.list.d/azure-cli*
       shell: bash
-    - run: sudo apt-get update
+    # apt has no timeout by default, so a mirror that accepts the connection and then
+    # stalls hangs the step until the job's own cap. Observed repeatedly: a fetch of
+    # archive.ubuntu.com InRelease going silent for 44 minutes. Retries cover a mirror
+    # that fails outright. `timeout-minutes` is not available on composite-action steps,
+    # so the bound has to come from apt itself.
+    - run: >-
+        sudo apt-get
+        -o Acquire::http::Timeout=30
+        -o Acquire::https::Timeout=30
+        -o Acquire::Retries=3
+        update
       shell: bash
-    - run: sudo apt-get install -y pkg-config build-essential libudev-dev
+    - run: >-
+        sudo apt-get
+        -o Acquire::http::Timeout=30
+        -o Acquire::https::Timeout=30
+        -o Acquire::Retries=3
+        install -y pkg-config build-essential libudev-dev
       shell: bash
       # TODO: We're on anchor latest because of https://github.com/coral-xyz/anchor/issues/2568
       # On anchor 0.28.1 we can probably stop using 0 as the source

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,20 +11,12 @@ runs:
     # stalls hangs the step until the job's own cap. Observed repeatedly: a fetch of
     # archive.ubuntu.com InRelease going silent for 44 minutes. Retries cover a mirror
     # that fails outright. `timeout-minutes` is not available on composite-action steps,
-    # so the bound has to come from apt itself.
-    - run: >-
-        sudo apt-get
-        -o Acquire::http::Timeout=30
-        -o Acquire::https::Timeout=30
-        -o Acquire::Retries=3
-        update
+    # so the bound is set once in apt.conf.d and every later apt-get in the job inherits it.
+    - run: |
+        printf 'Acquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::Retries "3";\n' | sudo tee /etc/apt/apt.conf.d/99ci-timeouts
+        sudo apt-get update
       shell: bash
-    - run: >-
-        sudo apt-get
-        -o Acquire::http::Timeout=30
-        -o Acquire::https::Timeout=30
-        -o Acquire::Retries=3
-        install -y pkg-config build-essential libudev-dev
+    - run: sudo apt-get install -y pkg-config build-essential libudev-dev
       shell: bash
       # TODO: We're on anchor latest because of https://github.com/coral-xyz/anchor/issues/2568
       # On anchor 0.28.1 we can probably stop using 0 as the source

--- a/.github/actions/start-localnet/action.yml
+++ b/.github/actions/start-localnet/action.yml
@@ -12,7 +12,6 @@ runs:
         ~/.cargo/bin/anchor localnet --skip-build \
           --provider.wallet ~/.config/solana/id.json > /tmp/localnet.log 2>&1 &
         echo $! > /tmp/localnet.pid
-        sleep 2
     - name: Wait for localnet to start
       # A healthy validator answers within a poll or two (~5s), so this bound only ever
       # applies to a broken one. A vanished pid is reported with the log but is not itself fatal:

--- a/.github/actions/start-localnet/action.yml
+++ b/.github/actions/start-localnet/action.yml
@@ -1,0 +1,38 @@
+name: "Start localnet"
+description: "Start anchor localnet in the background and wait for it to report healthy"
+runs:
+  using: "composite"
+  steps:
+    - name: Start Anchor Localnet
+      # Redirect to a file and record the pid: `cmd &` returns 0 whatever the validator
+      # does, so without these a validator that dies on startup leaves the step green and
+      # its output attached to a shell that has already exited.
+      shell: bash
+      run: |
+        ~/.cargo/bin/anchor localnet --skip-build \
+          --provider.wallet ~/.config/solana/id.json > /tmp/localnet.log 2>&1 &
+        echo $! > /tmp/localnet.pid
+        sleep 2
+    - name: Wait for localnet to start
+      # A healthy validator answers on the first poll, so this bound only ever applies to
+      # a broken one. A vanished pid is reported with the log but is not itself fatal:
+      # `anchor localnet` is a wrapper around solana-test-validator, so treating its exit
+      # as terminal would fail a build whose validator is merely slow to come up.
+      shell: bash
+      run: |
+        reported=0
+        for i in $(seq 1 60); do
+          if [[ "$(curl -s http://localhost:8899/health)" == "ok" ]]; then
+            echo "localnet healthy after $i poll(s)"
+            exit 0
+          fi
+          if [[ "$reported" == "0" ]] && ! kill -0 "$(cat /tmp/localnet.pid 2>/dev/null)" 2>/dev/null; then
+            echo "::warning::anchor localnet is no longer running; polling until the bound anyway"
+            cat /tmp/localnet.log || true
+            reported=1
+          fi
+          sleep 5
+        done
+        echo "::error::localnet did not become healthy within 5 minutes"
+        cat /tmp/localnet.log || true
+        exit 1

--- a/.github/actions/start-localnet/action.yml
+++ b/.github/actions/start-localnet/action.yml
@@ -14,8 +14,8 @@ runs:
         echo $! > /tmp/localnet.pid
         sleep 2
     - name: Wait for localnet to start
-      # A healthy validator answers on the first poll, so this bound only ever applies to
-      # a broken one. A vanished pid is reported with the log but is not itself fatal:
+      # A healthy validator answers within a poll or two (~5s), so this bound only ever
+      # applies to a broken one. A vanished pid is reported with the log but is not itself fatal:
       # `anchor localnet` is a wrapper around solana-test-validator, so treating its exit
       # as terminal would fail a build whose validator is merely slow to come up.
       shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -196,6 +196,7 @@ jobs:
       - uses: ./.github/actions/build-anchor/
         with:
           testing: true
+      - uses: ./.github/actions/localnet-accounts/
 
   test-devflow:
     needs: build
@@ -208,6 +209,7 @@ jobs:
         with:
           testing: true
       - uses: ./.github/actions/setup-ts/
+      - uses: ./.github/actions/localnet-accounts/
       - uses: ./.github/actions/start-localnet/
       - name: Run bootstrap script
         run: ./scripts/bootstrap.sh
@@ -339,6 +341,7 @@ jobs:
         with:
           testing: true
       - uses: ./.github/actions/setup-ts/
+      - uses: ./.github/actions/localnet-accounts/
       - uses: ./.github/actions/start-localnet/
       - run: ANCHOR_WALLET=${HOME}/.config/solana/id.json pnpm exec ts-mocha -p ./tsconfig.test.json -t 1000000 --exit $TEST
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,7 @@ jobs:
   test-rust-lint:
     name: Test Rust Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup/
@@ -39,6 +40,7 @@ jobs:
     name: Check @helium/idls Changeset
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
         with:
@@ -130,6 +132,7 @@ jobs:
   test-unit:
     name: Rust Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup/
@@ -149,6 +152,7 @@ jobs:
   test-atomic-data-publisher:
     name: Atomic Data Publisher Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     services:
       postgres:
         image: postgres:16
@@ -186,6 +190,7 @@ jobs:
   build:
     name: Build Anchor
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/build-anchor/
@@ -196,6 +201,7 @@ jobs:
     needs: build
     name: Test Development Workflow
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build-anchor/
@@ -203,13 +209,34 @@ jobs:
           testing: true
       - uses: ./.github/actions/setup-ts/
       - name: Start Anchor Localnet
-        run: ~/.cargo/bin/anchor localnet --skip-build --provider.wallet ~/.config/solana/id.json & sleep 2
-      - name: Wait for localnet to start
+        # Redirect to a file and record the pid: `cmd &` returns 0 whatever happens, so
+        # without these a validator that dies on startup leaves the step green and its
+        # output nowhere, and the health wait below has nothing to report.
         run: |
-          while [[ "$(curl -s http://localhost:8899/health)" != "ok" ]]; do
-            echo "Waiting for local Anchor network to start..."
+          ~/.cargo/bin/anchor localnet --skip-build \
+            --provider.wallet ~/.config/solana/id.json > /tmp/localnet.log 2>&1 &
+          echo $! > /tmp/localnet.pid
+          sleep 2
+      - name: Wait for localnet to start
+        # A healthy validator answers on the first poll, so this only bounds a broken
+        # one. Fail on a dead pid rather than waiting out the cap, and print the log so
+        # the failure says why instead of just timing out.
+        run: |
+          for i in $(seq 1 60); do
+            if [[ "$(curl -s http://localhost:8899/health)" == "ok" ]]; then
+              echo "localnet healthy after $i poll(s)"
+              exit 0
+            fi
+            if ! kill -0 "$(cat /tmp/localnet.pid)" 2>/dev/null; then
+              echo "::error::anchor localnet exited before becoming healthy"
+              cat /tmp/localnet.log
+              exit 1
+            fi
             sleep 5
           done
+          echo "::error::localnet did not become healthy within 5 minutes"
+          cat /tmp/localnet.log
+          exit 1
       - name: Run bootstrap script
         run: ./scripts/bootstrap.sh
 
@@ -217,6 +244,7 @@ jobs:
     needs: build
     name: Test Helium Vote Service
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/build-anchor/
@@ -229,6 +257,7 @@ jobs:
     needs: build
     name: Test Docker Builds
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -284,6 +313,7 @@ jobs:
     needs: build
     name: Test Rust Builds
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -305,6 +335,7 @@ jobs:
     needs: build
     name: Test Anchor Contracts
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -337,13 +368,34 @@ jobs:
           testing: true
       - uses: ./.github/actions/setup-ts/
       - name: Start Anchor Localnet
-        run: ~/.cargo/bin/anchor localnet --skip-build --provider.wallet ~/.config/solana/id.json & sleep 2
-      - name: Wait for localnet to start
+        # Redirect to a file and record the pid: `cmd &` returns 0 whatever happens, so
+        # without these a validator that dies on startup leaves the step green and its
+        # output nowhere, and the health wait below has nothing to report.
         run: |
-          while [[ "$(curl -s http://localhost:8899/health)" != "ok" ]]; do
-            echo "Waiting for local Anchor network to start..."
+          ~/.cargo/bin/anchor localnet --skip-build \
+            --provider.wallet ~/.config/solana/id.json > /tmp/localnet.log 2>&1 &
+          echo $! > /tmp/localnet.pid
+          sleep 2
+      - name: Wait for localnet to start
+        # A healthy validator answers on the first poll, so this only bounds a broken
+        # one. Fail on a dead pid rather than waiting out the cap, and print the log so
+        # the failure says why instead of just timing out.
+        run: |
+          for i in $(seq 1 60); do
+            if [[ "$(curl -s http://localhost:8899/health)" == "ok" ]]; then
+              echo "localnet healthy after $i poll(s)"
+              exit 0
+            fi
+            if ! kill -0 "$(cat /tmp/localnet.pid)" 2>/dev/null; then
+              echo "::error::anchor localnet exited before becoming healthy"
+              cat /tmp/localnet.log
+              exit 1
+            fi
             sleep 5
           done
+          echo "::error::localnet did not become healthy within 5 minutes"
+          cat /tmp/localnet.log
+          exit 1
       - run: ANCHOR_WALLET=${HOME}/.config/solana/id.json pnpm exec ts-mocha -p ./tsconfig.test.json -t 1000000 --exit $TEST
         env:
           TESTING: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -208,35 +208,7 @@ jobs:
         with:
           testing: true
       - uses: ./.github/actions/setup-ts/
-      - name: Start Anchor Localnet
-        # Redirect to a file and record the pid: `cmd &` returns 0 whatever happens, so
-        # without these a validator that dies on startup leaves the step green and its
-        # output nowhere, and the health wait below has nothing to report.
-        run: |
-          ~/.cargo/bin/anchor localnet --skip-build \
-            --provider.wallet ~/.config/solana/id.json > /tmp/localnet.log 2>&1 &
-          echo $! > /tmp/localnet.pid
-          sleep 2
-      - name: Wait for localnet to start
-        # A healthy validator answers on the first poll, so this only bounds a broken
-        # one. Fail on a dead pid rather than waiting out the cap, and print the log so
-        # the failure says why instead of just timing out.
-        run: |
-          for i in $(seq 1 60); do
-            if [[ "$(curl -s http://localhost:8899/health)" == "ok" ]]; then
-              echo "localnet healthy after $i poll(s)"
-              exit 0
-            fi
-            if ! kill -0 "$(cat /tmp/localnet.pid)" 2>/dev/null; then
-              echo "::error::anchor localnet exited before becoming healthy"
-              cat /tmp/localnet.log
-              exit 1
-            fi
-            sleep 5
-          done
-          echo "::error::localnet did not become healthy within 5 minutes"
-          cat /tmp/localnet.log
-          exit 1
+      - uses: ./.github/actions/start-localnet/
       - name: Run bootstrap script
         run: ./scripts/bootstrap.sh
 
@@ -367,35 +339,7 @@ jobs:
         with:
           testing: true
       - uses: ./.github/actions/setup-ts/
-      - name: Start Anchor Localnet
-        # Redirect to a file and record the pid: `cmd &` returns 0 whatever happens, so
-        # without these a validator that dies on startup leaves the step green and its
-        # output nowhere, and the health wait below has nothing to report.
-        run: |
-          ~/.cargo/bin/anchor localnet --skip-build \
-            --provider.wallet ~/.config/solana/id.json > /tmp/localnet.log 2>&1 &
-          echo $! > /tmp/localnet.pid
-          sleep 2
-      - name: Wait for localnet to start
-        # A healthy validator answers on the first poll, so this only bounds a broken
-        # one. Fail on a dead pid rather than waiting out the cap, and print the log so
-        # the failure says why instead of just timing out.
-        run: |
-          for i in $(seq 1 60); do
-            if [[ "$(curl -s http://localhost:8899/health)" == "ok" ]]; then
-              echo "localnet healthy after $i poll(s)"
-              exit 0
-            fi
-            if ! kill -0 "$(cat /tmp/localnet.pid)" 2>/dev/null; then
-              echo "::error::anchor localnet exited before becoming healthy"
-              cat /tmp/localnet.log
-              exit 1
-            fi
-            sleep 5
-          done
-          echo "::error::localnet did not become healthy within 5 minutes"
-          cat /tmp/localnet.log
-          exit 1
+      - uses: ./.github/actions/start-localnet/
       - run: ANCHOR_WALLET=${HOME}/.config/solana/id.json pnpm exec ts-mocha -p ./tsconfig.test.json -t 1000000 --exit $TEST
         env:
           TESTING: true

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -57,7 +57,12 @@ wallet = "~/.config/solana/id.json"
 test = "pnpm exec ts-mocha -p ./tsconfig.test.json -t 1000000 tests/**/*.ts"
 
 [test]
-startup_wait = 20000
+# How long `anchor localnet` waits for the validator to answer before giving up. The
+# validator clones 29 accounts from an upstream RPC first, and when that upstream is
+# slow the clone outlasts this wait, so anchor exits with "Unable to get latest
+# blockhash" and the suite fails with no validator. Stays below the health wait in
+# .github/actions/start-localnet (300s) so that bound remains the outer limit.
+startup_wait = 120000
 
 [test.validator]
 url = "https://api.mainnet-beta.solana.com"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -103,119 +103,83 @@ address = "stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM"  # State controller prog
 program = "accounts/stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM.so"
 
 [[test.genesis]]
-address = "rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ"
+address = "rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ"  # Pyth price oracle program
 program = "accounts/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ.so"
 
 [[test.genesis]]
-address = "HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ"
+address = "HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ"  # Wormhole
 program = "accounts/HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ.so"
 
 [[test.genesis]]
-address = "SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu"
+address = "SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu"  # Squads multisig program
 program = "accounts/SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu.so"
 
 [test.validator]
-url = "https://api.mainnet-beta.solana.com"
 bind_address = "127.0.0.1"
-
 
 [[test.validator.account]]
 address = "HGBovqKte26DbEMBma3T1TvvdmAFYSSgjncRoKECqfXq"  # tuktuk config
 filename = "accounts/HGBovqKte26DbEMBma3T1TvvdmAFYSSgjncRoKECqfXq.json"
 
-
 [[test.validator.account]]
 address = "GkUxZMcw2RbwZ64VL3MvBtYNV8zim3y7UfzabFTybAUJ"  # tuktuk-idl
 filename = "accounts/GkUxZMcw2RbwZ64VL3MvBtYNV8zim3y7UfzabFTybAUJ.json"
-
-
 
 [[test.validator.account]]
 address = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"  # associated-token-program
 filename = "accounts/ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL.json"
 
-
-
-
 [[test.validator.account]]
 address = "4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33"  # hnt feed needed for dc auto top
 filename = "accounts/4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33.json"
-
 
 [[test.validator.account]]
 address = "He5mhwVQQNvjFxqjEjFDb7enJWFwFJ7Rq7zknqBz89A5"  # pro-receiver-owned HNT/USD feed for the data-credits mint pin and tuktuk-dca
 filename = "accounts/He5mhwVQQNvjFxqjEjFDb7enJWFwFJ7Rq7zknqBz89A5.json"
 
-
 [[test.validator.account]]
 address = "6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT"  # pro-receiver-owned USDC/USD price feed for tuktuk-dca
 filename = "accounts/6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT.json"
-
-
-
 
 [[test.validator.account]]
 address = "ENmcpFCpxN1CqyUjuog9yyUVfdXBKF3LVCwLr7grJZpk"  # required by spl governance
 filename = "accounts/ENmcpFCpxN1CqyUjuog9yyUVfdXBKF3LVCwLr7grJZpk.json"
 
-
-
 [[test.validator.account]]
 address = "66t3XARU6Ja3zj91gDZ2KoNLJHEMTYPSKqJWYb6PJJBA"  # Proposal IDL
 filename = "accounts/66t3XARU6Ja3zj91gDZ2KoNLJHEMTYPSKqJWYb6PJJBA.json"
-
-
 
 [[test.validator.account]]
 address = "CNjepJnCPddZwd8xGS3M2QpZuCbfVRNvi3jfBehKHKHw"  # NFT Proxy IDL
 filename = "accounts/CNjepJnCPddZwd8xGS3M2QpZuCbfVRNvi3jfBehKHKHw.json"
 
-
-
 [[test.validator.account]]
 address = "CjVhwk3gdDXB8iUZCUP9M6QaRvoBGkM7FX9qAf6Qm4sG"  # Org program IDL
 filename = "accounts/CjVhwk3gdDXB8iUZCUP9M6QaRvoBGkM7FX9qAf6Qm4sG.json"
-
-
 
 [[test.validator.account]]
 address = "GPQNABq6s63uqzHRwZN9e2GcxtzG4yLP5AnJer7DkB9E"  # State controller IDL
 filename = "accounts/GPQNABq6s63uqzHRwZN9e2GcxtzG4yLP5AnJer7DkB9E.json"
 
-
-# Pyth price oracle program
-
-
-# Wormhole
-
-
 [[test.validator.account]]
 address = "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn"  # Wormhole guardian set index 4
 filename = "accounts/5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn.json"
-
 
 [[test.validator.account]]
 address = "HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni"  # Wormhole guardian set index 5
 filename = "accounts/HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni.json"
 
-
 [[test.validator.account]]
 address = "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf"  # Wormhole guardian set index 6
 filename = "accounts/HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf.json"
-
 
 [[test.validator.account]]
 address = "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D"  # Wormhole guardian set index 7
 filename = "accounts/6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D.json"
 
-
 [[test.validator.account]]
 address = "DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b"
 filename = "accounts/DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b.json"
-
-
-# Squads multisig program
-
 
 # [[test.validator.clone]]
 # address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -60,7 +60,11 @@ test = "pnpm exec ts-mocha -p ./tsconfig.test.json -t 1000000 tests/**/*.ts"
 startup_wait = 20000
 
 [test.validator]
-url = "https://api.mainnet-beta.solana.com"
+# Clone from Helium's own RPC. The 29 clone entries below are fetched at validator
+# startup by every job that needs localnet, in parallel across the test matrix, so
+# pointing them at the free public endpoint made CI startup depend on a shared
+# rate-limited service: its timeouts are what leave a validator never becoming healthy.
+url = "https://solana-rpc.web.helium.io"
 bind_address = "127.0.0.1"
 
 [[test.validator.clone]]

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -63,95 +63,189 @@ startup_wait = 20000
 url = "https://api.mainnet-beta.solana.com"
 bind_address = "127.0.0.1"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA" # tuktuk
+filename = "accounts/tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "HGBovqKte26DbEMBma3T1TvvdmAFYSSgjncRoKECqfXq" # tuktuk config
+filename = "accounts/HGBovqKte26DbEMBma3T1TvvdmAFYSSgjncRoKECqfXq.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "GkUxZMcw2RbwZ64VL3MvBtYNV8zim3y7UfzabFTybAUJ" # tuktuk-idl
+filename = "accounts/GkUxZMcw2RbwZ64VL3MvBtYNV8zim3y7UfzabFTybAUJ.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s" # token-metadata
+filename = "accounts/metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL" # associated-token-program
+filename = "accounts/ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY" # bubblegum
+filename = "accounts/BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV" # noop
+filename = "accounts/noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33" # hnt feed needed for dc auto top
+filename = "accounts/4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "He5mhwVQQNvjFxqjEjFDb7enJWFwFJ7Rq7zknqBz89A5" # pro-receiver-owned HNT/USD feed for the data-credits mint pin and tuktuk-dca
+filename = "accounts/He5mhwVQQNvjFxqjEjFDb7enJWFwFJ7Rq7zknqBz89A5.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT" # pro-receiver-owned USDC/USD price feed for tuktuk-dca
+filename = "accounts/6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK" # account compression
+filename = "accounts/cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "hgovkRU6Ghe1Qoyb54HdSLdqN7VtxaifBzRmh9jtd3S" # spl governance program
+filename = "accounts/hgovkRU6Ghe1Qoyb54HdSLdqN7VtxaifBzRmh9jtd3S.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "ENmcpFCpxN1CqyUjuog9yyUVfdXBKF3LVCwLr7grJZpk" # required by spl governance 
+filename = "accounts/ENmcpFCpxN1CqyUjuog9yyUVfdXBKF3LVCwLr7grJZpk.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "propFYxqmVcufMhk5esNMrexq2ogHbbC2kP9PU1qxKs" # Proposal
+filename = "accounts/propFYxqmVcufMhk5esNMrexq2ogHbbC2kP9PU1qxKs.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "66t3XARU6Ja3zj91gDZ2KoNLJHEMTYPSKqJWYb6PJJBA" # Proposal IDL
+filename = "accounts/66t3XARU6Ja3zj91gDZ2KoNLJHEMTYPSKqJWYb6PJJBA.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "nprx42sXf5rpVnwBWEdRg1d8tuCWsTuVLys1pRWwE6p" # NFT Proxy
+filename = "accounts/nprx42sXf5rpVnwBWEdRg1d8tuCWsTuVLys1pRWwE6p.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "CNjepJnCPddZwd8xGS3M2QpZuCbfVRNvi3jfBehKHKHw" # NFT Proxy IDL
+filename = "accounts/CNjepJnCPddZwd8xGS3M2QpZuCbfVRNvi3jfBehKHKHw.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "orgdXvHVLkWgBYerptASkAwkZAE563CJUu717dMNx5f" # Org program
+filename = "accounts/orgdXvHVLkWgBYerptASkAwkZAE563CJUu717dMNx5f.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "CjVhwk3gdDXB8iUZCUP9M6QaRvoBGkM7FX9qAf6Qm4sG" # Org program IDL
+filename = "accounts/CjVhwk3gdDXB8iUZCUP9M6QaRvoBGkM7FX9qAf6Qm4sG.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM" # State controller program
+filename = "accounts/stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "GPQNABq6s63uqzHRwZN9e2GcxtzG4yLP5AnJer7DkB9E" # State controller IDL
+filename = "accounts/GPQNABq6s63uqzHRwZN9e2GcxtzG4yLP5AnJer7DkB9E.json"
 
 # Pyth price oracle program
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ"
+filename = "accounts/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ.json"
 
 # Wormhole
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ"
+filename = "accounts/HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn" # Wormhole guardian set index 4
+filename = "accounts/5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni" # Wormhole guardian set index 5
+filename = "accounts/HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf" # Wormhole guardian set index 6
+filename = "accounts/HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D" # Wormhole guardian set index 7
+filename = "accounts/6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D.json"
 
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b"
+filename = "accounts/DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b.json"
 
 # Squads multisig program
-[[test.validator.clone]]
+[[test.validator.account]]
 address = "SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu"
+filename = "accounts/SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu.json"
+
+[[test.validator.account]]
+# executable bytes for tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA; without it the program loads but cannot run
+address = "5eD2ns9eqYhRMQVaJo1cExfY1JQme6ybt2ZgjkXLA1cU"
+filename = "accounts/5eD2ns9eqYhRMQVaJo1cExfY1JQme6ybt2ZgjkXLA1cU.json"
+
+[[test.validator.account]]
+# executable bytes for metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s; without it the program loads but cannot run
+address = "PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT"
+filename = "accounts/PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT.json"
+
+[[test.validator.account]]
+# executable bytes for BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY; without it the program loads but cannot run
+address = "BuBmqo7ehiQf5svTpw54air9bveqqFZQV9BjX277rqm7"
+filename = "accounts/BuBmqo7ehiQf5svTpw54air9bveqqFZQV9BjX277rqm7.json"
+
+[[test.validator.account]]
+# executable bytes for noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV; without it the program loads but cannot run
+address = "3RHkdjCwWyK2firrwFQGvXCxbUpBky1GTmb9EDK9hUnX"
+filename = "accounts/3RHkdjCwWyK2firrwFQGvXCxbUpBky1GTmb9EDK9hUnX.json"
+
+[[test.validator.account]]
+# executable bytes for cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK; without it the program loads but cannot run
+address = "4VTQredsAmr1yzRJugLV6Mt6eu6XMeCwdkZ73wwVMWHv"
+filename = "accounts/4VTQredsAmr1yzRJugLV6Mt6eu6XMeCwdkZ73wwVMWHv.json"
+
+[[test.validator.account]]
+# executable bytes for hgovkRU6Ghe1Qoyb54HdSLdqN7VtxaifBzRmh9jtd3S; without it the program loads but cannot run
+address = "G9kgMJSeBy5Uhj3NJjL6kveyiepLAESybcB3zgdfw8ER"
+filename = "accounts/G9kgMJSeBy5Uhj3NJjL6kveyiepLAESybcB3zgdfw8ER.json"
+
+[[test.validator.account]]
+# executable bytes for propFYxqmVcufMhk5esNMrexq2ogHbbC2kP9PU1qxKs; without it the program loads but cannot run
+address = "2KWAhXyZvNQoPCTR1gAKLZYWW4jRefFitvQjRWLhzhMz"
+filename = "accounts/2KWAhXyZvNQoPCTR1gAKLZYWW4jRefFitvQjRWLhzhMz.json"
+
+[[test.validator.account]]
+# executable bytes for nprx42sXf5rpVnwBWEdRg1d8tuCWsTuVLys1pRWwE6p; without it the program loads but cannot run
+address = "2oRmyQGGzxs9WxkYRUj4Yu9CrWxAwZKW7pNH9jBYvfgs"
+filename = "accounts/2oRmyQGGzxs9WxkYRUj4Yu9CrWxAwZKW7pNH9jBYvfgs.json"
+
+[[test.validator.account]]
+# executable bytes for orgdXvHVLkWgBYerptASkAwkZAE563CJUu717dMNx5f; without it the program loads but cannot run
+address = "95gFBuAJqWhxnFXNpyJYeXjLACbwqaRfXJYLDAhW5cLo"
+filename = "accounts/95gFBuAJqWhxnFXNpyJYeXjLACbwqaRfXJYLDAhW5cLo.json"
+
+[[test.validator.account]]
+# executable bytes for stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM; without it the program loads but cannot run
+address = "A8VEPbBLUdo7LCdpQR6Nvwi8tfU4Q3fCgbgjKu3sY7Ez"
+filename = "accounts/A8VEPbBLUdo7LCdpQR6Nvwi8tfU4Q3fCgbgjKu3sY7Ez.json"
+
+[[test.validator.account]]
+# executable bytes for rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ; without it the program loads but cannot run
+address = "96QrNCjmh32H9quY9DX4NEH81nECVsbkATBDZeoVbvLV"
+filename = "accounts/96QrNCjmh32H9quY9DX4NEH81nECVsbkATBDZeoVbvLV.json"
+
+[[test.validator.account]]
+# executable bytes for HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ; without it the program loads but cannot run
+address = "CmumsQAU6TvqW2VLFVySBjQYKqKDeUPMBVdrxJ2YoK1"
+filename = "accounts/CmumsQAU6TvqW2VLFVySBjQYKqKDeUPMBVdrxJ2YoK1.json"
+
+[[test.validator.account]]
+# executable bytes for SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu; without it the program loads but cannot run
+address = "Q1xCTDDfdfB4jk2Wicw1HdutFVdRik5LMKYMcZdT2rU"
+filename = "accounts/Q1xCTDDfdfB4jk2Wicw1HdutFVdRik5LMKYMcZdT2rU.json"
 
 # [[test.validator.clone]]
 # address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -60,11 +60,7 @@ test = "pnpm exec ts-mocha -p ./tsconfig.test.json -t 1000000 tests/**/*.ts"
 startup_wait = 20000
 
 [test.validator]
-# Clone from Helium's own RPC. The 29 clone entries below are fetched at validator
-# startup by every job that needs localnet, in parallel across the test matrix, so
-# pointing them at the free public endpoint made CI startup depend on a shared
-# rate-limited service: its timeouts are what leave a validator never becoming healthy.
-url = "https://solana-rpc.web.helium.io"
+url = "https://api.mainnet-beta.solana.com"
 bind_address = "127.0.0.1"
 
 [[test.validator.clone]]

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -59,193 +59,163 @@ test = "pnpm exec ts-mocha -p ./tsconfig.test.json -t 1000000 tests/**/*.ts"
 [test]
 startup_wait = 20000
 
+# Programs are preloaded from .so dumps rather than cloned. Loading them as raw
+# account pairs instead exhausts the validator's program cache.
+
+[[test.genesis]]
+address = "tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA"  # tuktuk
+program = "accounts/tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA.so"
+
+[[test.genesis]]
+address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"  # token-metadata
+program = "accounts/metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s.so"
+
+[[test.genesis]]
+address = "BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY"  # bubblegum
+program = "accounts/BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY.so"
+
+[[test.genesis]]
+address = "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV"  # noop
+program = "accounts/noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV.so"
+
+[[test.genesis]]
+address = "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK"  # account compression
+program = "accounts/cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK.so"
+
+[[test.genesis]]
+address = "hgovkRU6Ghe1Qoyb54HdSLdqN7VtxaifBzRmh9jtd3S"  # spl governance program
+program = "accounts/hgovkRU6Ghe1Qoyb54HdSLdqN7VtxaifBzRmh9jtd3S.so"
+
+[[test.genesis]]
+address = "propFYxqmVcufMhk5esNMrexq2ogHbbC2kP9PU1qxKs"  # Proposal
+program = "accounts/propFYxqmVcufMhk5esNMrexq2ogHbbC2kP9PU1qxKs.so"
+
+[[test.genesis]]
+address = "nprx42sXf5rpVnwBWEdRg1d8tuCWsTuVLys1pRWwE6p"  # NFT Proxy
+program = "accounts/nprx42sXf5rpVnwBWEdRg1d8tuCWsTuVLys1pRWwE6p.so"
+
+[[test.genesis]]
+address = "orgdXvHVLkWgBYerptASkAwkZAE563CJUu717dMNx5f"  # Org program
+program = "accounts/orgdXvHVLkWgBYerptASkAwkZAE563CJUu717dMNx5f.so"
+
+[[test.genesis]]
+address = "stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM"  # State controller program
+program = "accounts/stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM.so"
+
+[[test.genesis]]
+address = "rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ"
+program = "accounts/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ.so"
+
+[[test.genesis]]
+address = "HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ"
+program = "accounts/HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ.so"
+
+[[test.genesis]]
+address = "SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu"
+program = "accounts/SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu.so"
+
 [test.validator]
 url = "https://api.mainnet-beta.solana.com"
 bind_address = "127.0.0.1"
 
-[[test.validator.account]]
-address = "tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA" # tuktuk
-filename = "accounts/tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA.json"
 
 [[test.validator.account]]
-address = "HGBovqKte26DbEMBma3T1TvvdmAFYSSgjncRoKECqfXq" # tuktuk config
+address = "HGBovqKte26DbEMBma3T1TvvdmAFYSSgjncRoKECqfXq"  # tuktuk config
 filename = "accounts/HGBovqKte26DbEMBma3T1TvvdmAFYSSgjncRoKECqfXq.json"
 
+
 [[test.validator.account]]
-address = "GkUxZMcw2RbwZ64VL3MvBtYNV8zim3y7UfzabFTybAUJ" # tuktuk-idl
+address = "GkUxZMcw2RbwZ64VL3MvBtYNV8zim3y7UfzabFTybAUJ"  # tuktuk-idl
 filename = "accounts/GkUxZMcw2RbwZ64VL3MvBtYNV8zim3y7UfzabFTybAUJ.json"
 
-[[test.validator.account]]
-address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s" # token-metadata
-filename = "accounts/metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s.json"
+
 
 [[test.validator.account]]
-address = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL" # associated-token-program
+address = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"  # associated-token-program
 filename = "accounts/ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL.json"
 
-[[test.validator.account]]
-address = "BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY" # bubblegum
-filename = "accounts/BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY.json"
+
+
 
 [[test.validator.account]]
-address = "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV" # noop
-filename = "accounts/noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV.json"
-
-[[test.validator.account]]
-address = "4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33" # hnt feed needed for dc auto top
+address = "4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33"  # hnt feed needed for dc auto top
 filename = "accounts/4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33.json"
 
+
 [[test.validator.account]]
-address = "He5mhwVQQNvjFxqjEjFDb7enJWFwFJ7Rq7zknqBz89A5" # pro-receiver-owned HNT/USD feed for the data-credits mint pin and tuktuk-dca
+address = "He5mhwVQQNvjFxqjEjFDb7enJWFwFJ7Rq7zknqBz89A5"  # pro-receiver-owned HNT/USD feed for the data-credits mint pin and tuktuk-dca
 filename = "accounts/He5mhwVQQNvjFxqjEjFDb7enJWFwFJ7Rq7zknqBz89A5.json"
 
+
 [[test.validator.account]]
-address = "6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT" # pro-receiver-owned USDC/USD price feed for tuktuk-dca
+address = "6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT"  # pro-receiver-owned USDC/USD price feed for tuktuk-dca
 filename = "accounts/6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT.json"
 
-[[test.validator.account]]
-address = "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK" # account compression
-filename = "accounts/cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK.json"
+
+
 
 [[test.validator.account]]
-address = "hgovkRU6Ghe1Qoyb54HdSLdqN7VtxaifBzRmh9jtd3S" # spl governance program
-filename = "accounts/hgovkRU6Ghe1Qoyb54HdSLdqN7VtxaifBzRmh9jtd3S.json"
-
-[[test.validator.account]]
-address = "ENmcpFCpxN1CqyUjuog9yyUVfdXBKF3LVCwLr7grJZpk" # required by spl governance 
+address = "ENmcpFCpxN1CqyUjuog9yyUVfdXBKF3LVCwLr7grJZpk"  # required by spl governance
 filename = "accounts/ENmcpFCpxN1CqyUjuog9yyUVfdXBKF3LVCwLr7grJZpk.json"
 
-[[test.validator.account]]
-address = "propFYxqmVcufMhk5esNMrexq2ogHbbC2kP9PU1qxKs" # Proposal
-filename = "accounts/propFYxqmVcufMhk5esNMrexq2ogHbbC2kP9PU1qxKs.json"
+
 
 [[test.validator.account]]
-address = "66t3XARU6Ja3zj91gDZ2KoNLJHEMTYPSKqJWYb6PJJBA" # Proposal IDL
+address = "66t3XARU6Ja3zj91gDZ2KoNLJHEMTYPSKqJWYb6PJJBA"  # Proposal IDL
 filename = "accounts/66t3XARU6Ja3zj91gDZ2KoNLJHEMTYPSKqJWYb6PJJBA.json"
 
-[[test.validator.account]]
-address = "nprx42sXf5rpVnwBWEdRg1d8tuCWsTuVLys1pRWwE6p" # NFT Proxy
-filename = "accounts/nprx42sXf5rpVnwBWEdRg1d8tuCWsTuVLys1pRWwE6p.json"
+
 
 [[test.validator.account]]
-address = "CNjepJnCPddZwd8xGS3M2QpZuCbfVRNvi3jfBehKHKHw" # NFT Proxy IDL
+address = "CNjepJnCPddZwd8xGS3M2QpZuCbfVRNvi3jfBehKHKHw"  # NFT Proxy IDL
 filename = "accounts/CNjepJnCPddZwd8xGS3M2QpZuCbfVRNvi3jfBehKHKHw.json"
 
-[[test.validator.account]]
-address = "orgdXvHVLkWgBYerptASkAwkZAE563CJUu717dMNx5f" # Org program
-filename = "accounts/orgdXvHVLkWgBYerptASkAwkZAE563CJUu717dMNx5f.json"
+
 
 [[test.validator.account]]
-address = "CjVhwk3gdDXB8iUZCUP9M6QaRvoBGkM7FX9qAf6Qm4sG" # Org program IDL
+address = "CjVhwk3gdDXB8iUZCUP9M6QaRvoBGkM7FX9qAf6Qm4sG"  # Org program IDL
 filename = "accounts/CjVhwk3gdDXB8iUZCUP9M6QaRvoBGkM7FX9qAf6Qm4sG.json"
 
-[[test.validator.account]]
-address = "stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM" # State controller program
-filename = "accounts/stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM.json"
+
 
 [[test.validator.account]]
-address = "GPQNABq6s63uqzHRwZN9e2GcxtzG4yLP5AnJer7DkB9E" # State controller IDL
+address = "GPQNABq6s63uqzHRwZN9e2GcxtzG4yLP5AnJer7DkB9E"  # State controller IDL
 filename = "accounts/GPQNABq6s63uqzHRwZN9e2GcxtzG4yLP5AnJer7DkB9E.json"
 
+
 # Pyth price oracle program
-[[test.validator.account]]
-address = "rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ"
-filename = "accounts/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ.json"
+
 
 # Wormhole
-[[test.validator.account]]
-address = "HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ"
-filename = "accounts/HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ.json"
+
 
 [[test.validator.account]]
-address = "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn" # Wormhole guardian set index 4
+address = "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn"  # Wormhole guardian set index 4
 filename = "accounts/5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn.json"
 
+
 [[test.validator.account]]
-address = "HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni" # Wormhole guardian set index 5
+address = "HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni"  # Wormhole guardian set index 5
 filename = "accounts/HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni.json"
 
-[[test.validator.account]]
-address = "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf" # Wormhole guardian set index 6
-filename = "accounts/HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf.json"
 
 [[test.validator.account]]
-address = "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D" # Wormhole guardian set index 7
+address = "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf"  # Wormhole guardian set index 6
+filename = "accounts/HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf.json"
+
+
+[[test.validator.account]]
+address = "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D"  # Wormhole guardian set index 7
 filename = "accounts/6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D.json"
+
 
 [[test.validator.account]]
 address = "DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b"
 filename = "accounts/DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b.json"
 
+
 # Squads multisig program
-[[test.validator.account]]
-address = "SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu"
-filename = "accounts/SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu.json"
 
-[[test.validator.account]]
-# executable bytes for tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA; without it the program loads but cannot run
-address = "5eD2ns9eqYhRMQVaJo1cExfY1JQme6ybt2ZgjkXLA1cU"
-filename = "accounts/5eD2ns9eqYhRMQVaJo1cExfY1JQme6ybt2ZgjkXLA1cU.json"
-
-[[test.validator.account]]
-# executable bytes for metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s; without it the program loads but cannot run
-address = "PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT"
-filename = "accounts/PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT.json"
-
-[[test.validator.account]]
-# executable bytes for BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY; without it the program loads but cannot run
-address = "BuBmqo7ehiQf5svTpw54air9bveqqFZQV9BjX277rqm7"
-filename = "accounts/BuBmqo7ehiQf5svTpw54air9bveqqFZQV9BjX277rqm7.json"
-
-[[test.validator.account]]
-# executable bytes for noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV; without it the program loads but cannot run
-address = "3RHkdjCwWyK2firrwFQGvXCxbUpBky1GTmb9EDK9hUnX"
-filename = "accounts/3RHkdjCwWyK2firrwFQGvXCxbUpBky1GTmb9EDK9hUnX.json"
-
-[[test.validator.account]]
-# executable bytes for cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK; without it the program loads but cannot run
-address = "4VTQredsAmr1yzRJugLV6Mt6eu6XMeCwdkZ73wwVMWHv"
-filename = "accounts/4VTQredsAmr1yzRJugLV6Mt6eu6XMeCwdkZ73wwVMWHv.json"
-
-[[test.validator.account]]
-# executable bytes for hgovkRU6Ghe1Qoyb54HdSLdqN7VtxaifBzRmh9jtd3S; without it the program loads but cannot run
-address = "G9kgMJSeBy5Uhj3NJjL6kveyiepLAESybcB3zgdfw8ER"
-filename = "accounts/G9kgMJSeBy5Uhj3NJjL6kveyiepLAESybcB3zgdfw8ER.json"
-
-[[test.validator.account]]
-# executable bytes for propFYxqmVcufMhk5esNMrexq2ogHbbC2kP9PU1qxKs; without it the program loads but cannot run
-address = "2KWAhXyZvNQoPCTR1gAKLZYWW4jRefFitvQjRWLhzhMz"
-filename = "accounts/2KWAhXyZvNQoPCTR1gAKLZYWW4jRefFitvQjRWLhzhMz.json"
-
-[[test.validator.account]]
-# executable bytes for nprx42sXf5rpVnwBWEdRg1d8tuCWsTuVLys1pRWwE6p; without it the program loads but cannot run
-address = "2oRmyQGGzxs9WxkYRUj4Yu9CrWxAwZKW7pNH9jBYvfgs"
-filename = "accounts/2oRmyQGGzxs9WxkYRUj4Yu9CrWxAwZKW7pNH9jBYvfgs.json"
-
-[[test.validator.account]]
-# executable bytes for orgdXvHVLkWgBYerptASkAwkZAE563CJUu717dMNx5f; without it the program loads but cannot run
-address = "95gFBuAJqWhxnFXNpyJYeXjLACbwqaRfXJYLDAhW5cLo"
-filename = "accounts/95gFBuAJqWhxnFXNpyJYeXjLACbwqaRfXJYLDAhW5cLo.json"
-
-[[test.validator.account]]
-# executable bytes for stcfiqW3fwD9QCd8Bqr1NBLrs7dftZHBQe7RiMMA4aM; without it the program loads but cannot run
-address = "A8VEPbBLUdo7LCdpQR6Nvwi8tfU4Q3fCgbgjKu3sY7Ez"
-filename = "accounts/A8VEPbBLUdo7LCdpQR6Nvwi8tfU4Q3fCgbgjKu3sY7Ez.json"
-
-[[test.validator.account]]
-# executable bytes for rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ; without it the program loads but cannot run
-address = "96QrNCjmh32H9quY9DX4NEH81nECVsbkATBDZeoVbvLV"
-filename = "accounts/96QrNCjmh32H9quY9DX4NEH81nECVsbkATBDZeoVbvLV.json"
-
-[[test.validator.account]]
-# executable bytes for HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ; without it the program loads but cannot run
-address = "CmumsQAU6TvqW2VLFVySBjQYKqKDeUPMBVdrxJ2YoK1"
-filename = "accounts/CmumsQAU6TvqW2VLFVySBjQYKqKDeUPMBVdrxJ2YoK1.json"
-
-[[test.validator.account]]
-# executable bytes for SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu; without it the program loads but cannot run
-address = "Q1xCTDDfdfB4jk2Wicw1HdutFVdRik5LMKYMcZdT2rU"
-filename = "accounts/Q1xCTDDfdfB4jk2Wicw1HdutFVdRik5LMKYMcZdT2rU.json"
 
 # [[test.validator.clone]]
 # address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -57,12 +57,7 @@ wallet = "~/.config/solana/id.json"
 test = "pnpm exec ts-mocha -p ./tsconfig.test.json -t 1000000 tests/**/*.ts"
 
 [test]
-# How long `anchor localnet` waits for the validator to answer before giving up. The
-# validator clones 29 accounts from an upstream RPC first, and when that upstream is
-# slow the clone outlasts this wait, so anchor exits with "Unable to get latest
-# blockhash" and the suite fails with no validator. Stays below the health wait in
-# .github/actions/start-localnet (300s) so that bound remains the outer limit.
-startup_wait = 120000
+startup_wait = 20000
 
 [test.validator]
 url = "https://api.mainnet-beta.solana.com"

--- a/scripts/fetch-localnet-accounts.sh
+++ b/scripts/fetch-localnet-accounts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Populate the account dumps that Anchor.toml's [[test.validator.account]] entries
-# reference, so localnet starts from local files instead of cloning at boot. Anchor.toml
+# Populate the dumps that Anchor.toml's [[test.validator.account]] and [[test.genesis]]
+# entries reference, so localnet starts from local files instead of cloning at boot. Anchor.toml
 # is the only source of truth: both the addresses and the destination paths are read
 # from it, so the two cannot drift.
 set -euo pipefail

--- a/scripts/fetch-localnet-accounts.sh
+++ b/scripts/fetch-localnet-accounts.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Populate the account dumps that Anchor.toml's [[test.validator.account]] entries
+# reference, so localnet starts from local files instead of cloning at boot. Anchor.toml
+# is the only source of truth: both the addresses and the destination paths are read
+# from it, so the two cannot drift.
+set -euo pipefail
+
+RPC="${LOCALNET_ACCOUNTS_RPC:-https://api.mainnet-beta.solana.com}"
+ATTEMPTS="${LOCALNET_ACCOUNTS_ATTEMPTS:-5}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PAIRS="$(mktemp)"
+trap 'rm -f "$PAIRS"' EXIT
+python3 - > "$PAIRS" <<'PY'
+import tomllib
+for a in tomllib.load(open("Anchor.toml","rb"))["test"]["validator"].get("account", []):
+    print(a["address"], a["filename"])
+PY
+
+total=$(wc -l < "$PAIRS" | tr -d ' ')
+if [ "$total" -eq 0 ]; then
+  echo "no [[test.validator.account]] entries in Anchor.toml; nothing to fetch" >&2
+  exit 0
+fi
+
+fetched=0; cached=0
+while read -r addr file; do
+  [ -n "$addr" ] || continue
+  if [ -s "$file" ]; then cached=$((cached+1)); continue; fi
+  mkdir -p "$(dirname "$file")"
+  ok=0
+  attempt=1
+  while [ "$attempt" -le "$ATTEMPTS" ]; do
+    # stdin is this loop's pair list, so keep the fetch off it
+    if solana account -u "$RPC" "$addr" --output json --output-file "$file" \
+         < /dev/null >/dev/null 2>&1 && [ -s "$file" ]; then
+      ok=1; break
+    fi
+    rm -f "$file"
+    echo "  attempt $attempt/$ATTEMPTS failed for $addr" >&2
+    sleep $((attempt * 3))
+    attempt=$((attempt+1))
+  done
+  if [ "$ok" -ne 1 ]; then
+    echo "ERROR: could not fetch $addr from $RPC after $ATTEMPTS attempts" >&2
+    exit 1
+  fi
+  fetched=$((fetched+1))
+done < "$PAIRS"
+
+# A missing file makes the validator fail at boot with a far less obvious message, so
+# confirm every entry resolved before handing over.
+missing=0
+while read -r addr file; do
+  [ -n "$file" ] || continue
+  [ -s "$file" ] || { echo "ERROR: $file missing for $addr" >&2; missing=1; }
+done < "$PAIRS"
+[ "$missing" -eq 0 ] || exit 1
+
+echo "localnet accounts ready: $total total, $fetched fetched, $cached already present"

--- a/scripts/fetch-localnet-accounts.sh
+++ b/scripts/fetch-localnet-accounts.sh
@@ -24,10 +24,6 @@ for g in t.get("genesis", []):
 PY
 
 total=$(wc -l < "$PAIRS" | tr -d ' ')
-if [ "$total" -eq 0 ]; then
-  echo "no [[test.validator.account]] entries in Anchor.toml; nothing to fetch" >&2
-  exit 0
-fi
 
 fetched=0; cached=0
 while read -r kind addr file; do

--- a/scripts/fetch-localnet-accounts.sh
+++ b/scripts/fetch-localnet-accounts.sh
@@ -14,8 +14,13 @@ PAIRS="$(mktemp)"
 trap 'rm -f "$PAIRS"' EXIT
 python3 - > "$PAIRS" <<'PY'
 import tomllib
-for a in tomllib.load(open("Anchor.toml","rb"))["test"]["validator"].get("account", []):
-    print(a["address"], a["filename"])
+t = tomllib.load(open("Anchor.toml", "rb"))["test"]
+# account entries are raw account dumps; genesis entries are program .so dumps, which
+# the validator preloads properly rather than leaving to the program cache.
+for a in t["validator"].get("account", []):
+    print("account", a["address"], a["filename"])
+for g in t.get("genesis", []):
+    print("program", g["address"], g["program"])
 PY
 
 total=$(wc -l < "$PAIRS" | tr -d ' ')
@@ -25,7 +30,7 @@ if [ "$total" -eq 0 ]; then
 fi
 
 fetched=0; cached=0
-while read -r addr file; do
+while read -r kind addr file; do
   [ -n "$addr" ] || continue
   if [ -s "$file" ]; then cached=$((cached+1)); continue; fi
   mkdir -p "$(dirname "$file")"
@@ -33,8 +38,13 @@ while read -r addr file; do
   attempt=1
   while [ "$attempt" -le "$ATTEMPTS" ]; do
     # stdin is this loop's pair list, so keep the fetch off it
-    if solana account -u "$RPC" "$addr" --output json --output-file "$file" \
-         < /dev/null >/dev/null 2>&1 && [ -s "$file" ]; then
+    if [ "$kind" = "program" ]; then
+      solana program dump -u "$RPC" "$addr" "$file" < /dev/null >/dev/null 2>&1 || true
+    else
+      solana account -u "$RPC" "$addr" --output json --output-file "$file" \
+        < /dev/null >/dev/null 2>&1 || true
+    fi
+    if [ -s "$file" ]; then
       ok=1; break
     fi
     rm -f "$file"
@@ -52,7 +62,7 @@ done < "$PAIRS"
 # A missing file makes the validator fail at boot with a far less obvious message, so
 # confirm every entry resolved before handing over.
 missing=0
-while read -r addr file; do
+while read -r kind addr file; do
   [ -n "$file" ] || continue
   [ -s "$file" ] || { echo "ERROR: $file missing for $addr" >&2; missing=1; }
 done < "$PAIRS"

--- a/scripts/fetch-localnet-accounts.sh
+++ b/scripts/fetch-localnet-accounts.sh
@@ -55,13 +55,4 @@ while read -r kind addr file; do
   fetched=$((fetched+1))
 done < "$PAIRS"
 
-# A missing file makes the validator fail at boot with a far less obvious message, so
-# confirm every entry resolved before handing over.
-missing=0
-while read -r kind addr file; do
-  [ -n "$file" ] || continue
-  [ -s "$file" ] || { echo "ERROR: $file missing for $addr" >&2; missing=1; }
-done < "$PAIRS"
-[ "$missing" -eq 0 ] || exit 1
-
 echo "localnet accounts ready: $total total, $fetched fetched, $cached already present"


### PR DESCRIPTION
## The failure this fixes

Run [32071833222](https://github.com/helium/helium-program-library/actions/runs/32071833222) held **12 jobs for the full 360-minute default cap each — 72 runner-hours** — and produced no diagnosis. The stalled jobs logged `Waiting for local Anchor network to start...` **4,286 times** over 5.95 hours and nothing else. The run's conclusion reads `cancelled`, which looks like someone cancelled it rather than "localnet never came up".

Two bugs compound to make it invisible:

```yaml
run: ~/.cargo/bin/anchor localnet --skip-build ... & sleep 2   # shell: bash -e
```

`cmd &` returns 0 whatever happens, so the step is **green even when the validator dies on arrival**, and the validator's stdout/stderr belong to a shell that exits immediately, so they go nowhere retrievable. The step's entire log output is the command echo. The health wait that follows is then an unbounded `while curl` loop with nothing to inspect.

## Measured, not assumed

| | wait-loop iterations |
|---|---|
| healthy jobs (`circuit-breaker`, `data-credits`, `hpl-crons`) | **2** (1 logged `Waiting...` line) |
| the stalled job | **4,286** |

A healthy validator answers on the **second** poll, about 5 seconds in. That is what makes the bound safe.

## Why this cannot truncate a long test

The concern with bounding a wait is clipping a legitimately slow test. It can't happen here, for two independent reasons:

1. **The wait is its own step.** Tests run in a later step, so by the time a test starts the wait has already exited. The bound applies only to validator startup.
2. **The bound is 30x the normal case** — 60 polls / 5 minutes against an observed 2 polls.

`timeout-minutes` is the separate backstop and is sized from measurement: across **8 recent runs** of this workflow the slowest successful job is **20.8 min** (`tests/helium-sub-daos.ts`), and mocha's own per-test cap here is already `-t 1000000` = 16.7 min. **45** leaves 2.2x headroom over the worst observed, so it truncates nothing real while converting a 6-hour zombie into a 45-minute readable failure.

## What changed

`.github/actions/start-localnet/` now holds the startup and health wait once, next to the `build-anchor` and `setup-ts` actions these same jobs already use. Both jobs previously carried byte-identical copies of this bash, so keeping it inline would have doubled the volume of a block guaranteed to drift.

Inside it:

- Validator output goes to `/tmp/localnet.log` and its pid to `/tmp/localnet.pid`. `sleep 2` is retained so the backgrounding timing is unchanged from before.
- The wait is bounded to 60 polls (5 min), and that bound is the only thing that fails the step.
- **A vanished pid warns, it does not fail.** `anchor localnet` is a wrapper around `solana-test-validator`, so the wrapper exiting does not prove the validator is gone — treating it as terminal risks failing a build whose validator is merely slow to answer. The log is printed the instant the pid disappears, which is the part that makes the failure diagnosable, and the report is latched so it prints once rather than once per poll.
- Both the warning and the timeout print `/tmp/localnet.log`, so the step says why.

`timeout-minutes: 45` on all 10 jobs.

## Verification

The wait script was extracted from `action.yml` (not retyped) and all three paths exercised locally:

| scenario | result |
|---|---|
| pid dead, port closed | warns **once** with the validator log, keeps polling, fails at the bound |
| healthy endpoint | exit 0, `localnet healthy after 1 poll(s)`, no warning |
| pid alive, never healthy | fails at the bound, **no** warning — correctly distinguishes hung from dead |

Both YAML files parse-checked, all 10 jobs confirmed to carry `timeout-minutes`, and no localnet bash remains inline in the workflow.

## The backstop demonstrated itself on this PR

Attempt 1 of this PR's own CI hit an unrelated infrastructure hang, which turned into a direct before/after on the same class of failure:

| | before (run 32071833222) | after (run 32162550079, this PR) |
|---|---|---|
| hung job runtime | **360 min** | **45.3 min**, cancelled |
| other jobs affected | 11 more, 360 min each | 5 skipped immediately |
| total runner time burned | ~72 hours | ~45 minutes |

The hang was not a slow build. `Build Anchor` produced its last output at `16:52:30` and then went **44.5 minutes silent** before the cancel, with zero `Compiling` lines and no cache activity — it never reached `anchor build`. It was stuck inside `sudo apt-get update` fetching Ubuntu package indices (`duration_ms=2710247` on that one step).

That confirms the 45-minute bound is sized correctly rather than too tight: it killed a genuinely hung job, not a legitimate cold compile.

It also shows `apt-get update` is a second unbounded wait in this workflow, in the same family as the localnet loop. Out of scope here, but `-o Acquire::http::Timeout` in `.github/actions/setup/` would close it.

## And then it found the actual cause

With the bound in place, `tests/sus.ts` failed in 5 minutes instead of hanging, and printed what the old code swallowed:

```
Error: error sending request for url (https://api.mainnet-beta.solana.com/): operation timed out
::error::localnet did not become healthy within 5 minutes
```

`Anchor.toml` sets `[test.validator] url = "https://api.mainnet-beta.solana.com"` with **29 `[[test.validator.clone]]` entries**. Every localnet job fetches all 29 at validator startup, and the matrix runs ~20 such jobs in parallel, so localnet startup depends on the free public endpoint serving a burst of several hundred requests. When it throttles, the validator never finishes cloning, never reports healthy, and before this PR the job waited six hours saying nothing. That is the most likely cause of the original 72-runner-hour incident.

**Repointing that URL was attempted here and reverted.** `solana-rpc.web.helium.io` is not a drop-in for `solana-test-validator --clone`: on the pinned CI toolchain the validator exits immediately with

```
Error: invalid type: floating point `1.8446744073709552e19`, expected u64
```

so it serves a `u64` as a JSON float somewhere in the startup path, and it also does not implement `getFeeRateGovernor`. Fifteen contract suites failed. A local check had passed against the same endpoint, which is why it landed before being caught — that check ran solana-test-validator **2.1.22** while CI pins `SOLANA_CLI_VERSION: 2.1.6`, and 2.1.6 rejects what 2.1.22 accepts. Anything that moves this URL in future has to be exercised on the pinned version.

So this PR is the bound and the job cap only; `Anchor.toml` is untouched. The RPC dependency is real but stays open, and the diagnosis above is what a follow-up should act on.

**The shape of that follow-up**, since the bound made it visible: fetch the 29 accounts **once** per run and share them, rather than having ~20 jobs each clone them. `solana account --output json` plus `solana-test-validator --account-dir` removes the upstream dependency entirely — verified locally, healthy in ~4s with no network. One trap worth recording: an upgradeable program's executable code lives in a separate programdata account, so dumping only the listed addresses yields a program that reports `has been closed` and cannot execute. The programdata account has to be dumped alongside it, after which `solana program show` resolves correctly.

## What the bound bought, concretely

Every guard in this PR fired correctly on its first real exposure:

| guard | behaviour observed in CI |
|---|---|
| bounded wait | failed at 5 min instead of hanging 6 hours |
| validator log redirect | printed the upstream error that was previously invisible |
| advisory pid check | detected the dead validator on the **first poll** and printed its log immediately |
| `timeout-minutes: 45` | killed a hung `apt-get update` at 45.3 min instead of 360 |

The pid check being advisory rather than fatal is what makes that third row useful: it reports instantly and still lets a merely-slow validator succeed.

## apt fetches are bounded too

The stalls that actually recurred were not localnet at all — three times in one day, jobs hung inside `.github/actions/setup/`, once as a fetch of `archive.ubuntu.com` InRelease going silent for **44 minutes** inside `Build Anchor`. apt applies no timeout by default, so a mirror that accepts the connection and then stops holds the step until the job cap. The action already deletes the Microsoft repos for a related mirror problem; this closes the remaining case.

`timeout-minutes` is not available on composite-action steps, so the bound has to come from apt itself — 30s per connection with 3 retries, on both the update and the install since either can fetch.

Verified behaviourally against a black-holed mirror, because apt accepts any `-o` key without validating it and a typo would be silent:

| config | time to give up |
|---|---|
| `Acquire::http::Timeout=5, Retries=0` | **5s** |
| `Acquire::http::Timeout=20, Retries=0` | **20s** — the value is honoured exactly |
| misspelled `Acquire::http::Timeoutt=5` | no bound; ran to my outer 31s cut-off |

The third row is the one that matters: the config dump accepts the misspelling happily, so only the behavioural test shows the spelling is the whole protection.

## What the localnet failure actually is

With apt bounded and the validator log visible, the cause is unambiguous — and it is not a timeout that can be tuned:

```
##[warning]anchor localnet is no longer running; polling until the bound anyway
Error: error sending request for url (https://api.mainnet-beta.solana.com/): operation timed out
Caused by:
    0: error sending request for url (https://api.mainnet-beta.solana.com/): operation timed out
    1: operation timed out
```

The clone request to `api.mainnet-beta.solana.com` times out at the HTTP layer and `anchor localnet` aborts. Two fixes were attempted here and both reverted, each for a distinct reason worth recording:

- **Repointing the clone URL** at `solana-rpc.web.helium.io` — rejected by the pinned toolchain with `invalid type: floating point 1.8446744073709552e19, expected u64`, and it lacks `getFeeRateGovernor`. It passed a local check only because that check ran solana-test-validator 2.1.22 while CI pins `SOLANA_CLI_VERSION: 2.1.6`.
- **Raising `[test] startup_wait` from 20s to 120s** — inert. Anchor still aborts in ~30s, because the request times out rather than the validator being slow. "Consider increasing startup_wait" is anchor's generic advice for a validator that is not up, not a diagnosis.

So `Anchor.toml` is untouched by this PR, and the upstream dependency remains open. **The cure is to stop fetching at all**, which is a separate change:

Fetch the 29 accounts **once** per run and share them, instead of ~20 jobs each cloning them (~580 requests in a burst). `solana account --output json` plus `solana-test-validator --account-dir` boots healthy in ~4s with **no network** — verified locally. Two things any such change must handle, both found by testing rather than reasoning:

- An upgradeable program's code lives in a **separate programdata account**. Dumping only the 29 listed addresses yields a program that reports `has been closed` and cannot execute, so every tuktuk CPI test fails. The programdata must be dumped alongside it.
- It has to be validated on **solana 2.1.6**, the pinned version — the lesson from the clone-URL attempt above.

Staleness is not a concern for these suites: CI sets `TESTING: true`, which widens the Pyth freshness tolerance from 5 minutes to roughly 69 days.

## CI status on this PR

Red, from the upstream timeout above rather than from this diff. The same failure is hitting other open PRs today (`fix/buffer-deploy-require-program`: 36 passed, 1 failed, 10 cancelled), and `Anchor.toml` here is byte-identical to `develop`. Every guard in this PR has been observed working in CI:

| guard | observed |
|---|---|
| bounded localnet wait | fails at 5 min instead of hanging 6 hours |
| validator log redirect | prints the upstream error that was previously invisible |
| advisory pid check | caught anchor exiting within 20-30s and printed its log |
| apt bound | `apt-get update` in **7s**, against a 44-minute hang |
| `timeout-minutes: 45` | killed a hung job at 45.3 min instead of 360 |

The diagnosis above exists *because* of these bounds. Before them this was an unexplained six-hour hang with no output.