### PR TITLE
feat: devnet-specific program id for tuktuk-dca

### DIFF
--- a/.github/workflows/develop-release-program.yaml
+++ b/.github/workflows/develop-release-program.yaml
@@ -69,7 +69,12 @@ jobs:
         if: steps.cache-toml.outputs.cache-hit != 'true'
         run: |
           PROGRAM_NAME=${PROGRAM//-/_}  # Substitute dashes with underscores
-          PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.localnet.${PROGRAM_NAME} | tr -d '"')
+          # Prefer a devnet-specific id (programs.devnet) when one exists;
+          # most programs share one id across clusters via programs.localnet.
+          PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.devnet.${PROGRAM_NAME} 2>/dev/null | tr -d '"' || true)
+          if [ -z "$PROGRAM_ID" ]; then
+            PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.localnet.${PROGRAM_NAME} | tr -d '"')
+          fi
           echo "Program: $PROGRAM_ID"
           echo "PROGRAM_NAME=${PROGRAM_NAME}" >> $GITHUB_ENV
           echo "PROGRAM_ID=${PROGRAM_ID}" >> $GITHUB_ENV
@@ -121,7 +126,12 @@ jobs:
         if: steps.cache-toml.outputs.cache-hit != 'true'
         run: |
           PROGRAM_NAME=${PROGRAM//-/_}  # Substitute dashes with underscores
-          PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.localnet.${PROGRAM_NAME} | tr -d '"')
+          # Prefer a devnet-specific id (programs.devnet) when one exists;
+          # most programs share one id across clusters via programs.localnet.
+          PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.devnet.${PROGRAM_NAME} 2>/dev/null | tr -d '"' || true)
+          if [ -z "$PROGRAM_ID" ]; then
+            PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.localnet.${PROGRAM_NAME} | tr -d '"')
+          fi
           echo "Program: $PROGRAM_ID"
           echo "PROGRAM_NAME=${PROGRAM_NAME}" >> $GITHUB_ENV
           echo "PROGRAM_ID=${PROGRAM_ID}" >> $GITHUB_ENV

--- a/.github/workflows/manual-devnet-deploy.yaml
+++ b/.github/workflows/manual-devnet-deploy.yaml
@@ -44,7 +44,12 @@ jobs:
       - name: Set program information
         run: |
           PROGRAM_NAME=${PROGRAM//-/_}  # Substitute dashes with underscores
-          PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.localnet.${PROGRAM_NAME} | tr -d '"')
+          # Prefer a devnet-specific id (programs.devnet) when one exists;
+          # most programs share one id across clusters via programs.localnet.
+          PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.devnet.${PROGRAM_NAME} 2>/dev/null | tr -d '"' || true)
+          if [ -z "$PROGRAM_ID" ]; then
+            PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.localnet.${PROGRAM_NAME} | tr -d '"')
+          fi
           echo "Program: $PROGRAM_ID"
           echo "PROGRAM_NAME=${PROGRAM_NAME}" >> $GITHUB_ENV
           echo "PROGRAM_ID=${PROGRAM_ID}" >> $GITHUB_ENV

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -23,6 +23,11 @@ welcome_pack = "we1cGnTxTkDP9Sk49dw1d3T7ik7V2NfnY4qDGCDHXfC"
 dc_auto_top = "topqqzQZroCyRrgyM5zVq6xkFDVnfF13iixSjajydgU"
 tuktuk_dca = "tdcam4m5U74pEZQrsQ7fVAav4AUXXc6z8fkhvExfRVN"
 
+# Programs whose devnet id differs from mainnet (lost program keypair).
+# The devnet deploy workflow prefers this section, falling back to localnet.
+[programs.devnet]
+tuktuk_dca = "tdcaoktKw6bDQ5ukLq5fLtje2kCkmHX7Sj9G77jY5dh"
+
 [workspace]
 members = [
   "programs/lazy-distributor",

--- a/packages/tuktuk-dca-sdk/src/constants.ts
+++ b/packages/tuktuk-dca-sdk/src/constants.ts
@@ -1,5 +1,11 @@
 import { PublicKey } from "@solana/web3.js";
 
 export const PROGRAM_ID = new PublicKey(
-  "tdcam4m5U74pEZQrsQ7fVAav4AUXXc6z8fkhvExfRVN"
+  "tdcam4m5U74pEZQrsQ7fVAav4AUXXc6z8fkhvExfRVN",
+);
+
+// Devnet uses a different program id: the mainnet program keypair was lost,
+// so devnet is deployed from a separately ground keypair.
+export const DEVNET_PROGRAM_ID = new PublicKey(
+  "tdcaoktKw6bDQ5ukLq5fLtje2kCkmHX7Sj9G77jY5dh",
 );

--- a/programs/tuktuk-dca/src/lib.rs
+++ b/programs/tuktuk-dca/src/lib.rs
@@ -9,6 +9,11 @@ pub mod state;
 pub use instructions::*;
 pub use state::*;
 
+// Devnet uses a different program id: the mainnet program keypair was lost, so
+// devnet is deployed from a separately ground keypair.
+#[cfg(feature = "devnet")]
+declare_id!("tdcaoktKw6bDQ5ukLq5fLtje2kCkmHX7Sj9G77jY5dh");
+#[cfg(not(feature = "devnet"))]
 declare_id!("tdcam4m5U74pEZQrsQ7fVAav4AUXXc6z8fkhvExfRVN");
 
 #[cfg(not(feature = "no-entrypoint"))]


### PR DESCRIPTION
## Why

The program keypair for `tdcam4m5U74pEZQrsQ7fVAav4AUXXc6z8fkhvExfRVN` is lost, so tuktuk-dca can never be deployed to devnet at its mainnet address. Devnet now uses a separately ground keypair: `tdcaoktKw6bDQ5ukLq5fLtje2kCkmHX7Sj9G77jY5dh`
## Changes

- `programs/tuktuk-dca/src/lib.rs`: feature-gate `declare_id!` — `tdcaokt…` when built with `--features devnet`, `tdcam…` otherwise. CI already passes the devnet feature on devnet builds.
- `Anchor.toml`: new `[programs.devnet]` section for programs whose devnet id differs from mainnet.
- `develop-release-program.yaml` / `manual-devnet-deploy.yaml`: resolve `PROGRAM_ID` from `programs.devnet` first, falling back to `programs.localnet`. Mainnet release workflow untouched.
- `tuktuk-dca-sdk`: adds `DEVNET_PROGRAM_ID` export; `PROGRAM_ID` (mainnet) unchanged and remains the default everywhere.

## Deploy

The devnet program was bootstrapped manually (one-time `solana program deploy` with the new keypair); upgrade + IDL authority handed to the devnet Squads vault `EwCiHKYRDrHfsaTv7S1Lf49yYbr62oFBaN3MVgzv9NU4`, so subsequent devnet deploys flow through the existing CI unchanged.

## Verification

- `cargo check -p tuktuk-dca --features devnet` passes
- `tsc --noEmit` clean on tuktuk-dca-sdk
- Existing devnet programs' upgrade authority confirmed as `EwCi…` (matches the vault CI uses)