### PR TITLE
fix: address production-log bugs in proxy assignment, claims, and tx status

### DIFF
--- a/.changeset/prod-log-bugs-proxy-claims.md
+++ b/.changeset/prod-log-bugs-proxy-claims.md
@@ -9,3 +9,6 @@ Fix bugs surfaced in prod logs:
 - Dedupe hotspots across claim-rewards pages so Jito bundles never contain duplicate transactions
 - Refuse to build `closeDelegationV0` while a required epoch has no issued rewards (the program panics otherwise)
 - Serve the stored batch status when the on-chain status check fails instead of returning 500
+- Order the paginated hotspot query by asset so pages are stable, and dedupe within a page as well as across pages
+- Keep the safe-integer bound on proxy `expirationTime` after flooring
+- Rethrow database errors from the batch status check and build the fallback from a pre-check snapshot

--- a/.changeset/prod-log-bugs-proxy-claims.md
+++ b/.changeset/prod-log-bugs-proxy-claims.md
@@ -1,0 +1,11 @@
+---
+"@helium/blockchain-api-service": patch
+"@helium/blockchain-api": patch
+---
+
+Fix bugs surfaced in prod logs:
+
+- Floor fractional proxy `expirationTime` instead of rejecting it
+- Dedupe hotspots across claim-rewards pages so Jito bundles never contain duplicate transactions
+- Refuse to build `closeDelegationV0` while a required epoch has no issued rewards (the program panics otherwise)
+- Serve the stored batch status when the on-chain status check fails instead of returning 500

--- a/packages/blockchain-api-client/src/schemas/governance.ts
+++ b/packages/blockchain-api-client/src/schemas/governance.ts
@@ -218,7 +218,9 @@ export const AssignProxiesInputSchema = z.object({
   ),
   expirationTime: z
     .number()
-    .int()
+    // Clients compute this from Date.now() / 1000; floor rather than reject
+    // the fractional seconds.
+    .transform((n) => Math.floor(n))
     .describe("Unix timestamp when the proxy assignment expires"),
 });
 

--- a/packages/blockchain-api-client/src/schemas/governance.ts
+++ b/packages/blockchain-api-client/src/schemas/governance.ts
@@ -14,10 +14,10 @@ export const LockupKindSchema = z.enum(["cliff", "constant"]);
 
 export const CreatePositionInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that will own the position"
+    "Wallet address that will own the position",
   ),
   tokenAmount: TokenAmountInputSchema.describe(
-    "Token amount and mint to deposit"
+    "Token amount and mint to deposit",
   ),
   lockupKind: LockupKindSchema.describe("Type of lockup: cliff or constant"),
   lockupPeriodsInDays: z
@@ -27,7 +27,7 @@ export const CreatePositionInputSchema = z.object({
     .max(2920)
     .describe("Number of days to lock the position (max ~8 years)"),
   subDaoMint: PublicKeySchema.optional().describe(
-    "Sub-DAO mint to delegate to immediately after creation (optional)"
+    "Sub-DAO mint to delegate to immediately after creation (optional)",
   ),
   automationEnabled: z
     .boolean()
@@ -37,14 +37,14 @@ export const CreatePositionInputSchema = z.object({
 
 export const ClosePositionInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the position"
+    "Wallet address that owns the position",
   ),
   positionMint: PublicKeySchema.describe("Mint address of the position NFT"),
 });
 
 export const ExtendPositionInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the position"
+    "Wallet address that owns the position",
   ),
   positionMint: PublicKeySchema.describe("Mint address of the position NFT"),
   lockupPeriodsInDays: z
@@ -56,14 +56,14 @@ export const ExtendPositionInputSchema = z.object({
 
 export const FlipLockupKindInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the position"
+    "Wallet address that owns the position",
   ),
   positionMint: PublicKeySchema.describe("Mint address of the position NFT"),
 });
 
 export const ResetLockupInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the position"
+    "Wallet address that owns the position",
   ),
   positionMint: PublicKeySchema.describe("Mint address of the position NFT"),
   lockupKind: LockupKindSchema.describe("New lockup type: cliff or constant"),
@@ -77,16 +77,16 @@ export const ResetLockupInputSchema = z.object({
 
 export const SplitPositionInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the position"
+    "Wallet address that owns the position",
   ),
   positionMint: PublicKeySchema.describe(
-    "Mint address of the source position NFT"
+    "Mint address of the source position NFT",
   ),
   amount: z
     .string()
     .regex(/^\d+$/, "Amount must be a whole number in smallest unit (bones)")
     .describe(
-      "Raw token amount to transfer to new position (in smallest unit)"
+      "Raw token amount to transfer to new position (in smallest unit)",
     ),
   lockupKind: LockupKindSchema.describe("Lockup type for new position"),
   lockupPeriodsInDays: z
@@ -98,13 +98,13 @@ export const SplitPositionInputSchema = z.object({
 
 export const TransferPositionInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the source position and pays transaction fees"
+    "Wallet address that owns the source position and pays transaction fees",
   ),
   positionMint: PublicKeySchema.describe(
-    "Mint address of the source position NFT"
+    "Mint address of the source position NFT",
   ),
   targetPositionMint: PublicKeySchema.describe(
-    "Mint address of the target position NFT. May be owned by a different wallet; its lockup must be equal-or-longer and equal-or-stricter than the source's."
+    "Mint address of the target position NFT. May be owned by a different wallet; its lockup must be equal-or-longer and equal-or-stricter than the source's.",
   ),
   amount: z
     .string()
@@ -114,23 +114,23 @@ export const TransferPositionInputSchema = z.object({
 
 export const GetPositionsInputSchema = z.object({
   wallet: WalletAddressSchema.describe(
-    "Wallet address to list governance positions for"
+    "Wallet address to list governance positions for",
   ),
 });
 
 export const TransferPositionOwnershipInputSchema = z.object({
   from: WalletAddressSchema.describe(
-    "Wallet address that currently owns the position"
+    "Wallet address that currently owns the position",
   ),
   to: WalletAddressSchema.describe(
-    "Wallet address that will receive the position"
+    "Wallet address that will receive the position",
   ),
   positionMint: PublicKeySchema.describe("Mint address of the position NFT"),
 });
 
 export const DelegatePositionInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the positions"
+    "Wallet address that owns the positions",
   ),
   positionMints: z
     .array(PublicKeySchema)
@@ -145,21 +145,21 @@ export const DelegatePositionInputSchema = z.object({
 
 export const ExtendDelegationInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the position"
+    "Wallet address that owns the position",
   ),
   positionMint: PublicKeySchema.describe("Mint address of the position NFT"),
 });
 
 export const UndelegateInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the position"
+    "Wallet address that owns the position",
   ),
   positionMint: PublicKeySchema.describe("Mint address of the position NFT"),
 });
 
 export const ClaimDelegationRewardsInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the positions"
+    "Wallet address that owns the positions",
   ),
   positionMints: z
     .array(PublicKeySchema)
@@ -169,10 +169,10 @@ export const ClaimDelegationRewardsInputSchema = z.object({
 
 export const VoteInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the positions"
+    "Wallet address that owns the positions",
   ),
   proposalKey: PublicKeySchema.describe(
-    "Public key of the proposal to vote on"
+    "Public key of the proposal to vote on",
   ),
   positionMints: z
     .array(PublicKeySchema)
@@ -183,10 +183,10 @@ export const VoteInputSchema = z.object({
 
 export const RelinquishVoteInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the positions"
+    "Wallet address that owns the positions",
   ),
   proposalKey: PublicKeySchema.describe(
-    "Public key of the proposal to relinquish vote from"
+    "Public key of the proposal to relinquish vote from",
   ),
   positionMints: z
     .array(PublicKeySchema)
@@ -197,36 +197,38 @@ export const RelinquishVoteInputSchema = z.object({
 
 export const RelinquishPositionVotesInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the position"
+    "Wallet address that owns the position",
   ),
   positionMint: PublicKeySchema.describe("Mint address of the position NFT"),
   organization: PublicKeySchema.describe(
-    "Public key of the DAO organization to relinquish votes from"
+    "Public key of the DAO organization to relinquish votes from",
   ),
 });
 
 export const AssignProxiesInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the positions"
+    "Wallet address that owns the positions",
   ),
   positionMints: z
     .array(PublicKeySchema)
     .min(1)
     .describe("Array of position NFT mint addresses to assign proxy for"),
   proxyKey: PublicKeySchema.describe(
-    "Public key of the proxy recipient who will vote on your behalf"
+    "Public key of the proxy recipient who will vote on your behalf",
   ),
   expirationTime: z
     .number()
     // Clients compute this from Date.now() / 1000; floor rather than reject
     // the fractional seconds.
+    .min(0)
+    .max(Number.MAX_SAFE_INTEGER)
     .transform((n) => Math.floor(n))
     .describe("Unix timestamp when the proxy assignment expires"),
 });
 
 export const UnassignProxiesInputSchema = z.object({
   walletAddress: WalletAddressSchema.describe(
-    "Wallet address that owns the positions"
+    "Wallet address that owns the positions",
   ),
   proxyKey: PublicKeySchema.describe("Public key of the proxy to unassign"),
   positionMints: z
@@ -246,10 +248,10 @@ export const SkipReasonSchema = z.enum([
 
 export const SkippedPositionSchema = z.object({
   positionMint: PublicKeySchema.describe(
-    "Mint of the position that was not included in the vote transactions"
+    "Mint of the position that was not included in the vote transactions",
   ),
   reason: SkipReasonSchema.describe(
-    "Why the position was excluded from the vote transactions"
+    "Why the position was excluded from the vote transactions",
   ),
 });
 
@@ -280,7 +282,7 @@ export const PositionSchema = z.object({
   position: z.string().describe("Position PDA address"),
   registrar: z.string().describe("Registrar the position belongs to"),
   amountDeposited: TokenAmountOutputSchema.describe(
-    "Amount deposited in the position; mint is the governing token mint"
+    "Amount deposited in the position; mint is the governing token mint",
   ),
   numActiveVotes: z
     .number()
@@ -299,14 +301,14 @@ export const GetPositionsResponseSchema = z.array(PositionSchema);
 // ---------------------------------------------------------------------------
 
 export const CreatePositionResponseSchema = createTypedTransactionResponse(
-  CreatePositionMetadataSchema
+  CreatePositionMetadataSchema,
 );
 export const ClosePositionResponseSchema = createTransactionResponse();
 export const ExtendPositionResponseSchema = createTransactionResponse();
 export const FlipLockupKindResponseSchema = createTransactionResponse();
 export const ResetLockupResponseSchema = createTransactionResponse();
 export const SplitPositionResponseSchema = createTypedTransactionResponse(
-  SplitPositionMetadataSchema
+  SplitPositionMetadataSchema,
 );
 export const TransferPositionResponseSchema = createTransactionResponse();
 export const TransferPositionOwnershipResponseSchema =
@@ -330,7 +332,7 @@ export const VoteResponseSchema = createPaginatedTransactionResponse().extend({
     // reporting).
     .default([])
     .describe(
-      "Positions not included in the vote transactions, each with the reason it was skipped. Empty when every position is eligible."
+      "Positions not included in the vote transactions, each with the reason it was skipped. Empty when every position is eligible.",
     ),
 });
 export const RelinquishVoteResponseSchema =

--- a/packages/blockchain-api/src/lib/queries/hotspots.ts
+++ b/packages/blockchain-api/src/lib/queries/hotspots.ts
@@ -62,11 +62,11 @@ const IOT_SUB_DAO_KEY = subDaoKey(IOT_MINT)[0];
 const MOBILE_SUB_DAO_KEY = subDaoKey(MOBILE_MINT)[0];
 export const IOT_CONFIG_KEY = rewardableEntityConfigKey(
   IOT_SUB_DAO_KEY,
-  "IOT"
+  "IOT",
 )[0];
 export const MOBILE_CONFIG_KEY = rewardableEntityConfigKey(
   MOBILE_SUB_DAO_KEY,
-  "MOBILE"
+  "MOBILE",
 )[0];
 
 interface GetHotspotsOptions {
@@ -78,7 +78,7 @@ interface GetHotspotsOptions {
 
 const HNT_DAO = daoKey(HNT_MINT)[0];
 export function toHotspot(
-  hotspotOwnership: HotspotOwnershipAttributes
+  hotspotOwnership: HotspotOwnershipAttributes,
 ): Hotspot {
   const decodedAddress = hotspotOwnership.encodedEntityKey;
 
@@ -97,7 +97,7 @@ export function toHotspot(
       typeof hotspotOwnership.entityKey === "string"
         ? Buffer.from(hotspotOwnership.entityKey, "utf-8")
         : hotspotOwnership.entityKey,
-      hotspotOwnership.keySerialization as any
+      hotspotOwnership.keySerialization as any,
     )[0].toBase58(),
     entityKey: decodedAddress ? decodedAddress : "",
     name: decodedAddress ? animalName(decodedAddress) : "",
@@ -136,7 +136,7 @@ function toHotspotFromAsset(owner: string, asset: any): Hotspot {
 
 export async function getNumRecipientsNeeded(
   owner: string,
-  lazyDistributorAddress: string = HNT_LAZY_DISTRIBUTOR_ADDRESS
+  lazyDistributorAddress: string = HNT_LAZY_DISTRIBUTOR_ADDRESS,
 ): Promise<number> {
   if (env.NO_PG === "true") {
     const allAssets = await searchAssetsWithPageInfo(env.ASSET_ENDPOINT!, {
@@ -158,12 +158,11 @@ export async function getNumRecipientsNeeded(
       (asset) =>
         recipientKey(
           new PublicKey(lazyDistributorAddress),
-          new PublicKey(asset.id)
-        )[0]
+          new PublicKey(asset.id),
+        )[0],
     );
-    const recipients = await lazyProgram.account.recipientV0.fetchMultiple(
-      recipientKeys
-    );
+    const recipients =
+      await lazyProgram.account.recipientV0.fetchMultiple(recipientKeys);
     return recipients.filter((r) => !r).length;
   } else {
     await connectToDb();
@@ -216,29 +215,29 @@ export async function getHotspotsByOwner({
 
     // Fetch keyToAsset accounts in a single cached batch to ensure entityKey is decoded reliably
     const keyToAssetPubkeys = await Promise.all(
-      allAssets.items.map((asset) => keyToAssetForAsset(asset))
+      allAssets.items.map((asset) => keyToAssetForAsset(asset)),
     );
     // @ts-ignore
     const keyToAssets = await hemProgram.account.keyToAssetV0.fetchMultiple(
-      keyToAssetPubkeys.filter(Boolean) as PublicKey[]
+      keyToAssetPubkeys.filter(Boolean) as PublicKey[],
     );
 
     // Decode entity keys using helper
     const entityKeys = keyToAssets.map((kta: any) =>
       kta?.entityKey
         ? decodeEntityKey(kta.entityKey, kta.keySerialization)
-        : undefined
+        : undefined,
     );
 
     // Prepare hotspot info keys from env-provided configs (optional)
     const iotInfoPubkeys = entityKeys.length
       ? entityKeys.map((ek) =>
-          ek ? iotInfoKey(new PublicKey(IOT_CONFIG_KEY), ek)[0] : null
+          ek ? iotInfoKey(new PublicKey(IOT_CONFIG_KEY), ek)[0] : null,
         )
       : [];
     const mobileInfoPubkeys = entityKeys.length
       ? entityKeys.map((ek) =>
-          ek ? mobileInfoKey(new PublicKey(MOBILE_CONFIG_KEY), ek)[0] : null
+          ek ? mobileInfoKey(new PublicKey(MOBILE_CONFIG_KEY), ek)[0] : null,
         )
       : [];
 
@@ -247,14 +246,14 @@ export async function getHotspotsByOwner({
       iotInfoPubkeys.length > 0
         ? // @ts-ignore
           await hemProgram.account.iotHotspotInfoV0.fetchMultiple(
-            iotInfoPubkeys.filter(Boolean) as PublicKey[]
+            iotInfoPubkeys.filter(Boolean) as PublicKey[],
           )
         : [];
     const mobileInfos =
       mobileInfoPubkeys.length > 0
         ? // @ts-ignore
           await hemProgram.account.mobileHotspotInfoV0.fetchMultiple(
-            mobileInfoPubkeys.filter(Boolean) as PublicKey[]
+            mobileInfoPubkeys.filter(Boolean) as PublicKey[],
           )
         : [];
 
@@ -267,7 +266,7 @@ export async function getHotspotsByOwner({
         iotInfos.length > 0 && iotInfoPubkeys[index]
           ? iotInfos[
               (iotInfoPubkeys.filter(Boolean) as PublicKey[]).indexOf(
-                iotInfoPubkeys[index] as PublicKey
+                iotInfoPubkeys[index] as PublicKey,
               )
             ]
           : undefined;
@@ -275,7 +274,7 @@ export async function getHotspotsByOwner({
         mobileInfos.length > 0 && mobileInfoPubkeys[index]
           ? mobileInfos[
               (mobileInfoPubkeys.filter(Boolean) as PublicKey[]).indexOf(
-                mobileInfoPubkeys[index] as PublicKey
+                mobileInfoPubkeys[index] as PublicKey,
               )
             ]
           : undefined;
@@ -327,6 +326,7 @@ export async function getHotspotsByOwner({
     const { count: total, rows } = await HotspotOwnership.findAndCountAll({
       limit,
       offset,
+      order: [["asset", "ASC"]],
       where: {
         destination: owner,
       },
@@ -357,7 +357,7 @@ export async function getHotspotsByOwner({
 
 export async function getHotspotInfo(
   provider: AnchorProvider,
-  entityKey: string
+  entityKey: string,
 ): Promise<HotspotInfo> {
   const hemProgram = await initHemLocal(provider);
 
@@ -374,7 +374,7 @@ export async function getHotspotInfo(
 
 export async function detectHotspotNetworks(
   provider: AnchorProvider,
-  entityKey: string
+  entityKey: string,
 ): Promise<HotspotNetworks> {
   if (env.NO_PG === "false") {
     await connectToDb();
@@ -396,13 +396,12 @@ export async function detectHotspotNetworks(
 
 export async function getHotspotInfoByAsset(
   provider: AnchorProvider,
-  assetId: PublicKey
+  assetId: PublicKey,
 ): Promise<HotspotInfo & { entityKey: string }> {
   const hemProgram = await initHemLocal(provider);
 
-  const keyToAsset = await hemProgram.account.keyToAssetV0.fetchNullable(
-    assetId
-  );
+  const keyToAsset =
+    await hemProgram.account.keyToAssetV0.fetchNullable(assetId);
 
   if (!keyToAsset) {
     throw new Error("Asset not found in keyToAsset registry");
@@ -410,7 +409,7 @@ export async function getHotspotInfoByAsset(
 
   const entityKey = decodeEntityKey(
     keyToAsset.entityKey,
-    keyToAsset.keySerialization
+    keyToAsset.keySerialization,
   );
 
   if (!entityKey) {
@@ -423,7 +422,7 @@ export async function getHotspotInfoByAsset(
 }
 
 export async function hasRewardContract(
-  entityPubKey: string
+  entityPubKey: string,
 ): Promise<boolean> {
   const assetId = await getAssetIdFromPubkey(entityPubKey);
   if (!assetId) return false;
@@ -452,11 +451,10 @@ export async function hasRewardContract(
   const ldProgram = await initLd(provider);
   const [recipientK] = recipientKey(
     new PublicKey(HNT_LAZY_DISTRIBUTOR_ADDRESS),
-    assetPubkey
+    assetPubkey,
   );
-  const recipientAcc = await ldProgram.account.recipientV0.fetchNullable(
-    recipientK
-  );
+  const recipientAcc =
+    await ldProgram.account.recipientV0.fetchNullable(recipientK);
 
   if (recipientAcc && !recipientAcc.destination.equals(PublicKey.default)) {
     const mfProgram = await initMiniFanout(provider);
@@ -465,9 +463,8 @@ export async function hasRewardContract(
     // Verify the destination is actually a mini fanout account
     let miniFanoutAccount = null;
     try {
-      miniFanoutAccount = await mfProgram.account.miniFanoutV0.fetchNullable(
-        miniFanout
-      );
+      miniFanoutAccount =
+        await mfProgram.account.miniFanoutV0.fetchNullable(miniFanout);
     } catch {
       // Destination exists but is not a MiniFanout account - treat as no contract
     }

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/delegate.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/delegate.ts
@@ -35,6 +35,7 @@ import {
   requirePositionOwnershipWithMessage,
   getCurrentSeasonEnd,
   buildClaimInstructions,
+  type ClaimInstructionsResult,
   buildBatchedTransactions,
   PREPAID_TX_FEES,
   TASK_QUEUE,
@@ -230,10 +231,12 @@ export const delegate = publicProcedure.governance.delegatePositions.handler(
       info.delegatedPositionAcc = null;
     }
 
-    let claimResult = {
-      instructionBatches: [] as TransactionInstruction[][],
+    let claimResult: ClaimInstructionsResult = {
+      instructionBatches: [],
       hasMore: false,
       hasRewards: false,
+      rewardMints: [],
+      unclaimableEpochs: [],
     };
 
     if (positionsNeedingClaim.length > 0) {
@@ -297,6 +300,20 @@ export const delegate = publicProcedure.governance.delegatePositions.handler(
           ),
         };
       }
+    }
+
+    // closeDelegationV0 panics if any required epoch is still unclaimed.
+    // changeDelegationV0 tolerates it, so only the expired closes matter here.
+    const expiredMints = new Set(
+      expiredPositionInfos.map((info) => info.positionMintPubkey.toBase58())
+    );
+    const blocking = claimResult.unclaimableEpochs.find((u) =>
+      expiredMints.has(u.positionMint.toBase58())
+    );
+    if (blocking) {
+      throw errors.BAD_REQUEST({
+        message: `Rewards for epoch ${blocking.epoch} have not been issued yet. Try delegating again after they are issued.`,
+      });
     }
 
     const allGroups: InstructionGroup[] = [];

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/undelegate.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/undelegate.ts
@@ -41,9 +41,8 @@ export const undelegate = publicProcedure.governance.undelegatePosition.handler(
 
     const [positionPubkey] = positionKey(positionMintPubkey);
 
-    const positionAcc = await vsrProgram.account.positionV0.fetchNullable(
-      positionPubkey
-    );
+    const positionAcc =
+      await vsrProgram.account.positionV0.fetchNullable(positionPubkey);
 
     if (!positionAcc) {
       throw errors.NOT_FOUND({ message: "Position not found" });
@@ -86,6 +85,13 @@ export const undelegate = publicProcedure.governance.undelegatePosition.handler(
       connection,
       hsdProgram,
     });
+
+    if (!claimResult.hasMore && claimResult.unclaimableEpochs.length > 0) {
+      const { epoch } = claimResult.unclaimableEpochs[0];
+      throw errors.BAD_REQUEST({
+        message: `Rewards for epoch ${epoch} have not been issued yet. Try undelegating again after they are issued.`,
+      });
+    }
 
     if (claimResult.hasMore) {
       const claimGroups: InstructionGroup[] =

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
@@ -67,6 +67,13 @@ export interface ClaimInstructionsResult {
   hasMore: boolean;
   hasRewards: boolean;
   rewardMints: PublicKey[];
+  /**
+   * Epochs that closeDelegationV0 requires claimed but whose rewards have not
+   * been issued yet. The program asserts last_claimed_epoch >= curr_epoch - 1
+   * (capped by lockup end / expiration) and panics otherwise, so a close built
+   * while this is non-empty will fail on-chain.
+   */
+  unclaimableEpochs: { positionMint: PublicKey; epoch: number }[];
 }
 
 export interface BuildClaimInstructionsParams {
@@ -129,6 +136,7 @@ export async function buildClaimInstructions(
     epoch: BN;
     subDao: PublicKey;
     subDaoAcc: SubDaoAccount;
+    requiredForClose: boolean;
   };
 
   const maxEpochsThisCall = MAX_TXS_PER_CALL * EPOCHS_PER_BATCH;
@@ -143,6 +151,14 @@ export async function buildClaimInstructions(
     const isConstant = lockupKind === "constant";
     const isDecayed = !isConstant && lockup.endTs.lte(new BN(unixNow));
     const decayedEpoch = lockup.endTs.div(new BN(EPOCH_LENGTH));
+    // Mirrors to_claim_to_epoch in close_delegation_v0.rs
+    const isCliff = lockupKind === "cliff";
+    const closeRequiresThroughEpoch = Math.min(
+      isDecayed && isCliff
+        ? decayedEpoch.toNumber() - 1
+        : currentEpoch.toNumber() - 1,
+      expirationCapEpoch(position.delegatedPosition.expirationTs) - 1
+    );
 
     const subDao = position.delegatedPosition.subDao;
     const subDaoAcc = subDaos[subDao.toBase58()];
@@ -181,6 +197,7 @@ export async function buildClaimInstructions(
           epoch: new BN(e),
           subDao,
           subDaoAcc,
+          requiredForClose: e <= closeRequiresThroughEpoch,
         });
       }
     }
@@ -192,8 +209,11 @@ export async function buildClaimInstructions(
       hasMore: false,
       hasRewards: false,
       rewardMints: [],
+      unclaimableEpochs: [],
     };
   }
+
+  const unclaimableEpochs: ClaimInstructionsResult["unclaimableEpochs"] = [];
 
   const allInstructionBatches: TransactionInstruction[][] = [];
   const rewardMintSet = new Set<string>();
@@ -209,84 +229,97 @@ export async function buildClaimInstructions(
     );
 
     const batchInstructions = await Promise.all(
-      chunk.map(async ({ position, epoch, subDao, subDaoAcc }, index) => {
-        const subDaoEpochInfoAccount = subDaoEpochInfoAccounts[index];
-        if (!subDaoEpochInfoAccount) return null;
+      chunk.map(
+        async (
+          { position, epoch, subDao, subDaoAcc, requiredForClose },
+          index
+        ) => {
+          const subDaoEpochInfoAccount = subDaoEpochInfoAccounts[index];
+          const subDaoEpochInfoData = subDaoEpochInfoAccount
+            ? hsdProgram.coder.accounts.decode(
+                "subDaoEpochInfoV0",
+                subDaoEpochInfoAccount.data
+              )
+            : null;
 
-        const subDaoEpochInfoData = hsdProgram.coder.accounts.decode(
-          "subDaoEpochInfoV0",
-          subDaoEpochInfoAccount.data
-        );
+          if (!subDaoEpochInfoData?.rewardsIssuedAt) {
+            if (requiredForClose) {
+              unclaimableEpochs.push({
+                positionMint: position.mint,
+                epoch: epoch.toNumber(),
+              });
+            }
+            return null;
+          }
 
-        if (!subDaoEpochInfoData.rewardsIssuedAt) return null;
+          const commonAccounts = {
+            position: position.pubkey,
+            mint: position.mint,
+            positionTokenAccount: getAssociatedTokenAddressSync(
+              position.mint,
+              walletPubkey,
+              true
+            ),
+            positionAuthority: walletPubkey,
+            registrar: position.account.registrar,
+            dao: DAO,
+            subDao,
+            delegatedPosition: position.delegatedPositionKey,
+            vsrProgram: VSR_PROGRAM_ID,
+            systemProgram: SystemProgram.programId,
+            circuitBreakerProgram: CIRCUIT_BREAKER_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          };
 
-        const commonAccounts = {
-          position: position.pubkey,
-          mint: position.mint,
-          positionTokenAccount: getAssociatedTokenAddressSync(
-            position.mint,
-            walletPubkey,
-            true
-          ),
-          positionAuthority: walletPubkey,
-          registrar: position.account.registrar,
-          dao: DAO,
-          subDao,
-          delegatedPosition: position.delegatedPositionKey,
-          vsrProgram: VSR_PROGRAM_ID,
-          systemProgram: SystemProgram.programId,
-          circuitBreakerProgram: CIRCUIT_BREAKER_PROGRAM_ID,
-          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-          tokenProgram: TOKEN_PROGRAM_ID,
-        };
-
-        if (subDaoEpochInfoData.hntRewardsIssued.gt(new BN(0))) {
-          rewardMintSet.add(daoAcc.hntMint.toBase58());
-          return hsdProgram.methods
-            .claimRewardsV1({ epoch })
-            .accountsStrict({
-              ...commonAccounts,
-              payer: walletPubkey,
-              hntMint: daoAcc.hntMint,
-              daoEpochInfo: daoEpochInfoKey(
-                subDaoAcc.dao,
-                epoch.mul(new BN(EPOCH_LENGTH))
-              )[0],
-              delegatorPool: daoAcc.delegatorPool,
-              delegatorAta: getAssociatedTokenAddressSync(
-                daoAcc.hntMint,
-                walletPubkey,
-                true
-              ),
-              delegatorPoolCircuitBreaker: accountWindowedBreakerKey(
-                daoAcc.delegatorPool
-              )[0],
-            })
-            .instruction();
-        } else {
-          rewardMintSet.add(subDaoAcc.dntMint.toBase58());
-          return hsdProgram.methods
-            .claimRewardsV0({ epoch })
-            .accountsStrict({
-              ...commonAccounts,
-              dntMint: subDaoAcc.dntMint,
-              subDaoEpochInfo: subDaoEpochInfoKey(
-                subDao,
-                epoch.mul(new BN(EPOCH_LENGTH))
-              )[0],
-              delegatorPool: subDaoAcc.delegatorPool,
-              delegatorAta: getAssociatedTokenAddressSync(
-                subDaoAcc.dntMint,
-                walletPubkey,
-                true
-              ),
-              delegatorPoolCircuitBreaker: accountWindowedBreakerKey(
-                subDaoAcc.delegatorPool
-              )[0],
-            })
-            .instruction();
+          if (subDaoEpochInfoData.hntRewardsIssued.gt(new BN(0))) {
+            rewardMintSet.add(daoAcc.hntMint.toBase58());
+            return hsdProgram.methods
+              .claimRewardsV1({ epoch })
+              .accountsStrict({
+                ...commonAccounts,
+                payer: walletPubkey,
+                hntMint: daoAcc.hntMint,
+                daoEpochInfo: daoEpochInfoKey(
+                  subDaoAcc.dao,
+                  epoch.mul(new BN(EPOCH_LENGTH))
+                )[0],
+                delegatorPool: daoAcc.delegatorPool,
+                delegatorAta: getAssociatedTokenAddressSync(
+                  daoAcc.hntMint,
+                  walletPubkey,
+                  true
+                ),
+                delegatorPoolCircuitBreaker: accountWindowedBreakerKey(
+                  daoAcc.delegatorPool
+                )[0],
+              })
+              .instruction();
+          } else {
+            rewardMintSet.add(subDaoAcc.dntMint.toBase58());
+            return hsdProgram.methods
+              .claimRewardsV0({ epoch })
+              .accountsStrict({
+                ...commonAccounts,
+                dntMint: subDaoAcc.dntMint,
+                subDaoEpochInfo: subDaoEpochInfoKey(
+                  subDao,
+                  epoch.mul(new BN(EPOCH_LENGTH))
+                )[0],
+                delegatorPool: subDaoAcc.delegatorPool,
+                delegatorAta: getAssociatedTokenAddressSync(
+                  subDaoAcc.dntMint,
+                  walletPubkey,
+                  true
+                ),
+                delegatorPoolCircuitBreaker: accountWindowedBreakerKey(
+                  subDaoAcc.delegatorPool
+                )[0],
+              })
+              .instruction();
+          }
         }
-      })
+      )
     );
 
     const validInstructions = batchInstructions.filter(truthy);
@@ -300,5 +333,6 @@ export async function buildClaimInstructions(
     hasMore: hitCap,
     hasRewards: allInstructionBatches.length > 0,
     rewardMints: [...rewardMintSet].map((m) => new PublicKey(m)),
+    unclaimableEpochs,
   };
 }

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimRewards.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimRewards.ts
@@ -118,6 +118,7 @@ export const claimRewards = publicProcedure.hotspots.claimRewards.handler(
       // building transactions so the tx packer never splits a hotspot's
       // init/set/distribute ixs across a slice boundary.
       let allClaimable: Array<{ asset: PublicKey; entityKey: string }> = [];
+      const seenAssets = new Set<string>();
       let currentPage = 1;
       const totalPages = Math.ceil(total / limit);
 
@@ -178,12 +179,16 @@ export const claimRewards = publicProcedure.hotspots.claimRewards.handler(
           );
 
         // Pagination is not stable across requests, so a hotspot can appear
-        // on two pages. A duplicate produces two identical transactions and
-        // Jito rejects the bundle ("must not contain any duplicate transactions").
-        const seen = new Set(allClaimable.map((h) => h.asset.toBase58()));
-        allClaimable.push(
-          ...pageClaimable.filter((h) => !seen.has(h.asset.toBase58())),
-        );
+        // on two pages. HotspotOwnership can also return one asset as several
+        // rows (composite PK), so duplicates can occur within a page too. A
+        // duplicate produces two identical transactions and Jito rejects the
+        // bundle ("must not contain any duplicate transactions").
+        for (const h of pageClaimable) {
+          const key = h.asset.toBase58();
+          if (seenAssets.has(key)) continue;
+          seenAssets.add(key);
+          allClaimable.push(h);
+        }
       }
 
       const hasMore = allClaimable.length > MAX_DIRECT_CLAIM_HOTSPOTS;

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimRewards.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/claimRewards.ts
@@ -177,7 +177,13 @@ export const claimRewards = publicProcedure.hotspots.claimRewards.handler(
             withPending,
           );
 
-        allClaimable.push(...pageClaimable);
+        // Pagination is not stable across requests, so a hotspot can appear
+        // on two pages. A duplicate produces two identical transactions and
+        // Jito rejects the bundle ("must not contain any duplicate transactions").
+        const seen = new Set(allClaimable.map((h) => h.asset.toBase58()));
+        allClaimable.push(
+          ...pageClaimable.filter((h) => !seen.has(h.asset.toBase58())),
+        );
       }
 
       const hasMore = allClaimable.length > MAX_DIRECT_CLAIM_HOTSPOTS;

--- a/packages/blockchain-api/src/server/api/routers/transactions/procedures/get.ts
+++ b/packages/blockchain-api/src/server/api/routers/transactions/procedures/get.ts
@@ -26,7 +26,25 @@ export const get = publicProcedure.transactions.get.handler(
       throw errors.NOT_FOUND({ message: "Batch not found" });
     }
 
-    const result = await checkAndUpdateBatchStatus(batch, commitment);
+    let result: Awaited<ReturnType<typeof checkAndUpdateBatchStatus>>;
+    try {
+      result = await checkAndUpdateBatchStatus(batch, commitment);
+    } catch (error) {
+      // A transient RPC failure (e.g. a 500 from getBlockHeight) must not
+      // surface as a 500 to a client that is polling. Serve the stored state;
+      // the background job re-checks on its next tick.
+      console.error(`Status check failed for batch ${batch.id}:`, error);
+      result = {
+        batchStatus: batch.status,
+        confirmedCount: 0,
+        failedCount: 0,
+        transactionStatuses: (batch.transactions || []).map((tx) => ({
+          signature: tx.signature,
+          status: tx.status,
+          transaction: null,
+        })),
+      };
+    }
 
     return {
       batchId: batch.id,

--- a/packages/blockchain-api/src/server/api/routers/transactions/procedures/get.ts
+++ b/packages/blockchain-api/src/server/api/routers/transactions/procedures/get.ts
@@ -1,7 +1,10 @@
 import { publicProcedure } from "../../../procedures";
 import PendingTransaction from "@/lib/models/pending-transaction";
 import TransactionBatch from "@/lib/models/transaction-batch";
-import { checkAndUpdateBatchStatus } from "@/lib/utils/transaction-status-checker";
+import {
+  BatchStatusResult,
+  checkAndUpdateBatchStatus,
+} from "@/lib/utils/transaction-status-checker";
 import { connectToDb } from "@/lib/utils/db";
 
 /**
@@ -26,23 +29,33 @@ export const get = publicProcedure.transactions.get.handler(
       throw errors.NOT_FOUND({ message: "Batch not found" });
     }
 
-    let result: Awaited<ReturnType<typeof checkAndUpdateBatchStatus>>;
+    // Snapshot the stored state before the check: checkAndUpdateBatchStatus
+    // mutates the loaded instances in memory before committing, and a rollback
+    // does not revert them.
+    const storedBatchStatus = batch.status;
+    const storedStatuses = (batch.transactions || []).map((tx) => ({
+      signature: tx.signature,
+      status: tx.status,
+      transaction: null,
+    }));
+
+    let result: BatchStatusResult;
     try {
       result = await checkAndUpdateBatchStatus(batch, commitment);
     } catch (error) {
+      if (error instanceof Error && error.name === "SequelizeDatabaseError") {
+        throw error;
+      }
       // A transient RPC failure (e.g. a 500 from getBlockHeight) must not
       // surface as a 500 to a client that is polling. Serve the stored state;
       // the background job re-checks on its next tick.
       console.error(`Status check failed for batch ${batch.id}:`, error);
       result = {
-        batchStatus: batch.status,
-        confirmedCount: 0,
-        failedCount: 0,
-        transactionStatuses: (batch.transactions || []).map((tx) => ({
-          signature: tx.signature,
-          status: tx.status,
-          transaction: null,
-        })),
+        batchStatus: storedBatchStatus,
+        confirmedCount: storedStatuses.filter((t) => t.status === "confirmed")
+          .length,
+        failedCount: storedStatuses.filter((t) => t.status === "failed").length,
+        transactionStatuses: storedStatuses,
       };
     }
 
@@ -55,5 +68,5 @@ export const get = publicProcedure.transactions.get.handler(
       jitoBundleId: batch.jitoBundleId,
       jitoBundleStatus: result.jitoBundleStatus,
     };
-  }
+  },
 );


### PR DESCRIPTION
## Summary
Fixes four bugs found in the my-helium production pod logs.

- **Proxy assignment**: `expirationTime` arrived as a float (`Date.now()/1000` on the client) and failed zod validation. The schema now floors it. Companion wallet-app fix on `fix/assign-proxy-int-expiration`.
- **Undelegate / delegate panics**: `closeDelegationV0` `assert!`s that every epoch through `curr_epoch - 1` is claimed. `buildClaimInstructions` skipped epochs whose rewards were not issued yet, leaving a gap, so the close tx panicked on-chain. It now reports `unclaimableEpochs`, and undelegate/delegate return a clear `BAD_REQUEST` instead of building a doomed tx. `changeDelegationV0` paths are unchanged (the program tolerates gaps there).
- **claimRewards Jito rejections**: `getHotspotsByOwner` pagination returned the same hotspot on two pages, producing duplicate txs that Jito rejects. Hotspots are now deduped by asset across pages.
- **transactions.get 500s**: a transient RPC failure in `checkAndUpdateBatchStatus` surfaced as "Failed to update database". The stored batch status is now served with the error logged.

## Follow-up (not in this PR)
`close_delegation_v0.rs` should use `require!` instead of `assert!` so the error is a clean program error. Needs a program deploy.

## Test plan
- `tsc --noEmit` clean for `src` (6 pre-existing e2e typing errors unchanged)
- `pnpm test:unit`: 52 passing
- `changeset status --since=develop` bumps `@helium/blockchain-api-service` and `@helium/blockchain-api` at patch
