### PR TITLE
Seed the DCA PDA from a monotonic index

### DIFF
--- a/.changeset/dca-monotonic-index.md
+++ b/.changeset/dca-monotonic-index.md
@@ -1,0 +1,5 @@
+---
+"@helium/idls": patch
+---
+
+Seed the dc-auto-top DCA PDA from a per-account `dca_index` instead of a hardcoded `0`, so a DCA that fails to drain and close no longer occupies the slot the next top-off needs. `dca_index` is carved out of `AutoTopOffV0.reserved`, leaving every other field at its existing byte offset.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -339,6 +339,7 @@ jobs:
           - tests/mini-fanout-bankrun.ts
           - tests/welcome-pack.ts
           - tests/dc-auto-topoff.ts
+          - tests/dc-auto-topoff-bankrun.ts
           - tests/tuktuk-dca.ts
           - tests/priority-fees.ts
     steps:

--- a/programs/dc-auto-top/src/instructions/initialize_auto_top_off_v0.rs
+++ b/programs/dc-auto-top/src/instructions/initialize_auto_top_off_v0.rs
@@ -152,7 +152,8 @@ pub fn handler(
       &tuktuk_dca::ID,
     )
     .0,
-    reserved: [0; 6],
+    dca_index: 0,
+    reserved: [0; 4],
   };
 
   Ok(())

--- a/programs/dc-auto-top/src/instructions/schedule_task_v0.rs
+++ b/programs/dc-auto-top/src/instructions/schedule_task_v0.rs
@@ -138,7 +138,7 @@ pub fn get_task_ix_hnt(
       auto_top_off_key.as_ref(),
       auto_top_off.dca_mint.as_ref(),
       auto_top_off.hnt_mint.as_ref(),
-      0_u16.to_le_bytes().as_ref(),
+      auto_top_off.dca_index.to_le_bytes().as_ref(),
     ],
     &tuktuk_dca::ID,
   )

--- a/programs/dc-auto-top/src/instructions/top_off_dc_v0.rs
+++ b/programs/dc-auto-top/src/instructions/top_off_dc_v0.rs
@@ -222,7 +222,7 @@ pub fn handler<'info>(
     .ok_or(ErrorCode::ArithmeticError)?;
 
   let min_rent_exempt = Rent::get()?.minimum_balance(auto_top_off_acc.data_len());
-  if auto_top_off_acc.lamports() - min_rent_exempt >= total_crank_reward {
+  if auto_top_off_acc.lamports().saturating_sub(min_rent_exempt) >= total_crank_reward {
     auto_top_off_acc.sub_lamports(total_crank_reward)?;
     ctx.accounts.task_queue.add_lamports(total_crank_reward)?;
   } else {

--- a/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
+++ b/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
@@ -383,9 +383,23 @@ pub fn handler<'info>(
         // Advance the slot before the next task is compiled below, so the next run targets a
         // fresh PDA whether or not this DCA drains and closes. `init` on an occupied PDA fails,
         // and that failure would take the no-reschedule path and stop the HNT leg.
-        ctx.accounts.auto_top_off.load_mut()?.dca_index = dca_index.wrapping_add(1);
+        //
+        // `dca` names the DCA this account is currently feeding. Nothing else advances it, so
+        // leaving it behind would point it at a slot that has since closed or been abandoned.
+        let mut auto_top_off = ctx.accounts.auto_top_off.load_mut()?;
+        auto_top_off.dca_index = dca_index.wrapping_add(1);
+        auto_top_off.dca = ctx.accounts.dca.key();
       }
     }
+  }
+
+  // The crank reward above was sized for two tasks because a DCA was wanted. Every path that
+  // wants one and does not start it returns only the topoff task, so the second reward is
+  // returned rather than left with the queue: those are the paths taken when the account is
+  // short of lamports or dca_mint, which is when it can least afford to leak either.
+  if needs_dca && dca_tasks.is_empty() {
+    ctx.accounts.task_queue.sub_lamports(min_crank_reward)?;
+    auto_top_off_info.add_lamports(min_crank_reward)?;
   }
 
   // Schedule next HNT topoff task

--- a/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
+++ b/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
@@ -270,6 +270,7 @@ pub fn handler<'info>(
       let swap_amount_per_order = auto_top_off.dca_swap_amount;
       let interval_seconds = auto_top_off.dca_interval_seconds;
       let dca_signer = auto_top_off.dca_signer;
+      let dca_index = auto_top_off.dca_index;
       drop(auto_top_off);
 
       // Calculate rent needed for DCA account and associated token account
@@ -322,7 +323,7 @@ pub fn handler<'info>(
           seeds,
         ),
         InitializeDcaArgsV0 {
-          index: 0,
+          index: dca_index,
           num_orders: num_orders as u32,
           swap_amount_per_order,
           interval_seconds,
@@ -337,6 +338,11 @@ pub fn handler<'info>(
       // Add DCA tasks to our task list
       let result_tasks = dca_result.get();
       dca_tasks.extend(result_tasks.tasks.clone());
+
+      // Advance the slot before the next task is compiled below, so the next run targets a fresh
+      // PDA whether or not this DCA drains and closes. `init` on an occupied PDA fails, and that
+      // failure would take the no-reschedule path and stop the HNT leg.
+      ctx.accounts.auto_top_off.load_mut()?.dca_index = dca_index.wrapping_add(1);
     }
   }
 

--- a/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
+++ b/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
@@ -286,21 +286,44 @@ pub fn handler<'info>(
       let total_rent = dca_rent + ata_rent;
       let rent_needed = total_rent.saturating_sub(ctx.accounts.dca_custom_signer.lamports());
 
+      // Both inputs are checked for the same reason: the run either affords the whole DCA or
+      // does not start it. Anything short reverts the run, and a reverted run never
+      // reschedules, so a shortfall would stop the leg rather than skip a day.
+      //
       // A DCA refunds its rent to the custom signer when it drains and closes, so in steady
       // state rent_needed is 0. An abandoned DCA never refunds, so each replacement draws
-      // fresh rent from here. Debiting past rent exemption fails the whole run, which stops
-      // the leg; skipping the DCA leaves it rescheduling and buys time to refill. Mirrors the
-      // crank-reward check above.
-      let affordable = auto_top_off_info.lamports().saturating_sub(min_rent_exempt) >= rent_needed;
-      if !affordable {
+      // fresh rent from here.
+      let spendable = auto_top_off_info.lamports().saturating_sub(min_rent_exempt);
+      let rent_ok = spendable >= rent_needed;
+      if !rent_ok {
         msg!(
           "Skipping DCA: needs {} lamports rent, {} available above rent exemption",
           rent_needed,
-          auto_top_off_info.lamports().saturating_sub(min_rent_exempt)
+          spendable
         );
       }
 
-      if affordable {
+      // initialize_dca_nested_v0 moves the whole run's USDC up front and takes the order count
+      // as a u32, so a count that does not fit is as unfundable as a balance that falls short.
+      let plan = u32::try_from(num_orders)
+        .ok()
+        .and_then(|orders| {
+          Some((
+            orders,
+            swap_amount_per_order.checked_mul(u64::from(orders))?,
+          ))
+        })
+        .filter(|(_, usdc_needed)| ctx.accounts.dca_mint_account.amount >= *usdc_needed);
+      if plan.is_none() {
+        msg!(
+          "Skipping DCA: {} orders at {} each exceeds the {} dca_mint available",
+          num_orders,
+          swap_amount_per_order,
+          ctx.accounts.dca_mint_account.amount
+        );
+      }
+
+      if let (true, Some((orders, _))) = (rent_ok, plan) {
         // Transfer SOL from auto_top_off to custom signer for DCA rent
         ctx.accounts.auto_top_off.sub_lamports(rent_needed)?;
         ctx.accounts.dca_custom_signer.add_lamports(rent_needed)?;
@@ -342,7 +365,7 @@ pub fn handler<'info>(
           ),
           InitializeDcaArgsV0 {
             index: dca_index,
-            num_orders: num_orders as u32,
+            num_orders: orders,
             swap_amount_per_order,
             interval_seconds,
             slippage_bps_from_oracle: 500, // 5% slippage

--- a/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
+++ b/programs/dc-auto-top/src/instructions/top_off_hnt_v0.rs
@@ -161,10 +161,13 @@ pub fn handler<'info>(
 
   let auto_top_off_info = ctx.accounts.auto_top_off.to_account_info();
   let min_rent_exempt = Rent::get()?.minimum_balance(auto_top_off_info.data_len());
-  if auto_top_off_info.lamports() - min_rent_exempt >= total_crank_reward {
+  if auto_top_off_info.lamports().saturating_sub(min_rent_exempt) >= total_crank_reward {
     auto_top_off_info.sub_lamports(total_crank_reward)?;
     ctx.accounts.task_queue.add_lamports(total_crank_reward)?;
   } else {
+    // The immutable borrow taken above is still live here; load_mut would fail on it and
+    // return AccountBorrowFailed instead of marking the leg unscheduled.
+    drop(auto_top_off);
     let mut auto_top_off = ctx.accounts.auto_top_off.load_mut()?;
     auto_top_off.next_hnt_task = auto_top_off_key;
     drop(auto_top_off);
@@ -283,66 +286,82 @@ pub fn handler<'info>(
       let total_rent = dca_rent + ata_rent;
       let rent_needed = total_rent.saturating_sub(ctx.accounts.dca_custom_signer.lamports());
 
-      // Transfer SOL from auto_top_off to custom signer for DCA rent
-      ctx.accounts.auto_top_off.sub_lamports(rent_needed)?;
-      ctx.accounts.dca_custom_signer.add_lamports(rent_needed)?;
+      // A DCA refunds its rent to the custom signer when it drains and closes, so in steady
+      // state rent_needed is 0. An abandoned DCA never refunds, so each replacement draws
+      // fresh rent from here. Debiting past rent exemption fails the whole run, which stops
+      // the leg; skipping the DCA leaves it rescheduling and buys time to refill. Mirrors the
+      // crank-reward check above.
+      let affordable = auto_top_off_info.lamports().saturating_sub(min_rent_exempt) >= rent_needed;
+      if !affordable {
+        msg!(
+          "Skipping DCA: needs {} lamports rent, {} available above rent exemption",
+          rent_needed,
+          auto_top_off_info.lamports().saturating_sub(min_rent_exempt)
+        );
+      }
 
-      msg!(
-        "Initializing DCA with {} orders, swap amount per order: {}, interval seconds: {}",
-        num_orders,
-        swap_amount_per_order,
-        interval_seconds
-      );
-      // Initialize new DCA using nested version (no tuktuk accounts needed)
-      let dca_result = initialize_dca_nested_v0(
-        CpiContext::new_with_signer(
-          ctx.accounts.tuktuk_dca_program.to_account_info(),
-          InitializeDcaNestedV0Accounts {
-            core: tuktuk_dca::cpi::accounts::InitializeDcaCore {
-              rent_payer: ctx.accounts.dca_custom_signer.to_account_info(),
-              dca_payer: ctx.accounts.auto_top_off.to_account_info(),
-              authority: ctx.accounts.auto_top_off.to_account_info(),
-              dca: ctx.accounts.dca.to_account_info(),
-              input_mint: ctx.accounts.dca_mint.to_account_info(),
-              output_mint: ctx.accounts.hnt_mint.to_account_info(),
-              destination_token_account: ctx
-                .accounts
-                .dca_destination_token_account
-                .to_account_info(),
-              input_price_oracle: ctx.accounts.dca_input_price_oracle.to_account_info(),
-              output_price_oracle: ctx.accounts.hnt_price_oracle.to_account_info(),
-              input_account: ctx.accounts.dca_input_account.to_account_info(),
-              dca_payer_account: ctx.accounts.dca_mint_account.to_account_info(),
-              task_queue: ctx.accounts.task_queue.to_account_info(),
-              system_program: ctx.accounts.system_program.to_account_info(),
-              associated_token_program: ctx.accounts.associated_token_program.to_account_info(),
-              token_program: ctx.accounts.token_program.to_account_info(),
-            },
-            task: ctx.remaining_accounts[1].to_account_info(),
-          },
-          seeds,
-        ),
-        InitializeDcaArgsV0 {
-          index: dca_index,
-          num_orders: num_orders as u32,
+      if affordable {
+        // Transfer SOL from auto_top_off to custom signer for DCA rent
+        ctx.accounts.auto_top_off.sub_lamports(rent_needed)?;
+        ctx.accounts.dca_custom_signer.add_lamports(rent_needed)?;
+
+        msg!(
+          "Initializing DCA with {} orders, swap amount per order: {}, interval seconds: {}",
+          num_orders,
           swap_amount_per_order,
-          interval_seconds,
-          slippage_bps_from_oracle: 500, // 5% slippage
-          task_id: 0,
-          // This isn't actually used, since we're running in tuktuk it doesn't need to queue.
-          dca_signer,
-          dca_url,
-        },
-      )?;
+          interval_seconds
+        );
+        // Initialize new DCA using nested version (no tuktuk accounts needed)
+        let dca_result = initialize_dca_nested_v0(
+          CpiContext::new_with_signer(
+            ctx.accounts.tuktuk_dca_program.to_account_info(),
+            InitializeDcaNestedV0Accounts {
+              core: tuktuk_dca::cpi::accounts::InitializeDcaCore {
+                rent_payer: ctx.accounts.dca_custom_signer.to_account_info(),
+                dca_payer: ctx.accounts.auto_top_off.to_account_info(),
+                authority: ctx.accounts.auto_top_off.to_account_info(),
+                dca: ctx.accounts.dca.to_account_info(),
+                input_mint: ctx.accounts.dca_mint.to_account_info(),
+                output_mint: ctx.accounts.hnt_mint.to_account_info(),
+                destination_token_account: ctx
+                  .accounts
+                  .dca_destination_token_account
+                  .to_account_info(),
+                input_price_oracle: ctx.accounts.dca_input_price_oracle.to_account_info(),
+                output_price_oracle: ctx.accounts.hnt_price_oracle.to_account_info(),
+                input_account: ctx.accounts.dca_input_account.to_account_info(),
+                dca_payer_account: ctx.accounts.dca_mint_account.to_account_info(),
+                task_queue: ctx.accounts.task_queue.to_account_info(),
+                system_program: ctx.accounts.system_program.to_account_info(),
+                associated_token_program: ctx.accounts.associated_token_program.to_account_info(),
+                token_program: ctx.accounts.token_program.to_account_info(),
+              },
+              task: ctx.remaining_accounts[1].to_account_info(),
+            },
+            seeds,
+          ),
+          InitializeDcaArgsV0 {
+            index: dca_index,
+            num_orders: num_orders as u32,
+            swap_amount_per_order,
+            interval_seconds,
+            slippage_bps_from_oracle: 500, // 5% slippage
+            task_id: 0,
+            // This isn't actually used, since we're running in tuktuk it doesn't need to queue.
+            dca_signer,
+            dca_url,
+          },
+        )?;
 
-      // Add DCA tasks to our task list
-      let result_tasks = dca_result.get();
-      dca_tasks.extend(result_tasks.tasks.clone());
+        // Add DCA tasks to our task list
+        let result_tasks = dca_result.get();
+        dca_tasks.extend(result_tasks.tasks.clone());
 
-      // Advance the slot before the next task is compiled below, so the next run targets a fresh
-      // PDA whether or not this DCA drains and closes. `init` on an occupied PDA fails, and that
-      // failure would take the no-reschedule path and stop the HNT leg.
-      ctx.accounts.auto_top_off.load_mut()?.dca_index = dca_index.wrapping_add(1);
+        // Advance the slot before the next task is compiled below, so the next run targets a
+        // fresh PDA whether or not this DCA drains and closes. `init` on an occupied PDA fails,
+        // and that failure would take the no-reschedule path and stop the HNT leg.
+        ctx.accounts.auto_top_off.load_mut()?.dca_index = dca_index.wrapping_add(1);
+      }
     }
   }
 

--- a/programs/dc-auto-top/src/state.rs
+++ b/programs/dc-auto-top/src/state.rs
@@ -22,7 +22,10 @@ pub struct AutoTopOffV0 {
   pub circuit_breaker: Pubkey,
   pub bump: u8,
   pub queue_authority_bump: u8,
-  pub reserved: [u8; 6],
+  // Seeds the next DCA PDA. Advances once per DCA created, so a DCA that fails to drain and
+  // close never occupies the slot the next one needs.
+  pub dca_index: u16,
+  pub reserved: [u8; 4],
   pub threshold: u64,
   pub schedule: [u8; 128],
   pub dca_url: [u8; 128],
@@ -54,4 +57,31 @@ macro_rules! queue_authority_seeds {
   ( $queue_authority_bump:expr ) => {
     &[b"queue_authority".as_ref(), &[$queue_authority_bump]]
   };
+}
+
+#[cfg(test)]
+mod tests {
+  use anchor_lang::Discriminator;
+
+  use super::*;
+
+  /// `dca_index` is carved out of `reserved`, so every other field must sit at the byte offset
+  /// it occupied before. Existing accounts are not migrated; they decode with `dca_index == 0`.
+  #[test]
+  fn layout_is_unchanged_for_existing_accounts() {
+    let v = <AutoTopOffV0 as bytemuck::Zeroable>::zeroed();
+    let base = &v as *const _ as usize;
+    let at = |p: *const u8| p as usize - base + AutoTopOffV0::DISCRIMINATOR.len();
+
+    assert_eq!(
+      std::mem::size_of::<AutoTopOffV0>(),
+      936,
+      "struct size moved"
+    );
+    assert_eq!(at(&v.dca_index as *const _ as *const u8), 490);
+    assert_eq!(at(&v.threshold as *const _ as *const u8), 496);
+    assert_eq!(at(&v.hnt_threshold as *const _ as *const u8), 792);
+    assert_eq!(at(&v.dca_mint_account as *const _ as *const u8), 832);
+    assert_eq!(at(&v.dca_input_price_oracle as *const _ as *const u8), 880);
+  }
 }

--- a/tests/dc-auto-topoff-bankrun.ts
+++ b/tests/dc-auto-topoff-bankrun.ts
@@ -208,7 +208,8 @@ describe("dc-auto-topoff under bankrun", () => {
    */
   async function autoTopOffWith(
     spendableLamports: number,
-    swapPayerLamports = 0
+    swapPayerLamports = 0,
+    dcaMintFunding = 1_000_000_000n
   ) {
     // Set rather than transfer, and set it every time: the payer is one PDA shared by every
     // scenario, and rent_needed is measured against its balance, so a leftover balance from
@@ -225,7 +226,7 @@ describe("dc-auto-topoff under bankrun", () => {
     const delegatedDataCredits = Keypair.generate().publicKey;
     const [autoTopOff, bump] = autoTopOffKey(delegatedDataCredits, me);
     const hntAccount = await ataWith(hntMint, autoTopOff, 10_00000000n);
-    const dcaMintAccount = await ataWith(dcaMint, autoTopOff, 1_000_000_000n);
+    const dcaMintAccount = await ataWith(dcaMint, autoTopOff, dcaMintFunding);
 
     const data = Buffer.alloc(OFF.SIZE);
     discriminator("AutoTopOffV0").copy(data, 0);
@@ -309,6 +310,31 @@ describe("dc-auto-topoff under bankrun", () => {
       await readAccount(ctx, dcaKey(autoTopOff, dcaMint, hntMint, 0)[0]),
       "the DCA should have been created in slot 0"
     ).to.not.equal(null);
+  });
+
+  it("skips the DCA rather than reverting when the USDC is short", async () => {
+    // initialize_dca_nested_v0 moves the whole run's USDC up front, so a short balance fails
+    // the transfer, fails the CPI, and reverts the run -- which never reschedules. The DCA is
+    // sized against a 20 HNT gap, so a single unit of dca_mint cannot cover any of it.
+    const { autoTopOff, hntTask } = await autoTopOffWith(50_000_000, 1_000_000_000, 1n);
+
+    const task = await tuktukProgram.account.taskV0.fetch(hntTask);
+    await warpTo(ctx, BigInt(task.trigger.timestamp![0].toString()) + 1n);
+    await crank(hntTask);
+
+    const after = await program.account.autoTopOffV0.fetch(autoTopOff);
+    expect(after.nextHntTask.toBase58()).to.not.equal(
+      autoTopOff.toBase58(),
+      "leg should have rescheduled itself rather than stopping"
+    );
+    expect(after.dcaIndex).to.equal(
+      0,
+      "no DCA was created, so the slot should not advance"
+    );
+    expect(
+      await readAccount(ctx, dcaKey(autoTopOff, dcaMint, hntMint, 0)[0]),
+      "no DCA account should exist"
+    ).to.equal(null);
   });
 
   it("skips the DCA rather than debiting past rent exemption", async () => {

--- a/tests/dc-auto-topoff-bankrun.ts
+++ b/tests/dc-auto-topoff-bankrun.ts
@@ -29,7 +29,6 @@ import {
 import { BankrunProvider } from "anchor-bankrun";
 import { ProgramTestContext } from "solana-bankrun";
 import { expect } from "chai";
-import { createHash } from "crypto";
 import { autoTopOffKey, queueAuthorityKey } from "../packages/dc-auto-top-sdk/src";
 import { dcaKey } from "../packages/tuktuk-dca-sdk/src/pdas";
 import { DcAutoTop } from "../target/types/dc_auto_top";
@@ -61,47 +60,12 @@ const USDC_PRICE_FEED = new PublicKey(
   "6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT"
 );
 
-/**
- * `AutoTopOffV0` field offsets, discriminator included. Reaching the rent-shortfall branch
- * needs an account holding barely more than its own rent exemption, and
- * `initialize_auto_top_off_v0` funds one properly, so the state is written directly rather
- * than produced. `state.rs`'s layout test pins these same offsets from the Rust side.
- */
-const OFF = {
-  authority: 8,
-  dataCredits: 40,
-  taskQueue: 72,
-  subDao: 104,
-  nextTask: 136,
-  nextHntTask: 168,
-  delegatedDataCredits: 200,
-  dcMint: 232,
-  hntMint: 264,
-  dao: 296,
-  hntPriceOracle: 328,
-  hntAccount: 360,
-  dcAccount: 392,
-  escrowAccount: 424,
-  circuitBreaker: 456,
-  bump: 488,
-  queueAuthorityBump: 489,
-  dcaIndex: 490,
-  threshold: 496,
-  schedule: 504,
-  dcaUrl: 632,
-  dcaSigner: 760,
-  hntThreshold: 792,
-  dcaMint: 800,
-  dcaMintAccount: 832,
-  dcaSwapAmount: 864,
-  dcaIntervalSeconds: 872,
-  dcaInputPriceOracle: 880,
-  dca: 912,
-  SIZE: 944,
+/** A fixed-width byte array field, as the IDL declares it. */
+const padded = (text: string, width: number) => {
+  const buf = Buffer.alloc(width);
+  Buffer.from(text).copy(buf);
+  return [...buf];
 };
-
-const discriminator = (name: string) =>
-  createHash("sha256").update(`account:${name}`).digest().subarray(0, 8);
 
 describe("dc-auto-topoff under bankrun", () => {
   let ctx: ProgramTestContext;
@@ -115,9 +79,16 @@ describe("dc-auto-topoff under bankrun", () => {
 
   const queueAuthority = queueAuthorityKey()[0];
 
+  const lamportsOf = async (address: PublicKey) =>
+    Number((await ctx.banksClient.getAccount(address))!.lamports);
+
   const send = (instructions: anchor.web3.TransactionInstruction[]) =>
     provider.sendAndConfirm(new Transaction().add(...instructions));
 
+  // spl-utils' createMint/createAtaAndMint are the obvious reuse here and do not work under
+  // bankrun: their existence check calls connection.getAccountInfo, which BankrunConnectionProxy
+  // throws from rather than returning null for a missing account. The idempotent instruction
+  // needs no such check, which is why mini-fanout-bankrun.ts builds these locally too.
   async function createMint(decimals: number): Promise<PublicKey> {
     const kp = Keypair.generate();
     const lamports =
@@ -228,35 +199,47 @@ describe("dc-auto-topoff under bankrun", () => {
     const hntAccount = await ataWith(hntMint, autoTopOff, 10_00000000n);
     const dcaMintAccount = await ataWith(dcaMint, autoTopOff, dcaMintFunding);
 
-    const data = Buffer.alloc(OFF.SIZE);
-    discriminator("AutoTopOffV0").copy(data, 0);
-    const put = (offset: number, key: PublicKey) => key.toBuffer().copy(data, offset);
-    put(OFF.authority, me);
-    put(OFF.taskQueue, taskQueue);
-    // next_task/next_hnt_task pointing at the account itself is the "nothing scheduled"
-    // sentinel schedule_task_v0 requires.
-    put(OFF.nextTask, autoTopOff);
-    put(OFF.nextHntTask, autoTopOff);
-    put(OFF.delegatedDataCredits, delegatedDataCredits);
-    put(OFF.hntMint, hntMint);
-    put(OFF.hntPriceOracle, HNT_PRICE_FEED);
-    put(OFF.hntAccount, hntAccount);
-    put(OFF.dcaMint, dcaMint);
-    put(OFF.dcaMintAccount, dcaMintAccount);
-    put(OFF.dcaInputPriceOracle, USDC_PRICE_FEED);
-    put(OFF.dcaSigner, Keypair.generate().publicKey);
-    data.writeUInt8(bump, OFF.bump);
-    data.writeUInt8(queueAuthorityKey()[1], OFF.queueAuthorityBump);
-    data.writeUInt16LE(0, OFF.dcaIndex);
-    Buffer.from("0 0 16 * * *").copy(data, OFF.schedule);
-    Buffer.from("http://localhost:8129/dca").copy(data, OFF.dcaUrl);
-    // 30 HNT wanted against 10 held, bought 250 units at a time.
-    data.writeBigUInt64LE(30_00000000n, OFF.hntThreshold);
-    data.writeBigUInt64LE(250_000000n, OFF.dcaSwapAmount);
-    data.writeBigUInt64LE(300n, OFF.dcaIntervalSeconds);
+    // Encoded by the program's own coder rather than by hand: AutoTopOffV0 is self-padded,
+    // so borsh and its repr(C) layout agree, and a second copy of the layout here would be
+    // one `state.rs` does not pin.
+    const data = await program.coder.accounts.encode("autoTopOffV0", {
+      authority: me,
+      dataCredits: PublicKey.default,
+      taskQueue,
+      subDao: PublicKey.default,
+      // next_task/next_hnt_task pointing at the account itself is the "nothing scheduled"
+      // sentinel schedule_task_v0 requires.
+      nextTask: autoTopOff,
+      nextHntTask: autoTopOff,
+      delegatedDataCredits,
+      dcMint: PublicKey.default,
+      hntMint,
+      dao: PublicKey.default,
+      hntPriceOracle: HNT_PRICE_FEED,
+      hntAccount,
+      dcAccount: PublicKey.default,
+      escrowAccount: PublicKey.default,
+      circuitBreaker: PublicKey.default,
+      bump,
+      queueAuthorityBump: queueAuthorityKey()[1],
+      dcaIndex: 0,
+      reserved: [0, 0, 0, 0],
+      threshold: new anchor.BN(0),
+      schedule: padded("0 0 16 * * *", 128),
+      dcaUrl: padded("http://localhost:8129/dca", 128),
+      dcaSigner: Keypair.generate().publicKey,
+      // 30 HNT wanted against 10 held, bought 250 units at a time.
+      hntThreshold: new anchor.BN(30_00000000),
+      dcaMint,
+      dcaMintAccount,
+      dcaSwapAmount: new anchor.BN(250_000000),
+      dcaIntervalSeconds: new anchor.BN(300),
+      dcaInputPriceOracle: USDC_PRICE_FEED,
+      dca: PublicKey.default,
+    });
 
     const rentExempt =
-      await provider.connection.getMinimumBalanceForRentExemption(OFF.SIZE);
+      await provider.connection.getMinimumBalanceForRentExemption(data.length);
     ctx.setAccount(autoTopOff, {
       lamports: rentExempt + spendableLamports,
       data,
@@ -306,6 +289,10 @@ describe("dc-auto-topoff under bankrun", () => {
 
     const after = await program.account.autoTopOffV0.fetch(autoTopOff);
     expect(after.dcaIndex).to.equal(1, "the slot should advance once per DCA");
+    expect(after.dca.toBase58()).to.equal(
+      dcaKey(autoTopOff, dcaMint, hntMint, 0)[0].toBase58(),
+      "dca should name the DCA just created, not a slot that has since closed"
+    );
     expect(
       await readAccount(ctx, dcaKey(autoTopOff, dcaMint, hntMint, 0)[0]),
       "the DCA should have been created in slot 0"
@@ -320,7 +307,15 @@ describe("dc-auto-topoff under bankrun", () => {
 
     const task = await tuktukProgram.account.taskV0.fetch(hntTask);
     await warpTo(ctx, BigInt(task.trigger.timestamp![0].toString()) + 1n);
+    const before = await lamportsOf(autoTopOff);
     await crank(hntTask);
+
+    // The reward was debited for two tasks because a DCA was wanted; one task was returned,
+    // so exactly one min_crank_reward (1 in this queue) should have left the account.
+    expect(await lamportsOf(autoTopOff)).to.equal(
+      before - 1,
+      "the unused task's crank reward should have been returned"
+    );
 
     const after = await program.account.autoTopOffV0.fetch(autoTopOff);
     expect(after.nextHntTask.toBase58()).to.not.equal(

--- a/tests/dc-auto-topoff-bankrun.ts
+++ b/tests/dc-auto-topoff-bankrun.ts
@@ -1,0 +1,339 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { Tuktuk } from "@helium/tuktuk-idls/lib/types/tuktuk";
+import {
+  customSignerKey,
+  init as initTuktuk,
+  nextAvailableTaskIds,
+  runTask,
+  taskKey,
+  taskQueueKey,
+  taskQueueNameMappingKey,
+  tuktukConfigKey,
+} from "@helium/tuktuk-sdk";
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  createInitializeMint2Instruction,
+  createMintToInstruction,
+  getAssociatedTokenAddressSync,
+  MINT_SIZE,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import { BankrunProvider } from "anchor-bankrun";
+import { ProgramTestContext } from "solana-bankrun";
+import { expect } from "chai";
+import { createHash } from "crypto";
+import { autoTopOffKey, queueAuthorityKey } from "../packages/dc-auto-top-sdk/src";
+import { dcaKey } from "../packages/tuktuk-dca-sdk/src/pdas";
+import { DcAutoTop } from "../target/types/dc_auto_top";
+import {
+  ensureCloned,
+  ensureDumped,
+  readAccount,
+  startBankrun,
+  warpTo,
+} from "./utils/bankrun";
+
+const DC_AUTO_TOP = new PublicKey(
+  "topqqzQZroCyRrgyM5zVq6xkFDVnfF13iixSjajydgU"
+);
+const TUKTUK = new PublicKey("tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA");
+const TUKTUK_DCA = new PublicKey(
+  "tdcam4m5U74pEZQrsQ7fVAav4AUXXc6z8fkhvExfRVN"
+);
+const TUKTUK_CONFIG = tuktukConfigKey()[0];
+const TUKTUK_IDL = new PublicKey(
+  "GkUxZMcw2RbwZ64VL3MvBtYNV8zim3y7UfzabFTybAUJ"
+);
+// The pro-receiver feeds dc-auto-top accepts. Cloned rather than faked so the staleness and
+// verification-level constraints see the real shape.
+const HNT_PRICE_FEED = new PublicKey(
+  "He5mhwVQQNvjFxqjEjFDb7enJWFwFJ7Rq7zknqBz89A5"
+);
+const USDC_PRICE_FEED = new PublicKey(
+  "6HAuqASbHEh4w4REJEUUUCginTLfj1kwCh215ZLtMkrT"
+);
+
+/**
+ * `AutoTopOffV0` field offsets, discriminator included. Reaching the rent-shortfall branch
+ * needs an account holding barely more than its own rent exemption, and
+ * `initialize_auto_top_off_v0` funds one properly, so the state is written directly rather
+ * than produced. `state.rs`'s layout test pins these same offsets from the Rust side.
+ */
+const OFF = {
+  authority: 8,
+  dataCredits: 40,
+  taskQueue: 72,
+  subDao: 104,
+  nextTask: 136,
+  nextHntTask: 168,
+  delegatedDataCredits: 200,
+  dcMint: 232,
+  hntMint: 264,
+  dao: 296,
+  hntPriceOracle: 328,
+  hntAccount: 360,
+  dcAccount: 392,
+  escrowAccount: 424,
+  circuitBreaker: 456,
+  bump: 488,
+  queueAuthorityBump: 489,
+  dcaIndex: 490,
+  threshold: 496,
+  schedule: 504,
+  dcaUrl: 632,
+  dcaSigner: 760,
+  hntThreshold: 792,
+  dcaMint: 800,
+  dcaMintAccount: 832,
+  dcaSwapAmount: 864,
+  dcaIntervalSeconds: 872,
+  dcaInputPriceOracle: 880,
+  dca: 912,
+  SIZE: 944,
+};
+
+const discriminator = (name: string) =>
+  createHash("sha256").update(`account:${name}`).digest().subarray(0, 8);
+
+describe("dc-auto-topoff under bankrun", () => {
+  let ctx: ProgramTestContext;
+  let provider: BankrunProvider;
+  let program: Program<DcAutoTop>;
+  let tuktukProgram: Program<Tuktuk>;
+  let me: PublicKey;
+  let taskQueue: PublicKey;
+  let hntMint: PublicKey;
+  let dcaMint: PublicKey;
+
+  const queueAuthority = queueAuthorityKey()[0];
+
+  const send = (instructions: anchor.web3.TransactionInstruction[]) =>
+    provider.sendAndConfirm(new Transaction().add(...instructions));
+
+  async function createMint(decimals: number): Promise<PublicKey> {
+    const kp = Keypair.generate();
+    const lamports =
+      await provider.connection.getMinimumBalanceForRentExemption(MINT_SIZE);
+    await provider.sendAndConfirm(
+      new Transaction().add(
+        SystemProgram.createAccount({
+          fromPubkey: me,
+          newAccountPubkey: kp.publicKey,
+          space: MINT_SIZE,
+          lamports,
+          programId: TOKEN_PROGRAM_ID,
+        }),
+        createInitializeMint2Instruction(kp.publicKey, decimals, me, me)
+      ),
+      [kp]
+    );
+    return kp.publicKey;
+  }
+
+  async function ataWith(mint: PublicKey, owner: PublicKey, amount: bigint) {
+    const ata = getAssociatedTokenAddressSync(mint, owner, true);
+    const instructions = [
+      createAssociatedTokenAccountIdempotentInstruction(me, ata, owner, mint),
+    ];
+    if (amount > 0n) {
+      instructions.push(createMintToInstruction(mint, ata, me, amount));
+    }
+    await send(instructions);
+    return ata;
+  }
+
+  before(async () => {
+    ensureDumped("tuktuk", TUKTUK);
+    ctx = await startBankrun(
+      [
+        { name: "dc_auto_top", programId: DC_AUTO_TOP },
+        { name: "tuktuk", programId: TUKTUK },
+        { name: "tuktuk_dca", programId: TUKTUK_DCA },
+      ],
+      [
+        ensureCloned("tuktuk_config", TUKTUK_CONFIG),
+        ensureCloned("tuktuk_idl", TUKTUK_IDL),
+        ensureCloned("hnt_price_feed", HNT_PRICE_FEED),
+        ensureCloned("usdc_price_feed", USDC_PRICE_FEED),
+      ]
+    );
+    provider = new BankrunProvider(ctx);
+    program = new Program<DcAutoTop>(
+      require("../target/idl/dc_auto_top.json"),
+      provider
+    );
+    tuktukProgram = await initTuktuk(provider);
+    me = provider.wallet.publicKey;
+
+    hntMint = await createMint(8);
+    dcaMint = await createMint(6);
+
+    const name = "bankrun-dcauto";
+    const { nextTaskQueueId } =
+      await tuktukProgram.account.tuktukConfigV0.fetch(TUKTUK_CONFIG);
+    taskQueue = taskQueueKey(TUKTUK_CONFIG, nextTaskQueueId)[0];
+    await tuktukProgram.methods
+      .initializeTaskQueueV0({
+        name,
+        minCrankReward: new anchor.BN(1),
+        capacity: 1000,
+        lookupTables: [],
+        staleTaskAge: 10000,
+      })
+      .accounts({
+        tuktukConfig: TUKTUK_CONFIG,
+        payer: me,
+        updateAuthority: me,
+        taskQueue,
+        taskQueueNameMapping: taskQueueNameMappingKey(TUKTUK_CONFIG, name)[0],
+      })
+      .rpc();
+    await tuktukProgram.methods
+      .addQueueAuthorityV0()
+      .accounts({ payer: me, queueAuthority, taskQueue })
+      .rpc();
+  });
+
+  /**
+   * An AutoTopOffV0 written straight to the ledger, holding `spendableLamports` above its own
+   * rent exemption. HNT sits below hnt_threshold so the run wants a DCA.
+   */
+  async function autoTopOffWith(
+    spendableLamports: number,
+    swapPayerLamports = 0
+  ) {
+    // Set rather than transfer, and set it every time: the payer is one PDA shared by every
+    // scenario, and rent_needed is measured against its balance, so a leftover balance from
+    // an earlier test silently turns the shortfall case into the funded one.
+    const [swapPayer] = customSignerKey(taskQueue, [
+      Buffer.from("dca_swap_payer"),
+    ]);
+    ctx.setAccount(swapPayer, {
+      lamports: swapPayerLamports,
+      data: Buffer.alloc(0),
+      owner: SystemProgram.programId,
+      executable: false,
+    });
+    const delegatedDataCredits = Keypair.generate().publicKey;
+    const [autoTopOff, bump] = autoTopOffKey(delegatedDataCredits, me);
+    const hntAccount = await ataWith(hntMint, autoTopOff, 10_00000000n);
+    const dcaMintAccount = await ataWith(dcaMint, autoTopOff, 1_000_000_000n);
+
+    const data = Buffer.alloc(OFF.SIZE);
+    discriminator("AutoTopOffV0").copy(data, 0);
+    const put = (offset: number, key: PublicKey) => key.toBuffer().copy(data, offset);
+    put(OFF.authority, me);
+    put(OFF.taskQueue, taskQueue);
+    // next_task/next_hnt_task pointing at the account itself is the "nothing scheduled"
+    // sentinel schedule_task_v0 requires.
+    put(OFF.nextTask, autoTopOff);
+    put(OFF.nextHntTask, autoTopOff);
+    put(OFF.delegatedDataCredits, delegatedDataCredits);
+    put(OFF.hntMint, hntMint);
+    put(OFF.hntPriceOracle, HNT_PRICE_FEED);
+    put(OFF.hntAccount, hntAccount);
+    put(OFF.dcaMint, dcaMint);
+    put(OFF.dcaMintAccount, dcaMintAccount);
+    put(OFF.dcaInputPriceOracle, USDC_PRICE_FEED);
+    put(OFF.dcaSigner, Keypair.generate().publicKey);
+    data.writeUInt8(bump, OFF.bump);
+    data.writeUInt8(queueAuthorityKey()[1], OFF.queueAuthorityBump);
+    data.writeUInt16LE(0, OFF.dcaIndex);
+    Buffer.from("0 0 16 * * *").copy(data, OFF.schedule);
+    Buffer.from("http://localhost:8129/dca").copy(data, OFF.dcaUrl);
+    // 30 HNT wanted against 10 held, bought 250 units at a time.
+    data.writeBigUInt64LE(30_00000000n, OFF.hntThreshold);
+    data.writeBigUInt64LE(250_000000n, OFF.dcaSwapAmount);
+    data.writeBigUInt64LE(300n, OFF.dcaIntervalSeconds);
+
+    const rentExempt =
+      await provider.connection.getMinimumBalanceForRentExemption(OFF.SIZE);
+    ctx.setAccount(autoTopOff, {
+      lamports: rentExempt + spendableLamports,
+      data,
+      owner: DC_AUTO_TOP,
+      executable: false,
+    });
+
+    const { taskBitmap } = await tuktukProgram.account.taskQueueV0.fetch(
+      taskQueue
+    );
+    const [taskId, hntTaskId] = nextAvailableTaskIds(taskBitmap, 2, false);
+    await program.methods
+      .scheduleTaskV0({ taskId, hntTaskId })
+      .preInstructions([
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
+      ])
+      .accounts({
+        payer: me,
+        autoTopOff,
+        task: taskKey(taskQueue, taskId)[0],
+        hntTask: taskKey(taskQueue, hntTaskId)[0],
+      })
+      .rpc();
+
+    return { autoTopOff, hntTask: taskKey(taskQueue, hntTaskId)[0] };
+  }
+
+  const crank = async (task: PublicKey) =>
+    send([
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
+      ...(await runTask({ program: tuktukProgram, task, crankTurner: me })),
+    ]);
+
+  // The control for the test below. Identical fixture but funded, so it establishes that
+  // everything other than the rent shortfall is satisfied -- without it, "no DCA was created"
+  // would pass just as well for a fixture that never reached the DCA at all.
+  it("creates the DCA when it can fund the rent", async () => {
+    // The swap payer must hold its own rent exemption on top of what the DCA consumes:
+    // dc-auto-top sizes the DCA by dca_url.len() that tuktuk-dca does not allocate, so the
+    // payer keeps that difference and a 0-data account below 890,880 lamports fails the
+    // runtime's rent check. Production keeps it funded; the fixture has to as well.
+    const { autoTopOff, hntTask } = await autoTopOffWith(50_000_000, 1_000_000_000);
+
+    const task = await tuktukProgram.account.taskV0.fetch(hntTask);
+    await warpTo(ctx, BigInt(task.trigger.timestamp![0].toString()) + 1n);
+    await crank(hntTask);
+
+    const after = await program.account.autoTopOffV0.fetch(autoTopOff);
+    expect(after.dcaIndex).to.equal(1, "the slot should advance once per DCA");
+    expect(
+      await readAccount(ctx, dcaKey(autoTopOff, dcaMint, hntMint, 0)[0]),
+      "the DCA should have been created in slot 0"
+    ).to.not.equal(null);
+  });
+
+  it("skips the DCA rather than debiting past rent exemption", async () => {
+    // A DCA refunds its rent when it drains and closes, so this only bites once one has been
+    // abandoned and the replacement has to find rent again. Debiting anyway fails the run,
+    // and a failed run never reschedules, so the leg would stop for want of ~0.008 SOL.
+    // 1000 lamports covers the crank reward (2) and nothing near the DCA's rent.
+    const { autoTopOff, hntTask } = await autoTopOffWith(1000);
+
+    const task = await tuktukProgram.account.taskV0.fetch(hntTask);
+    await warpTo(ctx, BigInt(task.trigger.timestamp![0].toString()) + 1n);
+    await crank(hntTask);
+
+    const after = await program.account.autoTopOffV0.fetch(autoTopOff);
+    expect(after.nextHntTask.toBase58()).to.not.equal(
+      autoTopOff.toBase58(),
+      "leg should have rescheduled itself rather than stopping"
+    );
+    expect(after.dcaIndex).to.equal(
+      0,
+      "no DCA was created, so the slot should not advance"
+    );
+    expect(
+      await readAccount(ctx, dcaKey(autoTopOff, dcaMint, hntMint, 0)[0]),
+      "no DCA account should exist"
+    ).to.equal(null);
+  });
+});

--- a/tests/dc-auto-topoff.ts
+++ b/tests/dc-auto-topoff.ts
@@ -41,6 +41,7 @@ import {
   queueAuthorityKey,
 } from "../packages/dc-auto-top-sdk/src";
 import { init as initTuktukDca } from "../packages/tuktuk-dca-sdk/src";
+import { dcaKey } from "../packages/tuktuk-dca-sdk/src/pdas";
 import { DataCredits } from "../target/types/data_credits";
 import { DcAutoTop } from "../target/types/dc_auto_top";
 import { TuktukDca } from "../target/types/tuktuk_dca";
@@ -756,6 +757,37 @@ describe("dc-auto-topoff", () => {
       expect(dcaMintAccountFinal.amount.toString()).to.equal(
         "0",
         "All DCA mint tokens should be consumed"
+      );
+
+      // A DCA that fails to drain and close leaves its PDA occupied, and `init` on an
+      // occupied PDA fails, which takes the no-reschedule path and stops the HNT leg. The
+      // slot therefore has to advance, and it has to advance *before* the next task is
+      // compiled -- a task compiled against the old slot would fail its seeds constraint
+      // when the next run passes the new index. Asserting the compiled account list is
+      // what pins the ordering; asserting dcaIndex alone would still pass if the task
+      // derivation kept using a literal 0.
+      const autoTopOffAfterDca = await program.account.autoTopOffV0.fetch(
+        autoTopOff
+      );
+      expect(autoTopOffAfterDca.dcaIndex).to.equal(
+        1,
+        "dca_index should advance once per DCA created"
+      );
+
+      const nextHntTaskAcc = await tuktukProgram.account.taskV0.fetch(
+        autoTopOffAfterDca.nextHntTask
+      );
+      const nextTaskAccounts =
+        nextHntTaskAcc.transaction.compiledV0![0].accounts.map((a) =>
+          a.toBase58()
+        );
+      expect(nextTaskAccounts).to.include(
+        dcaKey(autoTopOff, dcaMint, hntMint, 1)[0].toBase58(),
+        "next HNT task must target the next DCA slot"
+      );
+      expect(nextTaskAccounts).to.not.include(
+        dcaKey(autoTopOff, dcaMint, hntMint, 0)[0].toBase58(),
+        "next HNT task must not reuse the slot the last DCA occupied"
       );
     });
 

--- a/tests/dc-auto-topoff.ts
+++ b/tests/dc-auto-topoff.ts
@@ -791,6 +791,45 @@ describe("dc-auto-topoff", () => {
       );
     });
 
+    it("marks the leg unscheduled when it cannot fund the crank reward", async () => {
+      // top_off_hnt_v0 debits the crank reward from auto_top_off and, when it cannot do so
+      // while staying rent exempt, records next_hnt_task = auto_top_off rather than erroring:
+      // that marker is what distinguishes "no task scheduled" from "scheduled but not running".
+      // Reaching the branch means raising the queue minimum past what auto_top_off can spend,
+      // which is only possible because the queue's update authority is a test-held key.
+      // Fund HNT first so the DC leg has no unrelated reason to fail while the queue is raised.
+      await createAtaAndTransfer(provider, hntMint, 1000_00000000, me, autoTopOff);
+
+      const setMinCrankReward = async (minCrankReward: anchor.BN) =>
+        tuktukProgram.methods
+          .updateTaskQueueV0({
+            minCrankReward,
+            capacity: null,
+            lookupTables: null,
+            updateAuthority: null,
+            staleTaskAge: null,
+          })
+          .accounts({ payer: me, updateAuthority: me, taskQueue })
+          .rpc({ skipPreflight: true });
+
+      // Anything above auto_top_off's whole balance is comfortably above its balance less rent
+      // exemption, so the shortfall branch is taken for any num_tasks_used.
+      const autoTopOffLamports = await provider.connection.getBalance(autoTopOff);
+      await setMinCrankReward(new anchor.BN(autoTopOffLamports + 1));
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        await runAllTasks();
+
+        const after = await program.account.autoTopOffV0.fetch(autoTopOff);
+        expect(after.nextHntTask.toBase58()).to.equal(
+          autoTopOff.toBase58(),
+          "leg should be marked unscheduled, not left pointing at a stale task"
+        );
+      } finally {
+        await setMinCrankReward(new anchor.BN(1));
+      }
+    });
+
     it("should close the auto topoff", async () => {
       await program.methods
         .closeAutoTopOffV0()


### PR DESCRIPTION
## Why

`top_off_hnt_v0` seeded its DCA PDA with a hardcoded `index: 0`, so the leg had exactly one slot for the life of the account. A DCA that fails to drain and close occupies that slot permanently, every later run fails `init` on it, and a failed run never reschedules — so the HNT leg stops.

Recovery is not currently available. `close_dca_v0` is the designed cleanup, but its `authority` is the `AutoTopOffV0` PDA and `dc-auto-top` exposes no CPI wrapper to sign for it, and it also takes `next_task` as a strict `Account<TaskV0>`, which fails to deserialize once tuktuk has swept the task — the state it exists to clear. Both need program changes and are not in this PR.

The likeliest trigger is mundane. Every DCA order task is a `RemoteV0` task pointing at a hosted URL, and `stale_task_age` on the queue is 172,800s, so a two-day outage of that service leaves the DCA orphaned. The sweep is permissionless and pays the cranker, so it happens promptly once the task ages out.

## What changed

`dca_index` advances once per DCA created, before the next task is compiled, so the next run always targets a fresh slot. An orphan then costs one day's USDC to sweep later rather than the use of the feature. It is carved out of `AutoTopOffV0.reserved`, leaving every other field at its existing byte offset, so the two live accounts need no migration and read it as 0.

Two lamport paths in the same handler could also stop the leg, and are hardened here:

- The crank-reward shortfall branch marks the leg unscheduled so `schedule_task_v0` can restart it, but it called `load_mut` while an earlier immutable borrow was still live, returned `AccountBorrowFailed`, and wrote nothing. That marker is what distinguishes "no task scheduled" from "scheduled but not running".
- The DCA rent transfer had no rent-exemption guard. A DCA refunds its rent when it closes, so in steady state nothing is drawn; an abandoned one never refunds and each replacement draws fresh rent. Debiting past rent exemption fails the run, so it now skips the DCA and leaves the leg rescheduling.

Both comparisons now saturate — subtracting the rent-exempt minimum from a balance already below it would panic under overflow checks.

## Verification

Each guard was mutated and the suite confirmed red for the intended reason, not merely red:

| mutation | result |
|---|---|
| move `dca_index` after `reserved` | layout test fails (`left: 494, right: 490`) |
| advance the index *after* the next task is compiled | every pre-existing assertion passes; only the compiled-account-list assertion fails |
| drop the borrow fix | `TopOffHntV0` fails with "tries to borrow reference for an account which is already borrowed" |
| force the affordability guard true | `sub_lamports` overflows, the run dies and never reschedules |

The index test asserts the next task's compiled account list rather than `dca_index` alone: an index advanced too late still reports 1 while leaving that task pointed at the drained slot.

The bankrun suite writes the `AutoTopOffV0` directly, since the shortfall needs an account holding barely more than its own rent exemption and `initialize_auto_top_off_v0` funds one properly. It adds a file rather than moving one, so the localnet suite still feeds the CU sampler.

## Swap payer headroom

Checked while building the bankrun control, and healthy: the DCA swap payer `7F9Ncw7pzHZW44j5hwJ38TFU6kQ778Uhtb6sMEAM7PHv` holds 0.598 SOL.

Worth recording why that balance matters, since nothing enforces it. `dc-auto-top` sizes the DCA rent using a `dca_url` length that `tuktuk-dca` does not allocate, so the payer keeps the difference — 250,560 lamports for the mainnet URL — and a system account below its own rent exemption of 890,880 fails the runtime's rent check. The top-up therefore cannot fund a DCA creation from a zero balance on its own; it works because the payer holds a balance already. The practical floor is around 8,331,120 lamports, enough to stay above rent exemption after paying roughly 7,440,240 per DCA.

An abandoned DCA never refunds that rent, so each one costs the payer about 0.0074 SOL. The current balance is roughly 79 DCAs of headroom, against about 13 on `auto_top_off`, so `auto_top_off` is the binding constraint and the guard added here covers it. A monitor threshold well above the floor, say 0.05 SOL, would give ample warning.
