### PR TITLE
Pin the lint job's toolchain and clear needless_late_init

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup/
+      # Every other job takes its compiler from setup-anchor's `rustup default 1.85.0`; this one
+      # does not run setup-anchor, so without a version here it takes whatever the runner image
+      # ships and the gate drifts away from the code. It cannot simply reuse 1.85.0: the clippy
+      # flags below name lints that only exist in a later release, and an unknown lint is itself
+      # an error under `-D warnings`. Bump this deliberately, and expect new lints when you do.
+      - run: rustup install 1.98.0 --component clippy,rustfmt --profile minimal && rustup default 1.98.0
       - uses: actions/cache@v4
         name: Cache Cargo registry + index
         id: cache-cargo-build

--- a/programs/helium-entity-manager/src/instructions/set_entity_active_v0.rs
+++ b/programs/helium-entity-manager/src/instructions/set_entity_active_v0.rs
@@ -43,8 +43,7 @@ pub fn handler(ctx: Context<SetEntityActiveV0>, args: SetEntityActiveArgsV0) -> 
     && (ctx.accounts.rewardable_entity_config.symbol == "IOT" || TESTING);
 
   let mut info_data = ctx.accounts.info.try_borrow_mut_data()?;
-  let dc_fee: u64;
-  if is_iot {
+  let dc_fee: u64 = if is_iot {
     let mut info = IotHotspotInfoV0::try_deserialize(&mut info_data.as_ref())?;
     let expected_pda = Pubkey::create_program_address(
       iot_info_seeds!(info, ctx.accounts.rewardable_entity_config, args.entity_key),
@@ -60,7 +59,7 @@ pub fn handler(ctx: Context<SetEntityActiveV0>, args: SetEntityActiveArgsV0) -> 
     }
     info.is_active = args.is_active;
     info.try_serialize(&mut *info_data)?;
-    dc_fee = info.dc_onboarding_fee_paid;
+    info.dc_onboarding_fee_paid
   } else if is_mobile {
     let mut info = MobileHotspotInfoV0::try_deserialize(&mut info_data.as_ref())?;
     let expected_pda = Pubkey::create_program_address(
@@ -77,10 +76,10 @@ pub fn handler(ctx: Context<SetEntityActiveV0>, args: SetEntityActiveArgsV0) -> 
     }
     info.is_active = args.is_active;
     info.try_serialize(&mut *info_data)?;
-    dc_fee = info.dc_onboarding_fee_paid;
+    info.dc_onboarding_fee_paid
   } else {
     return Err(ErrorCode::InvalidSettings.into());
-  }
+  };
 
   track_dc_onboarding_fees_v0(
     CpiContext::new_with_signer(

--- a/utils/shared-utils/src/resize_to_fit.rs
+++ b/utils/shared-utils/src/resize_to_fit.rs
@@ -73,8 +73,7 @@ pub fn resize_to_fit_pda<'info, T: AccountSerialize + AccountDeserialize + Owner
   if new_size > old_size && (new_size - old_size) > MAX_PERMITTED_DATA_INCREASE {
     return Err(error!(ErrorCode::InvalidDataIncrease));
   }
-  let total_change;
-  if new_size > old_size {
+  let total_change = if new_size > old_size {
     let lamports_diff = new_minimum_balance.saturating_sub(account.to_account_info().lamports());
     msg!("Resizing to {} with lamports {}", new_size, lamports_diff);
     **payer.to_account_info().lamports.borrow_mut() = payer
@@ -85,7 +84,7 @@ pub fn resize_to_fit_pda<'info, T: AccountSerialize + AccountDeserialize + Owner
       .to_account_info()
       .lamports()
       .saturating_add(lamports_diff);
-    total_change = lamports_diff as i64;
+    lamports_diff as i64
   } else {
     let lamports_diff = new_minimum_balance.saturating_sub(account.to_account_info().lamports());
     msg!(
@@ -101,8 +100,8 @@ pub fn resize_to_fit_pda<'info, T: AccountSerialize + AccountDeserialize + Owner
       .to_account_info()
       .lamports()
       .saturating_sub(lamports_diff);
-    total_change = -(lamports_diff as i64);
-  }
+    -(lamports_diff as i64)
+  };
 
   account.to_account_info().realloc(new_size, false)?;
 


### PR DESCRIPTION
Unblocks the `Test Rust Lint` job, which currently fails on every PR against `develop`.

## What broke

Nothing in any diff. Every CI job takes its compiler from `setup-anchor`'s `rustup default 1.85.0` — except `Test Rust Lint`, which uses `./.github/actions/setup/` and does not run `setup-anchor`. It therefore took whatever `ubuntu-latest` shipped, that reached **1.98.0** on 2026-08-18, and the job began failing on `clippy::needless_late_init`, promoted in that release. The last `develop` run of the job was 2026-08-14, four days earlier, so nothing had exercised the new compiler.

## What changed

The lint job now names its version instead of inheriting one.

It cannot simply reuse 1.85.0. The clippy invocation passes `-A clippy::manual_is_multiple_of`, a lint that release does not know, and an unknown lint is itself an error under `-D warnings` — so the flags already assume something newer.

A repo-wide `rust-toolchain.toml` does not work either, and this PR tried it first. It overrides the 1.85.0 that `setup-anchor` selects, and `utils/ecc-sig-verifier` — excluded from the workspace and pinned to old solana crates — then fails to build against a `wasm-bindgen` too old for 1.98. Two toolchains are genuinely required, so the pin belongs on the one job that lacks one.

Two `needless_late_init` sites, both predating the lint and both the same shape: a binding declared empty and assigned once per branch, rewritten as the value of the `if`. `utils/shared-utils/src/resize_to_fit.rs` is the one CI reports; `programs/helium-entity-manager/src/instructions/set_entity_active_v0.rs` is the next, which CI never reached because it stops at the first crate.

## Verified

Locally, against the two toolchains CI will now use:

| | |
|---|---|
| `cargo build --locked` on 1.98.0 | pass |
| `cargo fmt -- --check` on 1.98.0 | pass |
| `cargo clippy --all-targets` on 1.98.0, CI's exact flag set | pass |
| `cargo clippy` on 1.85.0 | errors on the unknown `manual_is_multiple_of` — why the lint job needs its own version |
| `utils/ecc-sig-verifier` `cargo build` on 1.85.0 | pass |

`helium-entity-manager` builds a byte-identical IDL before and after (`anchor idl build` on both sides, `metadata.version` removed), so no `@helium/idls` changeset is due.

## Trade-off

Local checkouts still default to whatever the developer has, so `cargo clippy` locally is not automatically the lint gate — that is what a `rust-toolchain.toml` would have bought and what the `ecc-sig-verifier` constraint rules out. Reproducing the gate means `cargo +1.98.0 clippy` with the flags above. Making the two agree would mean getting `ecc-sig-verifier` onto a modern solana-sdk, which is a larger change than unblocking CI.
