### PR TITLE
chore: remove pyth_hnt_legacy_cron gauge (legacy crank teardown)

### DIFF
--- a/.changeset/remove-legacy-pyth-cron-gauge.md
+++ b/.changeset/remove-legacy-pyth-cron-gauge.md
@@ -1,0 +1,5 @@
+---
+"@helium/monitor-service": patch
+---
+
+Remove the pyth_hnt_legacy_cron SOL-balance gauge; the legacy pyth crank is decommissioned

--- a/packages/monitor-service/src/index.ts
+++ b/packages/monitor-service/src/index.ts
@@ -284,14 +284,6 @@ async function run() {
     ),
     "pyth_hnt_v2_cron"
   );
-  // Legacy crank cron; remove with the issue 10 legacy teardown.
-  await monitorSolBalance(
-    new PublicKey(
-      process.env.LEGACY_PYTH_CRON_KEY ||
-        "HoHXwG7W1vLA5PVs3iEUNfpYJarWcegqRUaktykB1jMc"
-    ),
-    "pyth_hnt_legacy_cron"
-  );
   await monitorSolBalance(
     new PublicKey(
       process.env.PYTH_PAYER_KEY ||


### PR DESCRIPTION
The legacy pyth crank is decommissioned; the v2 crank has been live since 2026-08-14. Removes the `pyth_hnt_legacy_cron` SOL-balance gauge from monitor-service, with a patch changeset.

Update 2026-08-21: the legacy `pyth-hnt` cron (`HoHXwG7W1vLA5PVs3iEUNfpYJarWcegqRUaktykB1jMc`) is now **closed on-chain** (cron-transaction 0 closed, then the cron; ~0.1 SOL reclaimed to the authority). The account no longer exists, so the gauge reads 0 and `PythLegacyCronBalanceThreshold` fires continuously until this gauge removal ships — that firing alert is expected, not an incident.

Companion PRs: helium/helium-foundation-k8s#765, helium/helium-terraform#148.