### PR TITLE
fix: skip sim-derived loaded-accounts-data-size limit on wallet-signed txs

### DIFF
--- a/.changeset/wallet-signed-data-size-limit.md
+++ b/.changeset/wallet-signed-data-size-limit.md
@@ -1,4 +1,5 @@
 ---
+"@helium/blockchain-api": patch
 "@helium/spl-utils": patch
 "@helium/distributor-oracle": patch
 "@helium/voter-stake-registry-hooks": patch

--- a/.changeset/wallet-signed-data-size-limit.md
+++ b/.changeset/wallet-signed-data-size-limit.md
@@ -1,6 +1,5 @@
 ---
 "@helium/spl-utils": patch
-"@helium/blockchain-api": patch
 ---
 
 Add `deriveLoadedAccountsDataSizeLimit` opt-out to `withPriorityFees` and `batchInstructionsToTxsWithPriorityFee`, and disable sim-derived loaded-accounts-data-size limits on all blockchain-api wallet-signed transactions. Wallets append guard instructions (Lighthouse) after sizing, which exceeded the derived limit and failed with `MaxLoadedAccountsDataSizeExceeded`.

--- a/.changeset/wallet-signed-data-size-limit.md
+++ b/.changeset/wallet-signed-data-size-limit.md
@@ -1,0 +1,6 @@
+---
+"@helium/spl-utils": patch
+"@helium/blockchain-api": patch
+---
+
+Add `deriveLoadedAccountsDataSizeLimit` opt-out to `withPriorityFees` and `batchInstructionsToTxsWithPriorityFee`, and disable sim-derived loaded-accounts-data-size limits on all blockchain-api wallet-signed transactions. Wallets append guard instructions (Lighthouse) after sizing, which exceeded the derived limit and failed with `MaxLoadedAccountsDataSizeExceeded`.

--- a/.changeset/wallet-signed-data-size-limit.md
+++ b/.changeset/wallet-signed-data-size-limit.md
@@ -1,5 +1,7 @@
 ---
 "@helium/spl-utils": patch
+"@helium/distributor-oracle": patch
+"@helium/voter-stake-registry-hooks": patch
 ---
 
-Add `deriveLoadedAccountsDataSizeLimit` opt-out to `withPriorityFees` and `batchInstructionsToTxsWithPriorityFee`, and disable sim-derived loaded-accounts-data-size limits on all blockchain-api wallet-signed transactions. Wallets append guard instructions (Lighthouse) after sizing, which exceeded the derived limit and failed with `MaxLoadedAccountsDataSizeExceeded`.
+Add `deriveLoadedAccountsDataSizeLimit` opt-out to `withPriorityFees` and `batchInstructionsToTxsWithPriorityFee`, and disable sim-derived loaded-accounts-data-size limits on wallet-signed transactions in blockchain-api, distributor-oracle, and voter-stake-registry-hooks. Wallets append guard instructions (Lighthouse) after sizing, which exceeded the derived limit and failed with `MaxLoadedAccountsDataSizeExceeded`.

--- a/packages/blockchain-api/src/lib/utils/build-transaction.ts
+++ b/packages/blockchain-api/src/lib/utils/build-transaction.ts
@@ -74,6 +74,9 @@ export async function buildVersionedTransaction({
       ...draftWithLuts,
       addressLookupTables,
       connection,
+      // The wallet signs this tx and may append guard ixs (Lighthouse) that
+      // load more account data than a sim-derived limit allows.
+      deriveLoadedAccountsDataSizeLimit: false,
     });
   } catch (error) {
     console.warn(

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-transaction.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/automation-transaction.ts
@@ -97,6 +97,8 @@ export const buildAutomationTransactionResponse = async ({
     await batchInstructionsToTxsWithPriorityFee(provider, instructions, {
       addressLookupTableAddresses: [getHeliumLookupTable()],
       commitment: "finalized",
+      // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+      deriveLoadedAccountsDataSizeLimit: false,
     })
   ).map((tx) => toVersionedTx(tx));
 

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimRewards.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimRewards.ts
@@ -397,6 +397,8 @@ export const claimRewards = publicProcedure.hotspots.claimRewards.handler(
             : HELIUM_COMMON_LUT,
         ],
         commitment: "finalized",
+        // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+        deriveLoadedAccountsDataSizeLimit: false,
       })
     ).map((tx) => toVersionedTx(tx));
 

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/closeAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/closeAutomation.ts
@@ -95,6 +95,8 @@ export const closeAutomation = publicProcedure.hotspots.closeAutomation.handler(
             : HELIUM_COMMON_LUT,
         ],
         commitment: "finalized",
+        // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+        deriveLoadedAccountsDataSizeLimit: false,
       })
     ).map((tx) => toVersionedTx(tx));
 

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createAutomation.ts
@@ -233,6 +233,8 @@ export const createAutomation =
               : HELIUM_COMMON_LUT,
           ],
           commitment: "finalized",
+          // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+          deriveLoadedAccountsDataSizeLimit: false,
         })
       ).map((tx) => toVersionedTx(tx));
 

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createSplit.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createSplit.ts
@@ -216,6 +216,8 @@ export const createSplit = publicProcedure.hotspots.createSplit.handler(
             : HELIUM_COMMON_LUT,
         ],
         commitment: "finalized",
+        // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+        deriveLoadedAccountsDataSizeLimit: false,
       })
     ).map((tx) => toVersionedTx(tx));
 

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/fundAutomation.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/fundAutomation.ts
@@ -146,6 +146,8 @@ export const fundAutomation = publicProcedure.hotspots.fundAutomation.handler(
             : HELIUM_COMMON_LUT,
         ],
         commitment: "finalized",
+        // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+        deriveLoadedAccountsDataSizeLimit: false,
       })
     ).map((tx) => toVersionedTx(tx));
 

--- a/packages/blockchain-api/src/server/api/routers/migration/procedures/migrate.ts
+++ b/packages/blockchain-api/src/server/api/routers/migration/procedures/migrate.ts
@@ -803,6 +803,8 @@ export const migrate = publicProcedure.migration.migrate.handler(
     const batchOpts = {
       addressLookupTableAddresses: [lut],
       commitment: "finalized" as const,
+      // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+      deriveLoadedAccountsDataSizeLimit: false,
     };
 
     const addDrafts = (drafts: TransactionDraft[], description: string) => {

--- a/packages/distributor-oracle/src/client.ts
+++ b/packages/distributor-oracle/src/client.ts
@@ -553,6 +553,8 @@ export async function formBulkTransactions({
       addressLookupTableAddresses: [
         isDevnet ? HELIUM_COMMON_LUT_DEVNET : HELIUM_COMMON_LUT,
       ],
+      // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+      deriveLoadedAccountsDataSizeLimit: false,
     }
   );
   const initialTxs = initialTxDrafts.map(toVersionedTx);

--- a/packages/distributor-oracle/src/client.ts
+++ b/packages/distributor-oracle/src/client.ts
@@ -772,6 +772,8 @@ export async function formTransaction({
     connection: provider.connection,
     basePriorityFee,
     ...fullDraft,
+    // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+    deriveLoadedAccountsDataSizeLimit: false,
   });
   const tx = toVersionedTx({
     ...fullDraft,

--- a/packages/spl-utils/src/priorityFees.ts
+++ b/packages/spl-utils/src/priorityFees.ts
@@ -268,11 +268,17 @@ export async function withPriorityFees({
   // simulation's measured size, or left unset (runtime 64 MiB default) when
   // no simulation validated a ceiling.
   loadedAccountsDataSizeLimit,
+  // Set false for txs a wallet signs. Wallets (Phantom, Solflare) append
+  // guard ixs (Lighthouse, ~424 KiB of program data) after we size the tx;
+  // a sim-derived limit with 10% headroom then fails on-chain with
+  // MaxLoadedAccountsDataSizeExceeded. An explicit limit is still honored.
+  deriveLoadedAccountsDataSizeLimit = true,
   ...rest
 }: {
   connection: Connection;
   computeUnits?: number;
   basePriorityFee?: number;
+  deriveLoadedAccountsDataSizeLimit?: boolean;
   // Headroom multiplier applied to the simulated CU consumption AND to the
   // sim-derived loaded-accounts-data-size request — one knob scales both.
   computeScaleUp?: number;
@@ -313,7 +319,10 @@ export async function withPriorityFees({
     // The ceiling the sim tx validates against when we insert our own
     // ComputeBudget ixs below.
     const simCeiling =
-      loadedAccountsDataSizeLimit ?? DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_LIMIT;
+      loadedAccountsDataSizeLimit ??
+      (deriveLoadedAccountsDataSizeLimit
+        ? DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_LIMIT
+        : undefined);
     // LUTs are needed to compile the sim tx; the blockhash is not —
     // simulation replaces it (replaceRecentBlockhash), so a placeholder
     // satisfies toVersionedTx without a getLatestBlockhash RPC.
@@ -331,9 +340,11 @@ export async function withPriorityFees({
     // Only true when our data-size ix actually enters the sim tx. When the
     // caller brought their own data-size ix the sim runs under their ceiling
     // instead, and nothing has validated ours.
-    const simValidatesDataSizeCeiling = !callerComputeBudgetTypes(
-      tx.instructions
-    ).has(COMPUTE_BUDGET_IX_DATA_SIZE);
+    const simValidatesDataSizeCeiling =
+      simCeiling != null &&
+      !callerComputeBudgetTypes(tx.instructions).has(
+        COMPUTE_BUDGET_IX_DATA_SIZE
+      );
     const ixWithComputeUnits = prependComputeBudgetIxs(tx.instructions, {
       computeUnits: MAX_COMPUTE_UNITS,
       microLamports: 1,
@@ -384,7 +395,7 @@ export async function withPriorityFees({
       }
     }
     computeUnits = budget.computeUnits;
-    if (loadedAccountsDataSizeLimit == null) {
+    if (loadedAccountsDataSizeLimit == null && simCeiling != null) {
       if (budget.simulated && budget.loadedAccountsDataSize) {
         // Request measured size × headroom, rounded up to the 32 KiB fee
         // quantum — mirrors the CU model. Clamp to the default ceiling only

--- a/packages/spl-utils/src/transaction.ts
+++ b/packages/spl-utils/src/transaction.ts
@@ -923,11 +923,18 @@ export async function batchInstructionsToTxsWithPriorityFee(
           microLamports: 1,
         }),
         // Probe must match the real tx's ix count or the size check
-        // under-measures and a full batch overflows maxTxSize. The ix is a
-        // fixed 5 bytes, so the placeholder value doesn't affect sizing.
-        setLoadedAccountsDataSizeLimit(
-          loadedAccountsDataSizeLimit ?? DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_LIMIT
-        ),
+        // mis-measures: under-counting overflows maxTxSize, over-counting
+        // splits early. The ix is a fixed 5 bytes, so the placeholder value
+        // doesn't affect sizing. Omit it when the real tx won't carry one.
+        ...(loadedAccountsDataSizeLimit != null ||
+        deriveLoadedAccountsDataSizeLimit !== false
+          ? [
+              setLoadedAccountsDataSizeLimit(
+                loadedAccountsDataSizeLimit ??
+                  DEFAULT_LOADED_ACCOUNTS_DATA_SIZE_LIMIT
+              ),
+            ]
+          : []),
         ...currentTxInstructions,
       ],
       addressLookupTableAddresses: addressLookupTableAddresses || [],

--- a/packages/spl-utils/src/transaction.ts
+++ b/packages/spl-utils/src/transaction.ts
@@ -822,6 +822,8 @@ export async function batchInstructionsToTxsWithPriorityFee(
     commitment = "confirmed",
     // Leave unset to let withPriorityFees derive it from simulation.
     loadedAccountsDataSizeLimit,
+    // See withPriorityFees; set false for wallet-signed txs.
+    deriveLoadedAccountsDataSizeLimit,
   }: {
     commitment?: Commitment;
     // Manually specify limit instead of simulating
@@ -839,6 +841,7 @@ export async function batchInstructionsToTxsWithPriorityFee(
     // Optional parameter to limit number of instructions per transaction
     maxInstructionsPerTx?: number;
     loadedAccountsDataSizeLimit?: number;
+    deriveLoadedAccountsDataSizeLimit?: boolean;
   } = {}
 ): Promise<TransactionDraft[]> {
   let currentTxInstructions: TransactionInstruction[] = [];
@@ -876,6 +879,7 @@ export async function batchInstructionsToTxsWithPriorityFee(
         addressLookupTables,
         feePayer: provider.wallet.publicKey,
         loadedAccountsDataSizeLimit,
+        deriveLoadedAccountsDataSizeLimit,
       });
       if (useFirstEstimateForAll) {
         // A sim-derived data-size limit was measured against THIS tx's

--- a/packages/voter-stake-registry-hooks/src/hooks/useSplitPosition.ts
+++ b/packages/voter-stake-registry-hooks/src/hooks/useSplitPosition.ts
@@ -149,7 +149,9 @@ export const useSplitPosition = () => {
           const sigs = [mintKeypair];
           const drafts = await batchInstructionsToTxsWithPriorityFee(
             provider,
-            instructions
+            instructions,
+            // Wallet-signed: guard ixs may be appended (see withPriorityFees).
+            { deriveLoadedAccountsDataSizeLimit: false }
           );
           const transactions = drafts.map(toVersionedTx);
 

--- a/tests/priority-fees.ts
+++ b/tests/priority-fees.ts
@@ -198,6 +198,43 @@ describe("withPriorityFees", () => {
     expect(dataSize.data.readUInt32LE(1)).to.eq(64 * 1024);
   });
 
+  it("emits no data-size ix in the sim tx or the output when deriveLoadedAccountsDataSizeLimit is false", async () => {
+    const simTxs: any[] = [];
+    const ixs = await withPriorityFees({
+      connection: stubConnection({
+        sim: {
+          err: null,
+          unitsConsumed: 50000,
+          loadedAccountsDataSize: 100000,
+        },
+        simTxs,
+      }),
+      instructions: [transferIx],
+      feePayer,
+      deriveLoadedAccountsDataSizeLimit: false,
+    });
+    expect(simCbIxs(simTxs[0], COMPUTE_BUDGET_IX_DATA_SIZE).length).to.eq(0);
+    expect(cbIxs(ixs, COMPUTE_BUDGET_IX_DATA_SIZE).length).to.eq(0);
+    // CU sizing is unaffected.
+    const [limit] = cbIxs(ixs, COMPUTE_BUDGET_IX_LIMIT);
+    expect(limit.data.readUInt32LE(1)).to.eq(Math.ceil(50000 * 1.1));
+  });
+
+  it("still emits an explicit loadedAccountsDataSizeLimit when deriveLoadedAccountsDataSizeLimit is false", async () => {
+    const ixs = await withPriorityFees({
+      connection: stubConnection({
+        sim: { err: null, unitsConsumed: 50000, loadedAccountsDataSize: 100000 },
+      }),
+      instructions: [transferIx],
+      feePayer,
+      loadedAccountsDataSizeLimit: 64 * 1024,
+      deriveLoadedAccountsDataSizeLimit: false,
+    });
+    const dataSizes = cbIxs(ixs, COMPUTE_BUDGET_IX_DATA_SIZE);
+    expect(dataSizes.length).to.eq(1);
+    expect(dataSizes[0].data.readUInt32LE(1)).to.eq(64 * 1024);
+  });
+
   it("derives the data-size limit from simulation, rounded up to the 32 KiB quantum", async () => {
     const ixs = await withPriorityFees({
       connection: stubConnection({


### PR DESCRIPTION
## Problem

blockchain-api preflight sims failed with `MaxLoadedAccountsDataSizeExceeded` on `governance.assignProxies` (prod `my-helium` logs, 2026-08-27 12:13Z). Decoding the failing message shows two Lighthouse (`L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`) instructions that this repo never adds — the user's wallet appended them at signing time. Lighthouse loads ~424 KiB of program data, which exceeds the ~10% headroom of the sim-derived `setLoadedAccountsDataSizeLimit` (2,424,832 bytes) we attached at build time.

Any tx we return unsigned to a wallet that injects guard ixs (Phantom, Solflare) is exposed.

## Fix

- `@helium/spl-utils`: add `deriveLoadedAccountsDataSizeLimit` (default `true`) to `withPriorityFees` and `batchInstructionsToTxsWithPriorityFee`. When `false`, the sim runs without a data-size ceiling and no data-size ix is emitted. An explicit `loadedAccountsDataSizeLimit` is still honored.
- blockchain-api: set it `false` at both build chokepoints — `buildVersionedTransaction` and every direct `batchInstructionsToTxsWithPriorityFee` call. Every tx built there is wallet-signed or wallet-co-signed (including `reward-contract/claim` and `welcomePacks/claim`, which pass a server fee payer), so all of them now run under the runtime 64 MiB default. Only callers outside blockchain-api that never hand a tx to a wallet keep the derived limit.
- distributor-oracle `client.ts` and `useSplitPosition` also build wallet-signed txs; both opt out.
- `batchInstructionsToTxsWithPriorityFee` size probe omits the data-size ix when the opt-out guarantees the real tx won't carry one.
- `distributor-oracle` `formTransaction` also opts out, matching `formBulkTransactions`.

## Why not floor wallet-signed txs up to the 16 MiB default instead?

Considered. A fixed ceiling is a guess about what wallets append, and the set of guards is outside our control. The fee saving from a 16 MiB request vs the 64 MiB runtime default is small on these txs; a failed tx costs the user more. So wallet-signed txs get no data-size ix at all.

## Verification

- `tests/priority-fees.ts`: 27 passing, including two new cases for the opt-out (no ix in sim or output; explicit limit still emitted).

- `spl-utils` `tsc -b` clean.
- blockchain-api `tsc --noEmit`: same 6 pre-existing `tests/e2e` errors before and after; none from this change.

