### PR TITLE
Fee payer options for update-info and transfers, and verification fixes

### DIFF
--- a/.changeset/fee-payer-options.md
+++ b/.changeset/fee-payer-options.md
@@ -1,0 +1,5 @@
+---
+"@helium/blockchain-api": minor
+---
+
+Add a `feePayer` option to `hotspots/update-info` (`"maker"` default, or `"owner"` to build the update here with the owner paying the fee, DC burn, and any mobile_info resize) and an optional third-party `feePayer` to `tokens/transfer` so a drained wallet's transfer can be paid by another account. Also verify delegate signatures and fee payers before the service signs or attributes anything, and require asset ownership on `updateRewardsDestination`, `createSplit`, and `deleteSplit`.

--- a/packages/blockchain-api-client/src/contracts/hotspots.ts
+++ b/packages/blockchain-api-client/src/contracts/hotspots.ts
@@ -155,6 +155,7 @@ export const hotspotsContract = oc
       .errors({
         BAD_REQUEST: { message: "Invalid parameters", status: 400 },
         NOT_FOUND,
+        UNAUTHORIZED,
         INSUFFICIENT_FUNDS,
       }),
 
@@ -184,6 +185,7 @@ export const hotspotsContract = oc
       .errors({
         NOT_FOUND,
         BAD_REQUEST: { message: "Invalid split configuration", status: 400 },
+        UNAUTHORIZED,
         INSUFFICIENT_FUNDS,
       }),
 
@@ -198,6 +200,7 @@ export const hotspotsContract = oc
       .output(DeleteSplitOutputSchema)
       .errors({
         NOT_FOUND,
+        UNAUTHORIZED,
         INSUFFICIENT_FUNDS,
       }),
     /** Protected: Close automation */

--- a/packages/blockchain-api-client/src/contracts/hotspots.ts
+++ b/packages/blockchain-api-client/src/contracts/hotspots.ts
@@ -364,7 +364,7 @@ export const hotspotsContract = oc
         path: "/update-info",
         summary: "Update hotspot info",
         description:
-          "Creates an unsigned transaction to update hotspot configuration. Requires deviceType discriminant (iot or mobile) to select the correct update path and validate against on-chain network.",
+          "Creates an unsigned transaction to update hotspot configuration. Requires deviceType discriminant (iot or mobile) to select the correct update path and validate against on-chain network. feePayer selects who pays: maker (default, relayed through the onboarding server) or owner (built here, owner pays DC, rent and fees).",
       })
       .input(UpdateHotspotInfoInputSchema)
       .output(UpdateHotspotInfoOutputSchema)
@@ -372,6 +372,10 @@ export const hotspotsContract = oc
         NOT_FOUND,
         UNAUTHORIZED,
         BAD_REQUEST: { message: "Device type mismatch", status: 400 },
+        CONFLICT: {
+          message: "Hotspot cNFT is delegated to another authority",
+          status: 409,
+        },
         INSUFFICIENT_FUNDS,
       }),
   });

--- a/packages/blockchain-api-client/src/schemas/hotspots.ts
+++ b/packages/blockchain-api-client/src/schemas/hotspots.ts
@@ -361,6 +361,15 @@ const LocationSchema = z.object({
   lng: z.number().min(-180).max(180),
 });
 
+/**
+ * Who pays for the update. `maker` relays the onboarding server, where the
+ * maker co-signs and covers the DC; `owner` builds the update instruction here
+ * and the hotspot owner pays the DC, the resize rent and the transaction fee.
+ */
+const UpdateHotspotInfoFeePayerSchema = z
+  .enum(["maker", "owner"])
+  .default("maker");
+
 const IotUpdateSchema = z.object({
   deviceType: z.literal("iot"),
   entityPubKey: HeliumPublicKeySchema,
@@ -369,6 +378,7 @@ const IotUpdateSchema = z.object({
   gain: z.number().optional(),
   elevation: z.number().optional(),
   azimuth: z.number().min(0).max(360).optional(),
+  feePayer: UpdateHotspotInfoFeePayerSchema,
 });
 
 const MobileUpdateSchema = z.object({
@@ -377,6 +387,7 @@ const MobileUpdateSchema = z.object({
   walletAddress: WalletAddressSchema,
   location: LocationSchema.optional(),
   deploymentInfo: DeploymentInfoSchema.optional(),
+  feePayer: UpdateHotspotInfoFeePayerSchema,
 });
 
 export const UpdateHotspotInfoInputSchema = z.discriminatedUnion("deviceType", [

--- a/packages/blockchain-api-client/src/schemas/tokens.ts
+++ b/packages/blockchain-api-client/src/schemas/tokens.ts
@@ -15,6 +15,9 @@ export const TransferInputSchema = z.object({
   walletAddress: WalletAddressSchema,
   destination: z.string().min(32),
   tokenAmount: TokenAmountInputSchema,
+  feePayer: WalletAddressSchema.optional().describe(
+    "Account that pays the transaction fee and the rent for the recipient's associated token account, when one has to be created. Defaults to walletAddress, which is the source authority either way; naming a different account lets a wallet be emptied. The transaction then needs both signatures. Not valid with multisig."
+  ),
   ...squadsProposeFields,
 });
 

--- a/packages/blockchain-api/src/lib/solana.ts
+++ b/packages/blockchain-api/src/lib/solana.ts
@@ -17,9 +17,14 @@ export function getCluster(): string {
   return process.env.NEXT_PUBLIC_SOLANA_CLUSTER || "mainnet";
 }
 
+/** The DAS endpoint asset reads go through; the RPC when none is configured. */
+export function getAssetEndpoint(): string {
+  return env.ASSET_ENDPOINT || env.SOLANA_RPC_URL;
+}
+
 export function loadKeypair(keypair: string): Keypair {
   return Keypair.fromSecretKey(
-    new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString()))
+    new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString())),
   );
 }
 
@@ -36,7 +41,7 @@ function getConnection(): Connection {
 }
 
 export function createSolanaConnection(
-  walletAddress: string
+  walletAddress: string,
 ): SolanaConnection {
   const connection = getConnection();
   const wallet = {
@@ -51,7 +56,7 @@ export function createSolanaConnection(
   const provider = new AnchorProvider(
     connection,
     wallet,
-    AnchorProvider.defaultOptions()
+    AnchorProvider.defaultOptions(),
   );
 
   return {

--- a/packages/blockchain-api/src/lib/utils/asset-ownership.ts
+++ b/packages/blockchain-api/src/lib/utils/asset-ownership.ts
@@ -1,0 +1,43 @@
+import type { Asset } from "@helium/spl-utils";
+
+/** The error builder an ownership refusal is raised through. */
+type AssetOwnerErrors = {
+  UNAUTHORIZED: (opts: { message: string }) => Error;
+};
+
+/**
+ * A cNFT's current owner in base58. The asset endpoints hand the field back
+ * either already decoded or as the string it arrived as, so both are accepted.
+ */
+export function assetOwnerAddress(asset: Asset): string {
+  const { owner } = asset.ownership;
+  return typeof owner === "string" ? owner : owner.toBase58();
+}
+
+/**
+ * Refuse a caller that is not the cNFT's owner, and hand back the owner it
+ * checked so the address is derived once.
+ *
+ * `expectedOwner` is the authority the endpoint builds its instruction for: the
+ * caller's own wallet, or the vault of the multisig it proposes through, which
+ * is the owner on chain while the caller is only a member of it. `message` is
+ * the endpoint's own wording, because the endpoints name different things the
+ * wallet failed to own.
+ */
+export function assertAssetOwner({
+  asset,
+  expectedOwner,
+  message,
+  errors,
+}: {
+  asset: Asset;
+  expectedOwner: string;
+  message: string;
+  errors: AssetOwnerErrors;
+}): string {
+  const ownerAddress = assetOwnerAddress(asset);
+  if (ownerAddress !== expectedOwner) {
+    throw errors.UNAUTHORIZED({ message });
+  }
+  return ownerAddress;
+}

--- a/packages/blockchain-api/src/lib/utils/asset-ownership.ts
+++ b/packages/blockchain-api/src/lib/utils/asset-ownership.ts
@@ -1,8 +1,14 @@
-import type { Asset } from "@helium/spl-utils";
+import { getAsset, type Asset } from "@helium/spl-utils";
+import type { PublicKey } from "@solana/web3.js";
 
 /** The error builder an ownership refusal is raised through. */
 type AssetOwnerErrors = {
   UNAUTHORIZED: (opts: { message: string }) => Error;
+};
+
+/** `fetchOwnedAsset` also refuses an asset the endpoint does not know. */
+type OwnedAssetErrors = AssetOwnerErrors & {
+  NOT_FOUND: (opts: { message: string }) => Error;
 };
 
 /**
@@ -40,4 +46,36 @@ export function assertAssetOwner({
     throw errors.UNAUTHORIZED({ message });
   }
   return ownerAddress;
+}
+
+/**
+ * Fetch a cNFT and refuse the caller unless `expectedOwner` owns it, handing
+ * back the asset so the endpoint never pays for a second DAS round-trip.
+ *
+ * `assetEndpoint` comes in rather than being read from the environment here so
+ * this module stays importable under the unit runner, which resolves no `@/`
+ * aliases; endpoints pass `getAssetEndpoint()` from `@/lib/solana`.
+ * `getAssetFn` exists for tests.
+ */
+export async function fetchOwnedAsset({
+  assetEndpoint,
+  assetId,
+  expectedOwner,
+  message,
+  errors,
+  getAssetFn = getAsset,
+}: {
+  assetEndpoint: string;
+  assetId: PublicKey;
+  expectedOwner: string;
+  message: string;
+  errors: OwnedAssetErrors;
+  getAssetFn?: (url: string, assetId: PublicKey) => Promise<Asset | undefined>;
+}): Promise<Asset> {
+  const asset = await getAssetFn(assetEndpoint, assetId);
+  if (!asset) {
+    throw errors.NOT_FOUND({ message: "Asset not found" });
+  }
+  assertAssetOwner({ asset, expectedOwner, message, errors });
+  return asset;
 }

--- a/packages/blockchain-api/src/lib/utils/claim-approval.ts
+++ b/packages/blockchain-api/src/lib/utils/claim-approval.ts
@@ -1,0 +1,99 @@
+import { ED25519_SIGNATURE_BYTES, verifyEd25519 } from "./ed25519";
+
+/**
+ * The furthest ahead an approval's expiry may be when it is claimed. The
+ * welcome-pack program holds every approval to this same bound
+ * (`MAX_CLAIM_APPROVAL_SECONDS` in
+ * `programs/welcome-pack/src/instructions/claim_welcome_pack_v0.rs`), so an
+ * approval reaching past it cannot be claimed and is refused before this
+ * service pays for a transaction carrying it.
+ */
+export const MAX_CLAIM_APPROVAL_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * The message the pack owner signs to approve a claim, built exactly as the
+ * program rebuilds it from the pack's `unique_id` and the expiry in the
+ * instruction's arguments. The two spellings have to agree byte for byte or a
+ * signature that the program accepts is refused here.
+ */
+export function claimApprovalMessage(
+  uniqueId: number,
+  expirationTs: number
+): string {
+  return `Approve invite ${uniqueId} expiring ${expirationTs}`;
+}
+
+/** Why an approval was refused. Each endpoint maps these to its own errors. */
+export type ClaimApprovalRejection =
+  | "malformed_expiration"
+  | "expired"
+  | "window_too_long"
+  | "malformed_signature"
+  | "invalid_signature";
+
+export type ClaimApprovalResult =
+  | { ok: true; signature: Buffer }
+  | { ok: false; reason: ClaimApprovalRejection };
+
+/**
+ * What a caller is told about an approval this service will not pay for. The
+ * two reasons a signature can be unusable share one message, so a caller
+ * learns that the signature was refused and not which check refused it.
+ */
+export const CLAIM_APPROVAL_MESSAGES: Record<ClaimApprovalRejection, string> = {
+  malformed_expiration: "Invalid invite expiration",
+  expired: "Invite has expired",
+  window_too_long: "Invite expires too far in the future",
+  malformed_signature: "Invalid delegate signature",
+  invalid_signature: "Invalid delegate signature",
+};
+
+/**
+ * Check a claim approval before anything is built or signed on its behalf.
+ * `owner` is the pack owner's raw public key, the only key the program will
+ * accept the approval from; `now` is the caller's clock in seconds.
+ *
+ * A successful result carries the decoded signature so the caller does not
+ * decode it a second time, and so the bytes that were verified are the bytes
+ * that go into the instruction.
+ */
+export function verifyClaimApproval({
+  uniqueId,
+  expirationTs,
+  owner,
+  signatureBase64,
+  now,
+}: {
+  uniqueId: number;
+  expirationTs: number;
+  owner: Uint8Array;
+  signatureBase64: string;
+  now: number;
+}): ClaimApprovalResult {
+  if (!Number.isSafeInteger(expirationTs)) {
+    return { ok: false, reason: "malformed_expiration" };
+  }
+  if (expirationTs <= now) {
+    return { ok: false, reason: "expired" };
+  }
+  if (expirationTs > now + MAX_CLAIM_APPROVAL_SECONDS) {
+    return { ok: false, reason: "window_too_long" };
+  }
+
+  // Base64 decoding is lenient, so the length check is what rejects a signature
+  // that is not one, rather than a throw further down.
+  const signature = Buffer.from(signatureBase64, "base64");
+  if (signature.length !== ED25519_SIGNATURE_BYTES) {
+    return { ok: false, reason: "malformed_signature" };
+  }
+
+  const message = Buffer.from(
+    claimApprovalMessage(uniqueId, expirationTs),
+    "utf8"
+  );
+  if (!verifyEd25519(message, signature, owner)) {
+    return { ok: false, reason: "invalid_signature" };
+  }
+
+  return { ok: true, signature };
+}

--- a/packages/blockchain-api/src/lib/utils/claim-approval.ts
+++ b/packages/blockchain-api/src/lib/utils/claim-approval.ts
@@ -18,18 +18,25 @@ export const MAX_CLAIM_APPROVAL_SECONDS = 30 * 24 * 60 * 60;
  */
 export function claimApprovalMessage(
   uniqueId: number,
-  expirationTs: number
+  expirationTs: number,
 ): string {
   return `Approve invite ${uniqueId} expiring ${expirationTs}`;
 }
 
 /** Why an approval was refused. Each endpoint maps these to its own errors. */
 export type ClaimApprovalRejection =
-  | "malformed_expiration"
-  | "expired"
-  | "window_too_long"
+  | ClaimApprovalWindowRejection
   | "malformed_signature"
   | "invalid_signature";
+
+/**
+ * The refusals that depend only on the expiry the caller supplied, and so can
+ * be decided before any account is read.
+ */
+export type ClaimApprovalWindowRejection =
+  | "malformed_expiration"
+  | "expired"
+  | "window_too_long";
 
 export type ClaimApprovalResult =
   | { ok: true; signature: Buffer }
@@ -47,6 +54,32 @@ export const CLAIM_APPROVAL_MESSAGES: Record<ClaimApprovalRejection, string> = {
   malformed_signature: "Invalid delegate signature",
   invalid_signature: "Invalid delegate signature",
 };
+
+/**
+ * The half of an approval that reads only the caller's own arguments. An
+ * endpoint calls this before it looks anything up, so a claim that cannot
+ * succeed costs no account reads and its refusal does not depend on whether the
+ * pack behind it still exists. `verifyClaimApproval` applies the same check, so
+ * the window and the signature over it are never decided by separate rules.
+ */
+export function checkApprovalWindow({
+  expirationTs,
+  now,
+}: {
+  expirationTs: number;
+  now: number;
+}): ClaimApprovalWindowRejection | null {
+  if (!Number.isSafeInteger(expirationTs)) {
+    return "malformed_expiration";
+  }
+  if (expirationTs <= now) {
+    return "expired";
+  }
+  if (expirationTs > now + MAX_CLAIM_APPROVAL_SECONDS) {
+    return "window_too_long";
+  }
+  return null;
+}
 
 /**
  * Check a claim approval before anything is built or signed on its behalf.
@@ -70,14 +103,9 @@ export function verifyClaimApproval({
   signatureBase64: string;
   now: number;
 }): ClaimApprovalResult {
-  if (!Number.isSafeInteger(expirationTs)) {
-    return { ok: false, reason: "malformed_expiration" };
-  }
-  if (expirationTs <= now) {
-    return { ok: false, reason: "expired" };
-  }
-  if (expirationTs > now + MAX_CLAIM_APPROVAL_SECONDS) {
-    return { ok: false, reason: "window_too_long" };
+  const windowRejection = checkApprovalWindow({ expirationTs, now });
+  if (windowRejection) {
+    return { ok: false, reason: windowRejection };
   }
 
   // Base64 decoding is lenient, so the length check is what rejects a signature
@@ -89,7 +117,7 @@ export function verifyClaimApproval({
 
   const message = Buffer.from(
     claimApprovalMessage(uniqueId, expirationTs),
-    "utf8"
+    "utf8",
   );
   if (!verifyEd25519(message, signature, owner)) {
     return { ok: false, reason: "invalid_signature" };

--- a/packages/blockchain-api/src/lib/utils/ed25519.ts
+++ b/packages/blockchain-api/src/lib/utils/ed25519.ts
@@ -1,0 +1,46 @@
+import { createPublicKey, verify } from "crypto";
+
+/** Bytes in an Ed25519 signature. */
+export const ED25519_SIGNATURE_BYTES = 64;
+
+/** Bytes in an Ed25519 public key. */
+const ED25519_PUBLIC_KEY_BYTES = 32;
+
+/**
+ * DER SubjectPublicKeyInfo header for an Ed25519 key. Prepending it to the raw
+ * 32-byte key is what lets the platform verifier take a Solana public key, so
+ * verification needs no third-party curve library.
+ */
+const SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+/**
+ * Whether `signature` is `publicKey`'s Ed25519 signature over `message`.
+ *
+ * Every malformed input answers false rather than throwing: a signature or key
+ * of the wrong length, and a key that is not a point on the curve. A caller can
+ * therefore treat one false as "refuse", without a second path for inputs that
+ * never had a chance of verifying.
+ */
+export function verifyEd25519(
+  message: Uint8Array,
+  signature: Uint8Array,
+  publicKey: Uint8Array
+): boolean {
+  if (
+    signature.length !== ED25519_SIGNATURE_BYTES ||
+    publicKey.length !== ED25519_PUBLIC_KEY_BYTES
+  ) {
+    return false;
+  }
+
+  try {
+    const key = createPublicKey({
+      key: Buffer.concat([SPKI_PREFIX, Buffer.from(publicKey)]),
+      format: "der",
+      type: "spki",
+    });
+    return verify(null, message, key, signature);
+  } catch {
+    return false;
+  }
+}

--- a/packages/blockchain-api/src/lib/utils/log-input.ts
+++ b/packages/blockchain-api/src/lib/utils/log-input.ts
@@ -1,0 +1,65 @@
+/**
+ * Input fields whose values may be written to the log. Everything else is
+ * reduced to its key, so the log still shows an input's shape without showing
+ * what is in it.
+ *
+ * An allowlist rather than a list of fields to hide: a schema that gains a
+ * field gains it unlisted, and an unlisted field's value is not logged. Naming
+ * the fields to withhold instead would make every new secret loggable until
+ * somebody remembered to add it -- and `fiat.createBankAccount` alone carries
+ * an account number, a routing number, a name and a home address.
+ */
+const LOGGABLE_INPUT_FIELDS = new Set([
+  "cluster",
+  "deviceType",
+  "entityPubKey",
+  "hotspotPubkey",
+  "mint",
+  "owner",
+  "packAddress",
+  "parallel",
+  "signerWalletAddress",
+  "simulate",
+  "tag",
+  "type",
+  "userAddress",
+  "userPublicKey",
+  "walletAddress",
+]);
+
+/**
+ * A value simple enough to log whole. A listed field that turns into an object
+ * or an array stops having its value logged, so nesting a secret under a name
+ * that was safe when it held a string does not start logging it.
+ */
+function isLoggableValue(value: unknown): boolean {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+/**
+ * A one-line rendering of a procedure's input for the request log: every key,
+ * and the value of each key that is on the allowlist. Empty for an input with
+ * nothing in it, so a procedure that takes no arguments logs no braces.
+ */
+export function summarizeProcedureInput(input: unknown): string {
+  if (input === null || typeof input !== "object") {
+    return "";
+  }
+
+  const fields = Object.entries(input as Record<string, unknown>).map(
+    ([key, value]) =>
+      LOGGABLE_INPUT_FIELDS.has(key) && isLoggableValue(value)
+        ? `${key}=${JSON.stringify(value)}`
+        : key
+  );
+  if (fields.length === 0) {
+    return "";
+  }
+
+  return ` {${fields.join(", ")}}`;
+}

--- a/packages/blockchain-api/src/lib/utils/transaction-payer.ts
+++ b/packages/blockchain-api/src/lib/utils/transaction-payer.ts
@@ -1,0 +1,26 @@
+import type { VersionedTransaction } from "@solana/web3.js";
+import { verifyEd25519 } from "./ed25519";
+
+/**
+ * The account that pays for a transaction, returned only once the transaction
+ * carries that account's own signature over its message. Null otherwise, which
+ * is the answer for an unsigned transaction, one signed by somebody else, and
+ * one whose message was altered after signing.
+ *
+ * A transaction's first static account key is its fee payer and the first
+ * signature is that account's. Extra signatures belong to other authorities the
+ * instructions require -- a transfer whose fee payer is not its source has two
+ * -- and are left to the cluster to check, because the fee payer is the only
+ * account this answer names.
+ */
+export function verifiedFeePayer(tx: VersionedTransaction): string | null {
+  const feePayer = tx.message.staticAccountKeys[0];
+  const signature = tx.signatures[0];
+  if (!feePayer || !signature) {
+    return null;
+  }
+  if (!verifyEd25519(tx.message.serialize(), signature, feePayer.toBytes())) {
+    return null;
+  }
+  return feePayer.toBase58();
+}

--- a/packages/blockchain-api/src/server/api/procedures.ts
+++ b/packages/blockchain-api/src/server/api/procedures.ts
@@ -3,6 +3,7 @@ import type { Meta } from "@orpc/contract";
 import { cookies, headers } from "next/headers";
 import { privy } from "@/lib/privy";
 import { env } from "@/lib/env";
+import { summarizeProcedureInput } from "@/lib/utils/log-input";
 import type { User } from "@privy-io/server-auth";
 import { fullApiContract } from "@helium/blockchain-api";
 
@@ -59,13 +60,9 @@ const timingMiddleware = os.middleware(async ({ next, path }, input) => {
 
   const ms = Date.now() - start;
   const ts = new Date().toISOString();
-  const params =
-    input &&
-    typeof input === "object" &&
-    Object.keys(input as object).length > 0
-      ? ` ${JSON.stringify(input)}`
-      : "";
-  console.log(`${ts} [ORPC] ${routePath}${params} ${ms}ms`);
+  console.log(
+    `${ts} [ORPC] ${routePath}${summarizeProcedureInput(input)} ${ms}ms`
+  );
 
   return result;
 });

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/mint.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/mint.ts
@@ -55,7 +55,7 @@ export const mint = publicProcedure.dataCredits.mint.handler(
     const useJito = shouldUseJitoBundle(txs.length, getCluster());
     const txFees = await getTotalTransactionFees(
       connection,
-      txs.map((t) => t.tx)
+      txs.map((t) => t.tx),
     );
     const jitoTipCost = useJito ? getJitoTipAmountLamports() : 0;
 
@@ -66,13 +66,13 @@ export const mint = publicProcedure.dataCredits.mint.handler(
     const recipientDcAta = getAssociatedTokenAddressSync(
       DC_MINT,
       recipientPubkey,
-      true
+      true,
     );
     const recipientDcAtaInfo = await connection.getAccountInfo(recipientDcAta);
     const ataRent = recipientDcAtaInfo ? 0 : RENT_COSTS.ATA;
     const requiredBalance = calculateRequiredBalance(
       txFees + jitoTipCost,
-      ataRent
+      ataRent,
     );
 
     const ownerPubkey = new PublicKey(owner);
@@ -89,6 +89,7 @@ export const mint = publicProcedure.dataCredits.mint.handler(
       userAddress: owner,
       dcAmount: dcAmount || undefined,
       hntAmount: hntAmount || undefined,
+      recipient: recipient && recipient !== owner ? recipient : undefined,
     });
 
     // The credits land on the recipient rather than the signer whenever one is
@@ -135,5 +136,5 @@ export const mint = publicProcedure.dataCredits.mint.handler(
         recipient: recipient || undefined,
       },
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/data-credits/procedures/mint.ts
+++ b/packages/blockchain-api/src/server/api/routers/data-credits/procedures/mint.ts
@@ -91,6 +91,15 @@ export const mint = publicProcedure.dataCredits.mint.handler(
       hntAmount: hntAmount || undefined,
     });
 
+    // The credits land on the recipient rather than the signer whenever one is
+    // named, so the signer is told which account before signing for it.
+    const recipientSuffix =
+      recipient && recipient !== owner ? ` to ${recipient}` : "";
+    const description =
+      (dcAmount
+        ? `Mint ${dcAmount} data credits`
+        : `Burn ${hntAmount} HNT bones for data credits`) + recipientSuffix;
+
     const transactions = txs.map((t) => {
       if (t.signers.length > 0) {
         t.tx.sign(t.signers);
@@ -99,9 +108,7 @@ export const mint = publicProcedure.dataCredits.mint.handler(
         serializedTransaction: serializeTransaction(t.tx),
         metadata: {
           type: "mint_data_credits",
-          description: dcAmount
-            ? `Mint ${dcAmount} data credits`
-            : `Burn ${hntAmount} HNT bones for data credits`,
+          description,
         },
       };
     });

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createSplit.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createSplit.ts
@@ -1,10 +1,14 @@
 import { publicProcedure } from "../../../procedures";
 import { env } from "@/lib/env";
-import { createSolanaConnection, getCluster } from "@/lib/solana";
+import {
+  createSolanaConnection,
+  getAssetEndpoint,
+  getCluster,
+} from "@/lib/solana";
 import { connectToDb } from "@/lib/utils/db";
 import { scheduleToUtcCron } from "@/lib/utils/misc";
 import animalName from "angry-purple-tiger";
-import { assertAssetOwner } from "@/lib/utils/asset-ownership";
+import { fetchOwnedAsset } from "@/lib/utils/asset-ownership";
 import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
 import {
   initializeCompressionRecipient,
@@ -15,7 +19,6 @@ import {
 import { init as initMiniFanout } from "@helium/mini-fanout-sdk";
 import {
   batchInstructionsToTxsWithPriorityFee,
-  getAsset,
   HELIUM_COMMON_LUT,
   HELIUM_COMMON_LUT_DEVNET,
   HNT_MINT,
@@ -93,15 +96,9 @@ export const createSplit = publicProcedure.hotspots.createSplit.handler(
 
     // Only the owner may redirect a hotspot's rewards, so the check comes
     // before anything is looked up or built on the caller's behalf.
-    const asset = await getAsset(
-      env.ASSET_ENDPOINT || env.SOLANA_RPC_URL,
-      new PublicKey(assetId)
-    );
-    if (!asset) {
-      throw errors.NOT_FOUND({ message: "Asset not found" });
-    }
-    assertAssetOwner({
-      asset,
+    const asset = await fetchOwnedAsset({
+      assetEndpoint: getAssetEndpoint(),
+      assetId: new PublicKey(assetId),
       expectedOwner: walletAddress,
       message: "Wallet does not own this hotspot",
       errors,
@@ -134,6 +131,9 @@ export const createSplit = publicProcedure.hotspots.createSplit.handler(
             payer: wallet.publicKey,
             assetEndpoint: env.SOLANA_RPC_URL,
             lazyDistributor: new PublicKey(lazyDistributor),
+            // The asset is already in hand from the ownership check above;
+            // reuse it rather than pay for a second DAS round-trip.
+            getAssetFn: async () => asset,
           })
         ).instruction(),
       );
@@ -222,6 +222,7 @@ export const createSplit = publicProcedure.hotspots.createSplit.handler(
         assetId: new PublicKey(assetId),
         lazyDistributor: new PublicKey(lazyDistributor),
         destination: pubkeys.miniFanout!,
+        getAssetFn: async () => asset,
       })
     ).instruction();
     instructions.push(setRecipientIx);

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createSplit.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/createSplit.ts
@@ -4,6 +4,7 @@ import { createSolanaConnection, getCluster } from "@/lib/solana";
 import { connectToDb } from "@/lib/utils/db";
 import { scheduleToUtcCron } from "@/lib/utils/misc";
 import animalName from "angry-purple-tiger";
+import { assertAssetOwner } from "@/lib/utils/asset-ownership";
 import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
 import {
   initializeCompressionRecipient,
@@ -14,6 +15,7 @@ import {
 import { init as initMiniFanout } from "@helium/mini-fanout-sdk";
 import {
   batchInstructionsToTxsWithPriorityFee,
+  getAsset,
   HELIUM_COMMON_LUT,
   HELIUM_COMMON_LUT_DEVNET,
   HNT_MINT,
@@ -88,6 +90,22 @@ export const createSplit = publicProcedure.hotspots.createSplit.handler(
         message: "Schedule frequency, time, and timezone are required",
       });
     }
+
+    // Only the owner may redirect a hotspot's rewards, so the check comes
+    // before anything is looked up or built on the caller's behalf.
+    const asset = await getAsset(
+      env.ASSET_ENDPOINT || env.SOLANA_RPC_URL,
+      new PublicKey(assetId)
+    );
+    if (!asset) {
+      throw errors.NOT_FOUND({ message: "Asset not found" });
+    }
+    assertAssetOwner({
+      asset,
+      expectedOwner: walletAddress,
+      message: "Wallet does not own this hotspot",
+      errors,
+    });
 
     // Build connection and programs
     const { provider, wallet } = createSolanaConnection(walletAddress);

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/deleteSplit.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/deleteSplit.ts
@@ -3,12 +3,10 @@ import { connectToDb } from "@/lib/utils/db";
 import { AssetOwner } from "@/lib/models/hotspot";
 import { MiniFanout } from "@/lib/models/mini-fanout";
 import { Recipient } from "@/lib/models/recipient";
-import { createSolanaConnection } from "@/lib/solana";
-import { env } from "@/lib/env";
+import { createSolanaConnection, getAssetEndpoint } from "@/lib/solana";
 import animalName from "angry-purple-tiger";
-import { assertAssetOwner } from "@/lib/utils/asset-ownership";
+import { fetchOwnedAsset } from "@/lib/utils/asset-ownership";
 import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
-import { getAsset } from "@helium/spl-utils";
 import {
   init as initLd,
   updateCompressionDestination,
@@ -52,15 +50,9 @@ export const deleteSplit = publicProcedure.hotspots.deleteSplit.handler(
 
     // Only the owner may remove a hotspot's split, so the check comes before
     // the split is looked up: an unauthorized caller learns nothing about it.
-    const asset = await getAsset(
-      env.ASSET_ENDPOINT || env.SOLANA_RPC_URL,
-      new PublicKey(assetId)
-    );
-    if (!asset) {
-      throw errors.NOT_FOUND({ message: "Asset not found" });
-    }
-    assertAssetOwner({
-      asset,
+    const asset = await fetchOwnedAsset({
+      assetEndpoint: getAssetEndpoint(),
+      assetId: new PublicKey(assetId),
       expectedOwner: walletAddress,
       message: "Wallet does not own this hotspot",
       errors,
@@ -96,9 +88,8 @@ export const deleteSplit = publicProcedure.hotspots.deleteSplit.handler(
     const { provider, connection } = createSolanaConnection(walletAddress);
     const program = await initMiniFanout(provider);
     const miniFanoutK = new PublicKey(assetOwner.recipient.split.address);
-    const miniFanout = await program.account.miniFanoutV0.fetchNullable(
-      miniFanoutK
-    );
+    const miniFanout =
+      await program.account.miniFanoutV0.fetchNullable(miniFanoutK);
 
     if (!miniFanout) {
       throw errors.NOT_FOUND({ message: "Fanout not found" });
@@ -106,7 +97,7 @@ export const deleteSplit = publicProcedure.hotspots.deleteSplit.handler(
 
     // Check wallet has sufficient balance for transaction fees
     const walletBalance = await connection.getBalance(
-      new PublicKey(walletAddress)
+      new PublicKey(walletAddress),
     );
     const required = calculateRequiredBalance(BASE_TX_FEE_LAMPORTS, 0);
     if (walletBalance < required) {
@@ -138,6 +129,9 @@ export const deleteSplit = publicProcedure.hotspots.deleteSplit.handler(
         assetId: new PublicKey(assetId),
         lazyDistributor: new PublicKey(assetOwner.recipient.lazyDistributor),
         destination: null,
+        // The asset is already in hand from the ownership check above;
+        // reuse it rather than pay for a second DAS round-trip.
+        getAssetFn: async () => asset,
       })
     ).instruction();
 
@@ -179,8 +173,8 @@ export const deleteSplit = publicProcedure.hotspots.deleteSplit.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(txFee),
-        NATIVE_MINT.toBase58()
+        NATIVE_MINT.toBase58(),
       ),
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/deleteSplit.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/deleteSplit.ts
@@ -4,8 +4,11 @@ import { AssetOwner } from "@/lib/models/hotspot";
 import { MiniFanout } from "@/lib/models/mini-fanout";
 import { Recipient } from "@/lib/models/recipient";
 import { createSolanaConnection } from "@/lib/solana";
+import { env } from "@/lib/env";
 import animalName from "angry-purple-tiger";
+import { assertAssetOwner } from "@/lib/utils/asset-ownership";
 import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
+import { getAsset } from "@helium/spl-utils";
 import {
   init as initLd,
   updateCompressionDestination,
@@ -46,6 +49,22 @@ export const deleteSplit = publicProcedure.hotspots.deleteSplit.handler(
     }
 
     const hotspotName = animalName(hotspotPubkey);
+
+    // Only the owner may remove a hotspot's split, so the check comes before
+    // the split is looked up: an unauthorized caller learns nothing about it.
+    const asset = await getAsset(
+      env.ASSET_ENDPOINT || env.SOLANA_RPC_URL,
+      new PublicKey(assetId)
+    );
+    if (!asset) {
+      throw errors.NOT_FOUND({ message: "Asset not found" });
+    }
+    assertAssetOwner({
+      asset,
+      expectedOwner: walletAddress,
+      message: "Wallet does not own this hotspot",
+      errors,
+    });
 
     // Find the hotspot
     const assetOwner = await AssetOwner.findOne({

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/hotspot-cnft.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/hotspot-cnft.ts
@@ -1,6 +1,7 @@
 import { Connection, PublicKey } from "@solana/web3.js";
 import { env } from "@/lib/env";
 import { hasRewardContract } from "@/lib/queries/hotspots";
+import { assertAssetOwner } from "@/lib/utils/asset-ownership";
 import { proofArgsAndAccounts } from "@helium/spl-utils";
 import {
   getAssetIdFromPubkey,
@@ -75,21 +76,17 @@ export const resolveOwnedHotspotCnft = async ({
     });
   }
 
-  const ownerAddress =
-    typeof asset.ownership.owner === "string"
-      ? asset.ownership.owner
-      : asset.ownership.owner.toBase58();
-
   // In Squads propose mode the on-chain owner must be the multisig's vault
   // (walletAddress is only the proposing member); otherwise the wallet itself.
   const expectedOwner = multisigPda ? vaultPda(multisigPda) : payerPubkey;
-  if (ownerAddress !== expectedOwner.toBase58()) {
-    throw errors.UNAUTHORIZED({
-      message: multisigPda
-        ? "Multisig vault is not the owner of this hotspot"
-        : "Wallet is not the owner of this hotspot",
-    });
-  }
+  const ownerAddress = assertAssetOwner({
+    asset,
+    expectedOwner: expectedOwner.toBase58(),
+    message: multisigPda
+      ? "Multisig vault is not the owner of this hotspot"
+      : "Wallet is not the owner of this hotspot",
+    errors,
+  });
 
   const contractExists = await hasRewardContract(hotspotPubkey);
   if (contractExists) {

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/update-info-owner.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/update-info-owner.ts
@@ -1,0 +1,353 @@
+import { BN } from "@coral-xyz/anchor";
+import { dataCreditsKey } from "@helium/data-credits-sdk";
+import {
+  iotInfoKey,
+  mobileInfoKey,
+  rewardableEntityConfigKey,
+} from "@helium/helium-entity-manager-sdk";
+import type { init as initHem } from "@helium/helium-entity-manager-sdk";
+import { daoKey, subDaoKey } from "@helium/helium-sub-daos-sdk";
+import {
+  DC_MINT,
+  HNT_MINT,
+  IOT_MINT,
+  MOBILE_MINT,
+} from "@helium/spl-utils";
+import { PROGRAM_ID as BUBBLEGUM_PROGRAM_ID } from "@metaplex-foundation/mpl-bubblegum";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import type { AccountMeta, TransactionInstruction } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
+
+/** The helium-entity-manager Anchor program, as the SDK builds it. */
+type HemProgram = Awaited<ReturnType<typeof initHem>>;
+
+/** The sub-DAO an update targets. */
+export type HotspotUpdateNetwork = "iot" | "mobile";
+
+/** Merkle-proof arguments shared by both update instructions. */
+export interface UpdateProofArgs {
+  dataHash: number[];
+  creatorHash: number[];
+  root: number[];
+  index: number;
+}
+
+const HNT_DAO = daoKey(HNT_MINT)[0];
+const DC_KEY = dataCreditsKey(DC_MINT)[0];
+
+const SUB_DAO: Record<HotspotUpdateNetwork, PublicKey> = {
+  iot: subDaoKey(IOT_MINT)[0],
+  mobile: subDaoKey(MOBILE_MINT)[0],
+};
+
+export const REWARDABLE_ENTITY_CONFIG: Record<HotspotUpdateNetwork, PublicKey> =
+  {
+    iot: rewardableEntityConfigKey(SUB_DAO.iot, "IOT")[0],
+    mobile: rewardableEntityConfigKey(SUB_DAO.mobile, "MOBILE")[0],
+  };
+
+/** The iot_info / mobile_info PDA holding a hotspot's on-chain metadata. */
+export function hotspotInfoKey(
+  network: HotspotUpdateNetwork,
+  entityKey: string
+): PublicKey {
+  const config = REWARDABLE_ENTITY_CONFIG[network];
+  return network === "iot"
+    ? iotInfoKey(config, entityKey)[0]
+    : mobileInfoKey(config, entityKey)[0];
+}
+
+/** The DC associated token account an owner-paid update burns from. */
+export function dcBurnerFor(owner: PublicKey): PublicKey {
+  return getAssociatedTokenAddressSync(DC_MINT, owner, true);
+}
+
+/**
+ * Accounts common to `updateIotInfoV0` and `updateMobileInfoV0` when the hotspot
+ * owner pays: the owner is the transaction payer, the DC fee payer and the leaf
+ * owner, and the DC is burned from the owner's own DC token account. Every
+ * account is supplied, so building the instruction needs no account resolution
+ * and therefore no RPC round-trips.
+ */
+function ownerPaidUpdateAccounts(
+  network: HotspotUpdateNetwork,
+  owner: PublicKey,
+  merkleTree: PublicKey
+) {
+  const [treeAuthority] = PublicKey.findProgramAddressSync(
+    [merkleTree.toBuffer()],
+    BUBBLEGUM_PROGRAM_ID
+  );
+
+  return {
+    payer: owner,
+    dcFeePayer: owner,
+    hotspotOwner: owner,
+    dcBurner: dcBurnerFor(owner),
+    merkleTree,
+    treeAuthority,
+    rewardableEntityConfig: REWARDABLE_ENTITY_CONFIG[network],
+    dao: HNT_DAO,
+    subDao: SUB_DAO[network],
+    dcMint: DC_MINT,
+    dc: DC_KEY,
+  };
+}
+
+/**
+ * Refuses a hotspot whose compressed-NFT leaf is delegated to anyone but its
+ * owner. The update instruction verifies the leaf with both its owner and its
+ * delegate bound to `hotspot_owner`, so the owner's signature alone cannot
+ * satisfy it and the transaction could only fail on chain.
+ */
+export function assertNotDelegated({
+  owner,
+  delegate,
+  errors,
+}: {
+  owner: string;
+  delegate: PublicKey | string | null | undefined;
+  errors: { CONFLICT: (opts: { message: string }) => Error };
+}): void {
+  if (!delegate) return;
+  const address = typeof delegate === "string" ? delegate : delegate.toBase58();
+  if (address === owner) return;
+
+  throw errors.CONFLICT({
+    message:
+      "Hotspot is delegated to another authority and cannot be updated with feePayer=owner",
+  });
+}
+
+/**
+ * Refuses an update the owner cannot fund in DC. Only a location assert costs
+ * DC, so this runs only when `locationAssertDcFee` priced one.
+ */
+export function assertDcCovered({
+  required,
+  available,
+  errors,
+}: {
+  required: BN;
+  available: bigint;
+  errors: {
+    INSUFFICIENT_FUNDS: (opts: {
+      message: string;
+      data: { required: number; available: number };
+    }) => Error;
+  };
+}): void {
+  const needed = BigInt(required.toString());
+  if (available >= needed) return;
+
+  throw errors.INSUFFICIENT_FUNDS({
+    message: "Insufficient DC balance to assert this hotspot's location",
+    data: { required: Number(needed), available: Number(available) },
+  });
+}
+
+/**
+ * On-chain gain is tenths of a dBi and elevation is whole meters, both i32.
+ */
+export function toOnChainGain(gain: number | undefined): number | null {
+  return gain === undefined ? null : Math.trunc(gain * 10);
+}
+
+export function toOnChainElevation(
+  elevation: number | undefined
+): number | null {
+  return elevation === undefined ? null : Math.trunc(elevation);
+}
+
+/** The fields an update writes, per sub-DAO. */
+export type OwnerPaidUpdate =
+  | {
+      network: "iot";
+      location: BN | null;
+      elevation: number | null;
+      gain: number | null;
+    }
+  | {
+      network: "mobile";
+      location: BN | null;
+      // Anchor's generated arg type for the deployment-info enum.
+      deploymentInfo: unknown;
+    };
+
+/**
+ * Builds the `update{Iot,Mobile}InfoV0` instruction paid for by the hotspot
+ * owner rather than the maker. Port of `direct_update_instruction` in
+ * helium-lib: same accounts, same argument layout, with the payer, DC fee payer
+ * and DC burner all bound to the owner.
+ */
+export async function buildOwnerPaidUpdateInstruction({
+  program,
+  owner,
+  entityKey,
+  merkleTree,
+  proofArgs,
+  remainingAccounts,
+  update,
+}: {
+  program: HemProgram;
+  owner: PublicKey;
+  entityKey: string;
+  merkleTree: PublicKey;
+  proofArgs: UpdateProofArgs;
+  remainingAccounts: AccountMeta[];
+  update: OwnerPaidUpdate;
+}): Promise<TransactionInstruction> {
+  const accounts = ownerPaidUpdateAccounts(update.network, owner, merkleTree);
+
+  if (update.network === "iot") {
+    return program.methods
+      .updateIotInfoV0({
+        ...proofArgs,
+        location: update.location,
+        elevation: update.elevation,
+        gain: update.gain,
+      })
+      .accountsPartial({
+        ...accounts,
+        iotInfo: hotspotInfoKey("iot", entityKey),
+      })
+      .remainingAccounts(remainingAccounts)
+      .instruction();
+  }
+
+  return program.methods
+    .updateMobileInfoV0({
+      ...proofArgs,
+      location: update.location,
+      deploymentInfo: update.deploymentInfo as any,
+    })
+    .accountsPartial({
+      ...accounts,
+      mobileInfo: hotspotInfoKey("mobile", entityKey),
+    })
+    .remainingAccounts(remainingAccounts)
+    .instruction();
+}
+
+/**
+ * DC the update burns. Both handlers burn the location staking fee once, and
+ * only when a location is asserted that differs from the one already stored;
+ * every other field is free.
+ */
+export function locationAssertDcFee({
+  newLocation,
+  currentLocation,
+  stakingFee,
+}: {
+  newLocation: BN | null;
+  currentLocation: BN | null | undefined;
+  stakingFee: BN | null;
+}): BN {
+  if (!newLocation || !stakingFee) return new BN(0);
+  if (currentLocation && currentLocation.eq(newLocation)) return new BN(0);
+  return stakingFee;
+}
+
+/**
+ * The `ConfigSettingsV0` variant as Anchor decodes it: one key per variant,
+ * with camelCased fields.
+ */
+type MobileDeviceFees = { deviceType: object; locationStakingFee: BN };
+
+type RewardableEntityConfigSettings = {
+  iotConfig?: {
+    fullLocationStakingFee: BN;
+    dataonlyLocationStakingFee: BN;
+  };
+  mobileConfig?: { fullLocationStakingFee: BN };
+  mobileConfigV1?: { feesByDevice: MobileDeviceFees[] };
+  mobileConfigV2?: { feesByDevice: MobileDeviceFees[] };
+};
+
+/**
+ * The location staking fee the sub-DAO charges this hotspot, mirroring
+ * `ConfigSettingsV0::mobile_device_fees` and the IoT handler's full/data-only
+ * split. Returns null when the settings variant carries no fee for this
+ * hotspot, in which case the on-chain program is left to price the burn.
+ */
+export function locationStakingFee(
+  settings: RewardableEntityConfigSettings,
+  hotspot:
+    | { network: "iot"; isFullHotspot: boolean }
+    | { network: "mobile"; deviceType: object }
+): BN | null {
+  if (hotspot.network === "iot") {
+    const iot = settings.iotConfig;
+    if (!iot) return null;
+    return hotspot.isFullHotspot
+      ? iot.fullLocationStakingFee
+      : iot.dataonlyLocationStakingFee;
+  }
+
+  if (settings.mobileConfig) {
+    return settings.mobileConfig.fullLocationStakingFee;
+  }
+
+  const feesByDevice =
+    settings.mobileConfigV2?.feesByDevice ??
+    settings.mobileConfigV1?.feesByDevice;
+  if (!feesByDevice) return null;
+
+  const wanted = variantName(hotspot.deviceType);
+  if (!wanted) return null;
+  const fees = feesByDevice.find(
+    (entry) => variantName(entry.deviceType) === wanted
+  );
+  return fees ? fees.locationStakingFee : null;
+}
+
+/** The single key of an Anchor-decoded unit enum, e.g. `wifiIndoor`. */
+function variantName(variant: object): string | undefined {
+  return Object.keys(variant)[0];
+}
+
+/** Structural view of the deployment-info enum, as Anchor decodes it. */
+type DeploymentInfoLike = {
+  wifiInfoV0?: { serial?: string | null } | null;
+  cbrsInfoV0?: unknown;
+};
+
+/**
+ * The deployment info the program actually stores. `preserve_wifi_serial`
+ * carries the existing serial forward whenever the incoming wifi info ships
+ * none — absent, null or empty — so a size estimate has to measure the same
+ * value the account will end up holding.
+ */
+export function withPreservedWifiSerial<
+  T extends DeploymentInfoLike | undefined
+>(incoming: T, existing: DeploymentInfoLike | undefined): T {
+  const wifi = incoming?.wifiInfoV0;
+  if (!wifi) return incoming;
+  if (wifi.serial) return incoming;
+
+  const existingSerial = existing?.wifiInfoV0?.serial;
+  if (!existingSerial) return incoming;
+
+  return {
+    ...incoming,
+    wifiInfoV0: { ...wifi, serial: existingSerial },
+  } as T;
+}
+
+/**
+ * Lamports the owner must supply for `resize_to_fit`: it tops the account up to
+ * the rent-exempt minimum for its new size and never withdraws, so a shrink or
+ * an already-funded account costs nothing.
+ */
+export function resizeTopUpLamports(
+  rentExemptForNewSize: number,
+  currentLamports: number
+): number {
+  return Math.max(0, rentExemptForNewSize - currentLamports);
+}
+
+/**
+ * `resize_to_fit` sizes the account to its serialized length plus 64 bytes of
+ * padding, so the rent target must include that same padding.
+ */
+export const RESIZE_PADDING_BYTES = 64;

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/updateHotspotInfo.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/updateHotspotInfo.ts
@@ -1,7 +1,7 @@
 import { publicProcedure } from "../../../procedures";
 import { env } from "@/lib/env";
-import { createSolanaConnection } from "@/lib/solana";
-import { assertAssetOwner } from "@/lib/utils/asset-ownership";
+import { createSolanaConnection, getAssetEndpoint } from "@/lib/solana";
+import { fetchOwnedAsset } from "@/lib/utils/asset-ownership";
 import {
   generateTransactionTag,
   TRANSACTION_TYPES,
@@ -14,7 +14,7 @@ import { detectHotspotNetworks, getHotspotInfo } from "@/lib/queries/hotspots";
 import animalName from "angry-purple-tiger";
 import { latLngToH3 } from "@/lib/location/h3";
 import OnboardingClient from "@helium/onboarding";
-import { getAsset, proofArgsAndAccounts } from "@helium/spl-utils";
+import { proofArgsAndAccounts } from "@helium/spl-utils";
 import {
   keyToAssetKey,
   decodeEntityKey,
@@ -45,6 +45,7 @@ import {
   hotspotInfoKey,
   locationAssertDcFee,
   locationStakingFee,
+  type OwnerPaidUpdate,
   REWARDABLE_ENTITY_CONFIG,
   RESIZE_PADDING_BYTES,
   resizeTopUpLamports,
@@ -76,7 +77,7 @@ type InputDeploymentInfo = Extract<
 
 // Convert input deploymentInfo to onboarding format (partial)
 function inputToOnboardingDeploymentInfo(
-  info: InputDeploymentInfo | undefined
+  info: InputDeploymentInfo | undefined,
 ): MobileDeploymentInfoV0 | undefined {
   if (!info) return undefined;
 
@@ -97,7 +98,7 @@ function inputToOnboardingDeploymentInfo(
 // null = unset the field, undefined = use the prior value
 function mergeDeploymentInfo(
   existing: MobileDeploymentInfoV0 | null | undefined,
-  newInfo: InputDeploymentInfo | undefined
+  newInfo: InputDeploymentInfo | undefined,
 ): MobileDeploymentInfoV0 | undefined {
   if (!newInfo) return existing ?? undefined;
   if (!existing) return inputToOnboardingDeploymentInfo(newInfo);
@@ -138,7 +139,7 @@ function mergeDeploymentInfo(
             ? serial === null
               ? null
               : serial
-            : existingWifi.serial ?? null,
+            : (existingWifi.serial ?? null),
       },
     };
   }
@@ -146,10 +147,12 @@ function mergeDeploymentInfo(
   if (existingType === "CBRS" && newType === "CBRS" && existing.cbrsInfoV0) {
     const { type: _, ...cbrs } = newInfo;
     return {
-      cbrsInfoV0:
-        cbrs.radioInfos !== undefined
-          ? cbrs.radioInfos
-          : existing.cbrsInfoV0.radioInfos,
+      cbrsInfoV0: {
+        radioInfos:
+          cbrs.radioInfos !== undefined
+            ? cbrs.radioInfos
+            : existing.cbrsInfoV0.radioInfos,
+      },
     };
   }
 
@@ -190,10 +193,10 @@ async function estimateMobileResizeRent({
   };
   const encoded = await program.coder.accounts.encode(
     "mobileHotspotInfoV0",
-    next
+    next,
   );
   const rentExempt = await connection.getMinimumBalanceForRentExemption(
-    encoded.length + RESIZE_PADDING_BYTES
+    encoded.length + RESIZE_PADDING_BYTES,
   );
   return resizeTopUpLamports(rentExempt, account.lamports);
 }
@@ -201,7 +204,7 @@ async function estimateMobileResizeRent({
 /** DC the owner holds, treating a missing token account as a zero balance. */
 async function dcBalance(
   connection: Connection,
-  owner: PublicKey
+  owner: PublicKey,
 ): Promise<bigint> {
   try {
     return (await getAccount(connection, dcBurnerFor(owner))).amount;
@@ -233,6 +236,8 @@ async function dcFeeForUpdate({
   info: HotspotInfo;
   newLocation: BN | null;
 }): Promise<BN> {
+  if (!newLocation) return new BN(0);
+
   const config = await (
     program.account as any
   ).rewardableEntityConfigV0.fetchNullable(REWARDABLE_ENTITY_CONFIG[network]);
@@ -245,7 +250,7 @@ async function dcFeeForUpdate({
           config.settings,
           network === "iot"
             ? { network: "iot", isFullHotspot: !!info.iot?.isFullHotspot }
-            : { network: "mobile", deviceType: info.mobile?.deviceType ?? {} }
+            : { network: "mobile", deviceType: info.mobile?.deviceType ?? {} },
         )
       : null,
   });
@@ -262,16 +267,12 @@ export const updateHotspotInfo =
       }
 
       const { connection, provider } = createSolanaConnection(walletAddress);
-      const assetEndpoint = env.ASSET_ENDPOINT || connection.rpcEndpoint;
+      const assetEndpoint = getAssetEndpoint();
       const assetPubkey = new PublicKey(assetId);
 
-      const asset = await getAsset(assetEndpoint, assetPubkey);
-      if (!asset) {
-        throw errors.NOT_FOUND({ message: "Asset not found" });
-      }
-
-      assertAssetOwner({
-        asset,
+      const asset = await fetchOwnedAsset({
+        assetEndpoint,
+        assetId: assetPubkey,
         expectedOwner: walletAddress,
         message: "Wallet does not own this hotspot",
         errors,
@@ -280,11 +281,11 @@ export const updateHotspotInfo =
       const hemProgram = await initHemLocal(provider);
       const [keyToAssetK] = keyToAssetKey(HNT_DAO, entityPubKey);
       const keyToAsset = await (hemProgram.account as any).keyToAssetV0.fetch(
-        keyToAssetK
+        keyToAssetK,
       );
       const entityKey = decodeEntityKey(
         keyToAsset.entityKey,
-        keyToAsset.keySerialization
+        keyToAsset.keySerialization,
       );
 
       if (!entityKey) {
@@ -338,40 +339,24 @@ export const updateHotspotInfo =
           : null;
         const info = await getHotspotInfo(provider, entityKey);
 
-        let updateIx;
+        let update: OwnerPaidUpdate;
         if (input.deviceType === "iot") {
-          updateIx = await buildOwnerPaidUpdateInstruction({
-            program: hemProgram,
-            owner,
-            entityKey,
-            merkleTree: accounts.merkleTree,
-            proofArgs: args,
-            remainingAccounts,
-            update: {
-              network: "iot",
-              location: newLocation,
-              elevation: toOnChainElevation(input.elevation),
-              gain: toOnChainGain(input.gain),
-            },
-          });
+          update = {
+            network: "iot",
+            location: newLocation,
+            elevation: toOnChainElevation(input.elevation),
+            gain: toOnChainGain(input.gain),
+          };
         } else {
           const mergedDeploymentInfo = mergeDeploymentInfo(
             info.mobile?.deploymentInfo ?? undefined,
-            input.deploymentInfo
+            input.deploymentInfo,
           );
-          updateIx = await buildOwnerPaidUpdateInstruction({
-            program: hemProgram,
-            owner,
-            entityKey,
-            merkleTree: accounts.merkleTree,
-            proofArgs: args,
-            remainingAccounts,
-            update: {
-              network: "mobile",
-              location: newLocation,
-              deploymentInfo: mergedDeploymentInfo ?? null,
-            },
-          });
+          update = {
+            network: "mobile",
+            location: newLocation,
+            deploymentInfo: mergedDeploymentInfo ?? null,
+          };
           rentLamports = await estimateMobileResizeRent({
             connection,
             program: hemProgram,
@@ -380,10 +365,20 @@ export const updateHotspotInfo =
             location: newLocation,
             deploymentInfo: withPreservedWifiSerial(
               mergedDeploymentInfo,
-              info.mobile?.deploymentInfo ?? undefined
+              info.mobile?.deploymentInfo ?? undefined,
             ),
           });
         }
+
+        const updateIx = await buildOwnerPaidUpdateInstruction({
+          program: hemProgram,
+          owner,
+          entityKey,
+          merkleTree: accounts.merkleTree,
+          proofArgs: args,
+          remainingAccounts,
+          update,
+        });
 
         const dcFee = await dcFeeForUpdate({
           program: hemProgram,
@@ -425,7 +420,9 @@ export const updateHotspotInfo =
             solanaAddress: walletAddress,
             location: h3?.iot,
             elevation: input.elevation,
-            gain: input.gain,
+            // The onboarding wire field is tenths of a dBi, like the on-chain
+            // i32; the input is decimal dBi in both fee-payer modes.
+            gain: toOnChainGain(input.gain) ?? undefined,
             format: "v0",
           });
           const txs = response.data?.solanaTransactions ?? [];
@@ -450,7 +447,7 @@ export const updateHotspotInfo =
           // Merge existing with new deploymentInfo
           const mergedDeploymentInfo = mergeDeploymentInfo(
             existingDeploymentInfo,
-            input.deploymentInfo
+            input.deploymentInfo,
           );
 
           const response = await onboardingClient.updateMobileMetadata({
@@ -484,7 +481,7 @@ export const updateHotspotInfo =
 
         // Calculate fees from external transactions (format: v0 ensures VersionedTransaction)
         const vtxs = rawTxBytes.map((bytes) =>
-          VersionedTransaction.deserialize(bytes)
+          VersionedTransaction.deserialize(bytes),
         );
         totalFee = await getTotalTransactionFees(connection, vtxs);
       }
@@ -497,7 +494,7 @@ export const updateHotspotInfo =
 
       // Check wallet has sufficient balance using actual transaction fees
       const walletBalance = await connection.getBalance(
-        new PublicKey(walletAddress)
+        new PublicKey(walletAddress),
       );
       const required = calculateRequiredBalance(totalFee, rentLamports);
       if (walletBalance < required) {
@@ -541,9 +538,9 @@ export const updateHotspotInfo =
         },
         estimatedSolFee: await toTokenAmountOutput(
           new BN(totalFee + rentLamports),
-          NATIVE_MINT.toBase58()
+          NATIVE_MINT.toBase58(),
         ),
         appliedTo,
       };
-    }
+    },
   );

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/updateHotspotInfo.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/updateHotspotInfo.ts
@@ -1,6 +1,7 @@
 import { publicProcedure } from "../../../procedures";
 import { env } from "@/lib/env";
 import { createSolanaConnection } from "@/lib/solana";
+import { assertAssetOwner } from "@/lib/utils/asset-ownership";
 import {
   generateTransactionTag,
   TRANSACTION_TYPES,
@@ -269,16 +270,12 @@ export const updateHotspotInfo =
         throw errors.NOT_FOUND({ message: "Asset not found" });
       }
 
-      const ownerAddress =
-        typeof asset.ownership.owner === "string"
-          ? asset.ownership.owner
-          : asset.ownership.owner.toBase58();
-
-      if (ownerAddress !== walletAddress) {
-        throw errors.UNAUTHORIZED({
-          message: "Wallet does not own this hotspot",
-        });
-      }
+      assertAssetOwner({
+        asset,
+        expectedOwner: walletAddress,
+        message: "Wallet does not own this hotspot",
+        errors,
+      });
 
       const hemProgram = await initHemLocal(provider);
       const [keyToAssetK] = keyToAssetKey(HNT_DAO, entityPubKey);

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/updateHotspotInfo.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/updateHotspotInfo.ts
@@ -13,14 +13,14 @@ import { detectHotspotNetworks, getHotspotInfo } from "@/lib/queries/hotspots";
 import animalName from "angry-purple-tiger";
 import { latLngToH3 } from "@/lib/location/h3";
 import OnboardingClient from "@helium/onboarding";
-import { getAsset } from "@helium/spl-utils";
+import { getAsset, proofArgsAndAccounts } from "@helium/spl-utils";
 import {
   keyToAssetKey,
   decodeEntityKey,
 } from "@helium/helium-entity-manager-sdk";
 import { daoKey } from "@helium/helium-sub-daos-sdk";
 import { HNT_MINT } from "@helium/spl-utils";
-import { PublicKey, VersionedTransaction } from "@solana/web3.js";
+import { Connection, PublicKey, VersionedTransaction } from "@solana/web3.js";
 
 import type { TransactionItem } from "@helium/blockchain-api/schemas/common";
 import type { IdlTypes, Program } from "@coral-xyz/anchor";
@@ -28,11 +28,36 @@ import type { z } from "zod";
 import { UpdateHotspotInfoInputSchema } from "@helium/blockchain-api/schemas/hotspots";
 import {
   getTotalTransactionFees,
+  getTransactionFee,
   calculateRequiredBalance,
   BASE_TX_FEE_LAMPORTS,
 } from "@/lib/utils/balance-validation";
+import {
+  buildVersionedTransaction,
+  serializeTransaction,
+} from "@/lib/utils/build-transaction";
+import {
+  assertDcCovered,
+  assertNotDelegated,
+  buildOwnerPaidUpdateInstruction,
+  dcBurnerFor,
+  hotspotInfoKey,
+  locationAssertDcFee,
+  locationStakingFee,
+  REWARDABLE_ENTITY_CONFIG,
+  RESIZE_PADDING_BYTES,
+  resizeTopUpLamports,
+  toOnChainElevation,
+  toOnChainGain,
+  withPreservedWifiSerial,
+} from "./update-info-owner";
 import { toTokenAmountOutput } from "@/lib/utils/token-math";
-import { NATIVE_MINT } from "@solana/spl-token";
+import {
+  getAccount,
+  NATIVE_MINT,
+  TokenAccountNotFoundError,
+  TokenInvalidAccountOwnerError,
+} from "@solana/spl-token";
 import BN from "bn.js";
 
 type HemProgram = Awaited<ReturnType<typeof initHemLocal>>;
@@ -130,6 +155,101 @@ function mergeDeploymentInfo(
   return inputToOnboardingDeploymentInfo(newInfo);
 }
 
+type HotspotInfo = Awaited<ReturnType<typeof getHotspotInfo>>;
+
+/**
+ * Lamports `resize_to_fit` moves from the payer into the mobile_info account.
+ * The size is measured by serializing the account as the update will leave it
+ * rather than modelling the layout, and the program only ever tops the account
+ * up to the rent-exempt minimum, so an already-large-enough account costs
+ * nothing.
+ */
+async function estimateMobileResizeRent({
+  connection,
+  program,
+  infoKey,
+  current,
+  location,
+  deploymentInfo,
+}: {
+  connection: Connection;
+  program: HemProgram;
+  infoKey: PublicKey;
+  current: HotspotInfo["mobile"];
+  location: BN | null;
+  deploymentInfo: MobileDeploymentInfoV0 | undefined;
+}): Promise<number> {
+  const account = await connection.getAccountInfo(infoKey);
+  if (!account || !current) return 0;
+
+  const next = {
+    ...current,
+    ...(location ? { location } : {}),
+    ...(deploymentInfo ? { deploymentInfo } : {}),
+  };
+  const encoded = await program.coder.accounts.encode(
+    "mobileHotspotInfoV0",
+    next
+  );
+  const rentExempt = await connection.getMinimumBalanceForRentExemption(
+    encoded.length + RESIZE_PADDING_BYTES
+  );
+  return resizeTopUpLamports(rentExempt, account.lamports);
+}
+
+/** DC the owner holds, treating a missing token account as a zero balance. */
+async function dcBalance(
+  connection: Connection,
+  owner: PublicKey
+): Promise<bigint> {
+  try {
+    return (await getAccount(connection, dcBurnerFor(owner))).amount;
+  } catch (e) {
+    if (
+      e instanceof TokenAccountNotFoundError ||
+      e instanceof TokenInvalidAccountOwnerError
+    ) {
+      return BigInt(0);
+    }
+    throw e;
+  }
+}
+
+/**
+ * DC this update will burn on chain: the sub-DAO's location staking fee for
+ * this hotspot, and only when the update actually moves the location. When the
+ * sub-DAO's settings carry no fee for the hotspot, the burn is left to the
+ * program to price rather than guessed at here.
+ */
+async function dcFeeForUpdate({
+  program,
+  network,
+  info,
+  newLocation,
+}: {
+  program: HemProgram;
+  network: "iot" | "mobile";
+  info: HotspotInfo;
+  newLocation: BN | null;
+}): Promise<BN> {
+  const config = await (
+    program.account as any
+  ).rewardableEntityConfigV0.fetchNullable(REWARDABLE_ENTITY_CONFIG[network]);
+
+  return locationAssertDcFee({
+    newLocation,
+    currentLocation: (network === "iot" ? info.iot : info.mobile)?.location,
+    stakingFee: config
+      ? locationStakingFee(
+          config.settings,
+          network === "iot"
+            ? { network: "iot", isFullHotspot: !!info.iot?.isFullHotspot }
+            : { network: "mobile", deviceType: info.mobile?.deviceType ?? {} }
+        )
+      : null,
+  });
+}
+
 export const updateHotspotInfo =
   publicProcedure.hotspots.updateHotspotInfo.handler(
     async ({ input, errors }) => {
@@ -189,71 +309,187 @@ export const updateHotspotInfo =
 
       const h3 = location ? latLngToH3(location) : null;
       const transactions: TransactionItem[] = [];
-      const rawTxBytes: Uint8Array[] = [];
       const appliedTo = { iot: false, mobile: false };
-      const onboardingClient = new OnboardingClient(env.ONBOARDING_ENDPOINT);
+      // Lamports the wallet pays on top of the transaction fee. Only owner mode
+      // pays any: `resize_to_fit` funds a grown mobile_info account from
+      // `payer`, which is the maker when the maker builds the transaction.
+      let rentLamports = 0;
+      let totalFee: number;
 
-      if (input.deviceType === "iot") {
-        const response = await onboardingClient.updateIotMetadata({
-          hotspotAddress: entityPubKey,
-          solanaAddress: walletAddress,
-          location: h3?.iot,
-          elevation: input.elevation,
-          gain: input.gain,
-          format: "v0",
+      if (input.feePayer === "owner") {
+        const owner = new PublicKey(walletAddress);
+        const network = input.deviceType;
+
+        assertNotDelegated({
+          owner: walletAddress,
+          delegate: asset.ownership.delegate,
+          errors,
         });
-        const txs = response.data?.solanaTransactions ?? [];
-        for (const txBytes of txs) {
-          const bytes = Buffer.from(txBytes);
-          rawTxBytes.push(bytes);
-          transactions.push({
-            serializedTransaction: Buffer.from(txBytes).toString("base64"),
-            metadata: {
-              type: "hotspot_update",
-              description: "Update IoT hotspot info",
+
+        const { args, accounts, remainingAccounts } =
+          await proofArgsAndAccounts({
+            connection,
+            assetId: assetPubkey,
+            assetEndpoint,
+            // The asset is already in hand from the ownership check above;
+            // reuse it rather than pay for a second DAS round-trip.
+            getAssetFn: async () => asset,
+          });
+
+        const newLocation = h3
+          ? new BN(network === "iot" ? h3.iot : h3.mobile, "hex")
+          : null;
+        const info = await getHotspotInfo(provider, entityKey);
+
+        let updateIx;
+        if (input.deviceType === "iot") {
+          updateIx = await buildOwnerPaidUpdateInstruction({
+            program: hemProgram,
+            owner,
+            entityKey,
+            merkleTree: accounts.merkleTree,
+            proofArgs: args,
+            remainingAccounts,
+            update: {
+              network: "iot",
+              location: newLocation,
+              elevation: toOnChainElevation(input.elevation),
+              gain: toOnChainGain(input.gain),
             },
           });
+        } else {
+          const mergedDeploymentInfo = mergeDeploymentInfo(
+            info.mobile?.deploymentInfo ?? undefined,
+            input.deploymentInfo
+          );
+          updateIx = await buildOwnerPaidUpdateInstruction({
+            program: hemProgram,
+            owner,
+            entityKey,
+            merkleTree: accounts.merkleTree,
+            proofArgs: args,
+            remainingAccounts,
+            update: {
+              network: "mobile",
+              location: newLocation,
+              deploymentInfo: mergedDeploymentInfo ?? null,
+            },
+          });
+          rentLamports = await estimateMobileResizeRent({
+            connection,
+            program: hemProgram,
+            infoKey: hotspotInfoKey("mobile", entityKey),
+            current: info.mobile,
+            location: newLocation,
+            deploymentInfo: withPreservedWifiSerial(
+              mergedDeploymentInfo,
+              info.mobile?.deploymentInfo ?? undefined
+            ),
+          });
         }
-        appliedTo.iot = true;
+
+        const dcFee = await dcFeeForUpdate({
+          program: hemProgram,
+          network,
+          info,
+          newLocation,
+        });
+        if (!dcFee.isZero()) {
+          assertDcCovered({
+            required: dcFee,
+            available: await dcBalance(connection, owner),
+            errors,
+          });
+        }
+
+        const tx = await buildVersionedTransaction({
+          connection,
+          draft: { instructions: [updateIx], feePayer: owner },
+        });
+        totalFee = await getTransactionFee(connection, tx);
+        transactions.push({
+          serializedTransaction: serializeTransaction(tx),
+          metadata: {
+            type: "hotspot_update",
+            description:
+              network === "iot"
+                ? "Update IoT hotspot info"
+                : "Update Mobile hotspot info",
+          },
+        });
+        appliedTo[network] = true;
       } else {
-        // Fetch existing mobile hotspot info to get current deploymentInfo
-        const hotspotInfo = await getHotspotInfo(provider, entityKey);
-        const existingDeploymentInfo =
-          hotspotInfo.mobile?.deploymentInfo ?? undefined;
+        const rawTxBytes: Uint8Array[] = [];
+        const onboardingClient = new OnboardingClient(env.ONBOARDING_ENDPOINT);
 
-        // Merge existing with new deploymentInfo
-        const mergedDeploymentInfo = mergeDeploymentInfo(
-          existingDeploymentInfo,
-          input.deploymentInfo
-        );
+        if (input.deviceType === "iot") {
+          const response = await onboardingClient.updateIotMetadata({
+            hotspotAddress: entityPubKey,
+            solanaAddress: walletAddress,
+            location: h3?.iot,
+            elevation: input.elevation,
+            gain: input.gain,
+            format: "v0",
+          });
+          const txs = response.data?.solanaTransactions ?? [];
+          for (const txBytes of txs) {
+            const bytes = Buffer.from(txBytes);
+            rawTxBytes.push(bytes);
+            transactions.push({
+              serializedTransaction: Buffer.from(txBytes).toString("base64"),
+              metadata: {
+                type: "hotspot_update",
+                description: "Update IoT hotspot info",
+              },
+            });
+          }
+          appliedTo.iot = true;
+        } else {
+          // Fetch existing mobile hotspot info to get current deploymentInfo
+          const hotspotInfo = await getHotspotInfo(provider, entityKey);
+          const existingDeploymentInfo =
+            hotspotInfo.mobile?.deploymentInfo ?? undefined;
 
-        const response = await onboardingClient.updateMobileMetadata({
-          hotspotAddress: entityPubKey,
-          solanaAddress: walletAddress,
-          location: h3?.mobile,
-          deploymentInfo: mergedDeploymentInfo,
-          format: "v0",
-        });
-        const txs = response.data?.solanaTransactions ?? [];
-        for (const txBytes of txs) {
-          const bytes = Buffer.from(txBytes);
-          rawTxBytes.push(bytes);
-          transactions.push({
-            serializedTransaction: Buffer.from(txBytes).toString("base64"),
-            metadata: {
-              type: "hotspot_update",
-              description: "Update Mobile hotspot info",
-            },
+          // Merge existing with new deploymentInfo
+          const mergedDeploymentInfo = mergeDeploymentInfo(
+            existingDeploymentInfo,
+            input.deploymentInfo
+          );
+
+          const response = await onboardingClient.updateMobileMetadata({
+            hotspotAddress: entityPubKey,
+            solanaAddress: walletAddress,
+            location: h3?.mobile,
+            deploymentInfo: mergedDeploymentInfo,
+            format: "v0",
+          });
+          const txs = response.data?.solanaTransactions ?? [];
+          for (const txBytes of txs) {
+            const bytes = Buffer.from(txBytes);
+            rawTxBytes.push(bytes);
+            transactions.push({
+              serializedTransaction: Buffer.from(txBytes).toString("base64"),
+              metadata: {
+                type: "hotspot_update",
+                description: "Update Mobile hotspot info",
+              },
+            });
+          }
+          appliedTo.mobile = true;
+        }
+
+        if (transactions.length === 0) {
+          throw errors.NOT_FOUND({
+            message:
+              "Onboarding server returned no transactions for this hotspot",
           });
         }
-        appliedTo.mobile = true;
-      }
 
-      if (transactions.length === 0) {
-        throw errors.NOT_FOUND({
-          message:
-            "Onboarding server returned no transactions for this hotspot",
-        });
+        // Calculate fees from external transactions (format: v0 ensures VersionedTransaction)
+        const vtxs = rawTxBytes.map((bytes) =>
+          VersionedTransaction.deserialize(bytes)
+        );
+        totalFee = await getTotalTransactionFees(connection, vtxs);
       }
 
       const tag = generateTransactionTag({
@@ -262,17 +498,11 @@ export const updateHotspotInfo =
         entityPubKey,
       });
 
-      // Calculate fees from external transactions (format: v0 ensures VersionedTransaction)
-      const vtxs = rawTxBytes.map((bytes) =>
-        VersionedTransaction.deserialize(bytes)
-      );
-      const totalFee = await getTotalTransactionFees(connection, vtxs);
-
       // Check wallet has sufficient balance using actual transaction fees
       const walletBalance = await connection.getBalance(
         new PublicKey(walletAddress)
       );
-      const required = calculateRequiredBalance(totalFee, 0);
+      const required = calculateRequiredBalance(totalFee, rentLamports);
       if (walletBalance < required) {
         throw errors.INSUFFICIENT_FUNDS({
           message: "Insufficient SOL balance for transaction fees",
@@ -313,7 +543,7 @@ export const updateHotspotInfo =
           },
         },
         estimatedSolFee: await toTokenAmountOutput(
-          new BN(totalFee),
+          new BN(totalFee + rentLamports),
           NATIVE_MINT.toBase58()
         ),
         appliedTo,

--- a/packages/blockchain-api/src/server/api/routers/hotspots/procedures/updateRewardsDestination.ts
+++ b/packages/blockchain-api/src/server/api/routers/hotspots/procedures/updateRewardsDestination.ts
@@ -16,6 +16,7 @@ import {
 } from "@helium/lazy-distributor-sdk";
 import { createSolanaConnection } from "@/lib/solana";
 import { env } from "@/lib/env";
+import { assertAssetOwner } from "@/lib/utils/asset-ownership";
 import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
 import {
   calculateRequiredBalance,
@@ -110,7 +111,17 @@ export const updateRewardsDestination =
           assetEndpoint,
         });
 
-      const { owner } = asset.ownership;
+      // The instruction's authority below is the asset's owner, so a caller who
+      // is not that owner would otherwise get a transaction built in the
+      // owner's name.
+      const owner = new PublicKey(
+        assertAssetOwner({
+          asset,
+          expectedOwner: walletAddress,
+          message: "Wallet does not own this hotspot",
+          errors,
+        })
+      );
       const hotspotName = asset.content?.metadata?.name;
 
       // Build instructions for each lazy distributor

--- a/packages/blockchain-api/src/server/api/routers/reward-contract/procedures/claim.ts
+++ b/packages/blockchain-api/src/server/api/routers/reward-contract/procedures/claim.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/utils/build-transaction";
 import { assetOwnerAddress } from "@/lib/utils/asset-ownership";
 import {
+  checkApprovalWindow,
   CLAIM_APPROVAL_MESSAGES,
   verifyClaimApproval,
 } from "@/lib/utils/claim-approval";
@@ -37,12 +38,22 @@ export const claim = publicProcedure.rewardContract.claim.handler(
     const { entityPubKey, signerWalletAddress, delegateSignature, expiration } =
       input;
 
+    const expirationTs = Math.floor(new Date(expiration).getTime() / 1000);
+    const now = Math.floor(Date.now() / 1000);
+
+    // An expiry the program would not accept is refused on its own, before the
+    // lookups, so the answer is the same whether or not a pack is still there.
+    const windowRejection = checkApprovalWindow({ expirationTs, now });
+    if (windowRejection) {
+      throw errors.BAD_REQUEST({
+        message: CLAIM_APPROVAL_MESSAGES[windowRejection],
+      });
+    }
+
     const assetId = await getAssetIdFromPubkey(entityPubKey);
     if (!assetId) {
       throw errors.NOT_FOUND({ message: "Hotspot not found" });
     }
-
-    const expirationTs = Math.floor(new Date(expiration).getTime() / 1000);
 
     // The lookups below only read accounts, so they run under the claimer's
     // address. The fee payer's key is loaded further down, once the approval it
@@ -74,7 +85,7 @@ export const claim = publicProcedure.rewardContract.claim.handler(
       expirationTs,
       owner: found.welcomePack.owner.toBytes(),
       signatureBase64: delegateSignature,
-      now: Math.floor(Date.now() / 1000),
+      now,
     });
     if (!approval.ok) {
       throw errors.BAD_REQUEST({
@@ -99,7 +110,7 @@ export const claim = publicProcedure.rewardContract.claim.handler(
       entityPubKey,
       errors,
     });
-  }
+  },
 );
 
 /**
@@ -231,10 +242,10 @@ async function buildClaimTransaction({
           getAssociatedTokenAddressSync(
             rewardsMint,
             new PublicKey(signerWalletAddress),
-            true
+            true,
           ),
           new PublicKey(signerWalletAddress),
-          rewardsMint
+          rewardsMint,
         ),
       ],
       feePayer: feePayerWallet.publicKey,
@@ -265,7 +276,7 @@ async function buildClaimTransaction({
     },
     estimatedSolFee: await toTokenAmountOutput(
       new BN(0),
-      NATIVE_MINT.toBase58()
+      NATIVE_MINT.toBase58(),
     ),
   };
 }

--- a/packages/blockchain-api/src/server/api/routers/reward-contract/procedures/claim.ts
+++ b/packages/blockchain-api/src/server/api/routers/reward-contract/procedures/claim.ts
@@ -5,6 +5,11 @@ import {
   buildVersionedTransaction,
   serializeTransaction,
 } from "@/lib/utils/build-transaction";
+import { assetOwnerAddress } from "@/lib/utils/asset-ownership";
+import {
+  CLAIM_APPROVAL_MESSAGES,
+  verifyClaimApproval,
+} from "@/lib/utils/claim-approval";
 import { getAssetIdFromPubkey } from "@/lib/utils/hotspot-helpers";
 import {
   generateTransactionTag,
@@ -38,90 +43,103 @@ export const claim = publicProcedure.rewardContract.claim.handler(
     }
 
     const expirationTs = Math.floor(new Date(expiration).getTime() / 1000);
-    const currentTs = Math.floor(Date.now() / 1000);
-    if (currentTs > expirationTs) {
-      throw errors.BAD_REQUEST({ message: "Invite has expired" });
-    }
 
-    const signatureBytes = Buffer.from(delegateSignature, "base64");
-
-    const feePayerWallet = loadKeypair(process.env.FEE_PAYER_WALLET_PATH!);
-
-    const { provider, connection } = createSolanaConnection(
-      feePayerWallet.publicKey.toString()
-    );
+    // The lookups below only read accounts, so they run under the claimer's
+    // address. The fee payer's key is loaded further down, once the approval it
+    // would be spent on has been verified.
+    const { provider, connection } =
+      createSolanaConnection(signerWalletAddress);
     const assetEndpoint = env.ASSET_ENDPOINT || connection.rpcEndpoint;
     const assetPubkey = new PublicKey(assetId);
 
     const wpProgram = await initWelcomePack(provider);
-    const tuktukProgram = await initTuktuk(provider);
 
     const asset = await getAsset(assetEndpoint, assetPubkey);
     if (!asset) {
       throw errors.NOT_FOUND({ message: "Asset not found" });
     }
-    const assetOwner = new PublicKey(
-      typeof asset.ownership.owner === "string"
-        ? asset.ownership.owner
-        : asset.ownership.owner.toBase58()
-    );
+    const assetOwner = new PublicKey(assetOwnerAddress(asset));
 
-    // When asset is transferred to WelcomePack, assetOwner IS the pack address
-    const directWelcomePack =
-      await wpProgram.account.welcomePackV0.fetchNullable(assetOwner);
-    if (directWelcomePack && directWelcomePack.asset.equals(assetPubkey)) {
-      return buildClaimTransaction({
-        wpProgram,
-        tuktukProgram,
-        welcomePackK: assetOwner,
-        welcomePack: directWelcomePack,
-        assetEndpoint,
-        signerWalletAddress,
-        feePayerWallet,
-        expirationTs,
-        signatureBytes,
-        connection,
-        entityPubKey,
-        errors,
+    const found = await findWelcomePack({
+      wpProgram,
+      assetOwner,
+      assetPubkey,
+    });
+    if (!found) {
+      throw errors.NOT_FOUND({ message: "Reward contract not found." });
+    }
+
+    const approval = verifyClaimApproval({
+      uniqueId: found.welcomePack.uniqueId,
+      expirationTs,
+      owner: found.welcomePack.owner.toBytes(),
+      signatureBase64: delegateSignature,
+      now: Math.floor(Date.now() / 1000),
+    });
+    if (!approval.ok) {
+      throw errors.BAD_REQUEST({
+        message: CLAIM_APPROVAL_MESSAGES[approval.reason],
       });
     }
 
-    // Iteration fallback - assetOwner is a wallet with UserWelcomePacks
-    const [userWelcomePacksK] = userWelcomePacksKey(assetOwner);
-    const userWelcomePacks =
-      await wpProgram.account.userWelcomePacksV0.fetchNullable(
-        userWelcomePacksK
-      );
+    const feePayerWallet = loadKeypair(process.env.FEE_PAYER_WALLET_PATH!);
+    const tuktukProgram = await initTuktuk(provider);
 
-    if (userWelcomePacks) {
-      for (let i = 0; i < (userWelcomePacks.nextId || 0); i++) {
-        const [welcomePackK] = welcomePackKey(assetOwner, i);
-        const welcomePack = await wpProgram.account.welcomePackV0.fetchNullable(
-          welcomePackK
-        );
-
-        if (welcomePack && welcomePack.asset.equals(assetPubkey)) {
-          return buildClaimTransaction({
-            wpProgram,
-            tuktukProgram,
-            welcomePackK,
-            welcomePack,
-            assetEndpoint,
-            signerWalletAddress,
-            feePayerWallet,
-            expirationTs,
-            signatureBytes,
-            connection,
-            entityPubKey,
-            errors,
-          });
-        }
-      }
-    }
-
-    throw errors.NOT_FOUND({ message: "Reward contract not found." });
+    return buildClaimTransaction({
+      wpProgram,
+      tuktukProgram,
+      welcomePackK: found.welcomePackK,
+      welcomePack: found.welcomePack,
+      assetEndpoint,
+      signerWalletAddress,
+      feePayerWallet,
+      expirationTs,
+      signatureBytes: approval.signature,
+      connection,
+      entityPubKey,
+      errors,
+    });
   }
 );
+
+/**
+ * The welcome pack holding this asset, by either of the two ways the asset can
+ * be held: transferred to the pack itself, in which case the asset's owner is
+ * the pack, or still with a wallet that has packs of its own to search.
+ */
+async function findWelcomePack({
+  wpProgram,
+  assetOwner,
+  assetPubkey,
+}: {
+  wpProgram: Awaited<ReturnType<typeof initWelcomePack>>;
+  assetOwner: PublicKey;
+  assetPubkey: PublicKey;
+}) {
+  const directWelcomePack =
+    await wpProgram.account.welcomePackV0.fetchNullable(assetOwner);
+  if (directWelcomePack && directWelcomePack.asset.equals(assetPubkey)) {
+    return { welcomePackK: assetOwner, welcomePack: directWelcomePack };
+  }
+
+  const [userWelcomePacksK] = userWelcomePacksKey(assetOwner);
+  const userWelcomePacks =
+    await wpProgram.account.userWelcomePacksV0.fetchNullable(userWelcomePacksK);
+  if (!userWelcomePacks) {
+    return null;
+  }
+
+  for (let i = 0; i < (userWelcomePacks.nextId || 0); i++) {
+    const [welcomePackK] = welcomePackKey(assetOwner, i);
+    const welcomePack =
+      await wpProgram.account.welcomePackV0.fetchNullable(welcomePackK);
+    if (welcomePack && welcomePack.asset.equals(assetPubkey)) {
+      return { welcomePackK, welcomePack };
+    }
+  }
+
+  return null;
+}
 
 async function buildClaimTransaction({
   wpProgram,

--- a/packages/blockchain-api/src/server/api/routers/reward-contract/procedures/create.ts
+++ b/packages/blockchain-api/src/server/api/routers/reward-contract/procedures/create.ts
@@ -2,6 +2,7 @@ import { publicProcedure } from "../../../procedures";
 import { env } from "@/lib/env";
 import { HNT_LAZY_DISTRIBUTOR_ADDRESS } from "@/lib/constants/lazy-distributor";
 import { createSolanaConnection } from "@/lib/solana";
+import { assertAssetOwner } from "@/lib/utils/asset-ownership";
 import {
   calculateRequiredBalance,
   getTransactionFee,
@@ -87,16 +88,12 @@ export const create = publicProcedure.rewardContract.create.handler(
       throw errors.NOT_FOUND({ message: "Asset not found" });
     }
 
-    const ownerAddress =
-      typeof asset.ownership.owner === "string"
-        ? asset.ownership.owner
-        : asset.ownership.owner.toBase58();
-
-    if (ownerAddress !== signerWalletAddress) {
-      throw errors.UNAUTHORIZED({
-        message: "Wallet does not own the specified entity.",
-      });
-    }
+    assertAssetOwner({
+      asset,
+      expectedOwner: signerWalletAddress,
+      message: "Wallet does not own the specified entity.",
+      errors,
+    });
 
     const ldProgram = await initLd(provider);
     const instructions: TransactionInstruction[] = [];

--- a/packages/blockchain-api/src/server/api/routers/reward-contract/procedures/create.ts
+++ b/packages/blockchain-api/src/server/api/routers/reward-contract/procedures/create.ts
@@ -1,8 +1,8 @@
 import { publicProcedure } from "../../../procedures";
 import { env } from "@/lib/env";
 import { HNT_LAZY_DISTRIBUTOR_ADDRESS } from "@/lib/constants/lazy-distributor";
-import { createSolanaConnection } from "@/lib/solana";
-import { assertAssetOwner } from "@/lib/utils/asset-ownership";
+import { createSolanaConnection, getAssetEndpoint } from "@/lib/solana";
+import { fetchOwnedAsset } from "@/lib/utils/asset-ownership";
 import {
   calculateRequiredBalance,
   getTransactionFee,
@@ -31,12 +31,7 @@ import {
   updateCompressionDestination,
 } from "@helium/lazy-distributor-sdk";
 import { init as initMiniFanout, miniFanoutKey } from "@helium/mini-fanout-sdk";
-import {
-  getAsset,
-  getAssetProof,
-  HNT_MINT,
-  proofArgsAndAccounts,
-} from "@helium/spl-utils";
+import { getAsset, getAssetProof, HNT_MINT } from "@helium/spl-utils";
 import { NATIVE_MINT } from "@solana/spl-token";
 import {
   init as initTuktuk,
@@ -75,21 +70,12 @@ export const create = publicProcedure.rewardContract.create.handler(
 
     const { connection, provider } =
       createSolanaConnection(signerWalletAddress);
-    const assetEndpoint = env.ASSET_ENDPOINT || connection.rpcEndpoint;
+    const assetEndpoint = getAssetEndpoint();
     const assetPubkey = new PublicKey(assetId);
 
-    const { asset } = await proofArgsAndAccounts({
-      connection,
-      assetId: assetPubkey,
+    await fetchOwnedAsset({
       assetEndpoint,
-    });
-
-    if (!asset) {
-      throw errors.NOT_FOUND({ message: "Asset not found" });
-    }
-
-    assertAssetOwner({
-      asset,
+      assetId: assetPubkey,
       expectedOwner: signerWalletAddress,
       message: "Wallet does not own the specified entity.",
       errors,
@@ -100,11 +86,10 @@ export const create = publicProcedure.rewardContract.create.handler(
 
     const recipientK = recipientKey(
       new PublicKey(HNT_LAZY_DISTRIBUTOR_ADDRESS),
-      assetPubkey
+      assetPubkey,
     )[0];
-    const recipientAcc = await ldProgram.account.recipientV0.fetchNullable(
-      recipientK
-    );
+    const recipientAcc =
+      await ldProgram.account.recipientV0.fetchNullable(recipientK);
 
     if (!recipientAcc) {
       instructions.push(
@@ -116,7 +101,7 @@ export const create = publicProcedure.rewardContract.create.handler(
             assetEndpoint,
             lazyDistributor: new PublicKey(HNT_LAZY_DISTRIBUTOR_ADDRESS),
           })
-        ).instruction()
+        ).instruction(),
       );
     }
 
@@ -124,7 +109,7 @@ export const create = publicProcedure.rewardContract.create.handler(
 
     // Check wallet has sufficient balance
     const walletBalance = await connection.getBalance(
-      new PublicKey(signerWalletAddress)
+      new PublicKey(signerWalletAddress),
     );
     let rentCost = 0;
     if (!recipientAcc) {
@@ -139,7 +124,7 @@ export const create = publicProcedure.rewardContract.create.handler(
         rentCost += (
           await resolveTokenAmountInput(
             claimableRecipient.giftedCurrency,
-            NATIVE_MINT.toBase58()
+            NATIVE_MINT.toBase58(),
           )
         ).toNumber();
       }
@@ -160,19 +145,17 @@ export const create = publicProcedure.rewardContract.create.handler(
       const program = await init(provider);
 
       const [uwpKey] = userWelcomePacksKey(
-        new PublicKey(delegateWalletAddress)
+        new PublicKey(delegateWalletAddress),
       );
-      const uwpAcc = await program.account.userWelcomePacksV0.fetchNullable(
-        uwpKey
-      );
+      const uwpAcc =
+        await program.account.userWelcomePacksV0.fetchNullable(uwpKey);
       if (uwpAcc && uwpAcc.nextId > 0) {
         const packKeys = Array.from(
           { length: uwpAcc.nextId },
-          (_, i) => welcomePackKey(new PublicKey(delegateWalletAddress), i)[0]
+          (_, i) => welcomePackKey(new PublicKey(delegateWalletAddress), i)[0],
         );
-        const packs = await program.account.welcomePackV0.fetchMultiple(
-          packKeys
-        );
+        const packs =
+          await program.account.welcomePackV0.fetchMultiple(packKeys);
         if (packs.some((p) => p && p.asset.equals(assetPubkey))) {
           throw errors.CONFLICT({
             message: "A welcome pack already exists for this hotspot",
@@ -185,7 +168,7 @@ export const create = publicProcedure.rewardContract.create.handler(
         claimableRecipient?.type === "CLAIMABLE"
           ? await resolveTokenAmountInput(
               claimableRecipient.giftedCurrency,
-              NATIVE_MINT.toBase58()
+              NATIVE_MINT.toBase58(),
             )
           : new BN(0);
 
@@ -202,7 +185,7 @@ export const create = publicProcedure.rewardContract.create.handler(
                 fixed: {
                   amount: await resolveTokenAmountInput(
                     r.receives.tokenAmount,
-                    HNT_MINT.toBase58()
+                    HNT_MINT.toBase58(),
                   ),
                 },
               },
@@ -213,7 +196,7 @@ export const create = publicProcedure.rewardContract.create.handler(
             share: { share: { amount: r.receives.shares } },
             wallet,
           };
-        })
+        }),
       );
 
       const { instruction: ix } = await (
@@ -238,7 +221,7 @@ export const create = publicProcedure.rewardContract.create.handler(
       const tuktukProgram = await initTuktuk(provider);
       const [miniFanoutK] = miniFanoutKey(
         new PublicKey(signerWalletAddress),
-        assetPubkey.toBuffer()
+        assetPubkey.toBuffer(),
       );
 
       const existingMiniFanout =
@@ -268,7 +251,7 @@ export const create = publicProcedure.rewardContract.create.handler(
                 fixed: {
                   amount: await resolveTokenAmountInput(
                     r.receives.tokenAmount,
-                    HNT_MINT.toBase58()
+                    HNT_MINT.toBase58(),
                   ),
                 },
               },
@@ -278,7 +261,7 @@ export const create = publicProcedure.rewardContract.create.handler(
             wallet,
             share: { share: { amount: r.receives.shares } },
           };
-        })
+        }),
       );
 
       const { instruction: initIx, pubkeys } = await miniFanoutProgram.methods
@@ -308,7 +291,7 @@ export const create = publicProcedure.rewardContract.create.handler(
           fromPubkey: new PublicKey(signerWalletAddress),
           toPubkey: pubkeys.miniFanout!,
           lamports: FANOUT_FUNDING_AMOUNT,
-        })
+        }),
       );
 
       const taskQueueAcc =
@@ -316,7 +299,7 @@ export const create = publicProcedure.rewardContract.create.handler(
 
       const [taskId, preTaskId] = nextAvailableTaskIds(
         taskQueueAcc!.taskBitmap,
-        2
+        2,
       );
 
       const scheduleIx = await miniFanoutProgram.methods
@@ -385,8 +368,8 @@ export const create = publicProcedure.rewardContract.create.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(estimatedSolFeeLamports),
-        NATIVE_MINT.toBase58()
+        NATIVE_MINT.toBase58(),
       ),
     };
-  }
+  },
 );

--- a/packages/blockchain-api/src/server/api/routers/swap/procedures/getInstructions.ts
+++ b/packages/blockchain-api/src/server/api/routers/swap/procedures/getInstructions.ts
@@ -149,14 +149,23 @@ export const getInstructions = publicProcedure.swap.getInstructions.handler(
       });
     }
 
-    // Generate transaction tag
+    // Generate transaction tag. The destination is part of it because it is
+    // where the output lands: two swaps that differ only in where the tokens
+    // go are different swaps and must not share a tag.
     const tag = generateTransactionTag({
       type: TRANSACTION_TYPES.SWAP,
       userAddress: userPublicKey,
       inputMint: quoteResponse.inputMint,
       outputMint: quoteResponse.outputMint,
       amount: quoteResponse.inAmount,
+      destinationTokenAccount,
     });
+
+    // A destination names an account other than the signer's own, so the
+    // signer is told where the output goes before signing for it.
+    const destinationSuffix = destinationTokenAccount
+      ? ` to ${destinationTokenAccount}`
+      : "";
 
     return {
       transactions: [
@@ -164,11 +173,12 @@ export const getInstructions = publicProcedure.swap.getInstructions.handler(
           serializedTransaction: serializeTransaction(tx),
           metadata: {
             type: "swap",
-            description: `Swap ${quoteResponse.inAmount} ${quoteResponse.inputMint} for ${quoteResponse.outAmount} ${quoteResponse.outputMint}`,
+            description: `Swap ${quoteResponse.inAmount} ${quoteResponse.inputMint} for ${quoteResponse.outAmount} ${quoteResponse.outputMint}${destinationSuffix}`,
             inputMint: quoteResponse.inputMint,
             outputMint: quoteResponse.outputMint,
             inputAmount: quoteResponse.inAmount,
             outputAmount: quoteResponse.outAmount,
+            destinationTokenAccount,
           },
         },
       ],
@@ -176,6 +186,7 @@ export const getInstructions = publicProcedure.swap.getInstructions.handler(
       tag,
       actionMetadata: {
         type: "swap",
+        destinationTokenAccount,
         inputTokenAmount: await toTokenAmountOutput(
           new BN(quoteResponse.inAmount),
           quoteResponse.inputMint

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer-helpers.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer-helpers.ts
@@ -1,0 +1,142 @@
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  createTransferCheckedInstruction,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
+import {
+  Connection,
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { getTokenDecimals } from "@/lib/constants/tokens";
+
+/**
+ * Build the raw transfer instructions. `authority` is the source owner and
+ * signs the transfer; `payer` funds the recipient's associated token account
+ * when one has to be created and is the transaction's fee payer. They are the
+ * same account unless the caller names a separate fee payer. Shared by the
+ * direct transfer path (authority = wallet) and the Squads propose path
+ * (authority = vault).
+ */
+export async function buildTransferInstructions({
+  connection,
+  authority,
+  payer,
+  destination,
+  mint,
+  rawAmount,
+  isSol,
+}: {
+  connection: Connection;
+  authority: PublicKey;
+  payer: PublicKey;
+  destination: PublicKey;
+  mint: string;
+  rawAmount: bigint;
+  isSol: boolean;
+}): Promise<{ instructions: TransactionInstruction[]; needsAta: boolean }> {
+  if (isSol) {
+    return {
+      instructions: [
+        SystemProgram.transfer({
+          fromPubkey: authority,
+          toPubkey: destination,
+          lamports: rawAmount,
+        }),
+      ],
+      needsAta: false,
+    };
+  }
+
+  const mintKey = new PublicKey(mint);
+  const senderAta = getAssociatedTokenAddressSync(mintKey, authority, true);
+  const destAta = getAssociatedTokenAddressSync(mintKey, destination, true);
+  const [destAtaInfo, decimals] = await Promise.all([
+    connection.getAccountInfo(destAta),
+    getTokenDecimals(mint),
+  ]);
+  const needsAta = !destAtaInfo;
+
+  return {
+    instructions: [
+      createAssociatedTokenAccountIdempotentInstruction(
+        payer,
+        destAta,
+        destination,
+        mintKey
+      ),
+      createTransferCheckedInstruction(
+        senderAta,
+        mintKey,
+        destAta,
+        authority,
+        rawAmount,
+        decimals
+      ),
+    ],
+    needsAta,
+  };
+}
+
+/** An account that cannot cover the SOL a transfer charges it. */
+export interface SolShortfall {
+  message: string;
+  required: number;
+  available: number;
+}
+
+/**
+ * Which side of a transfer falls short of its SOL cost, or null when both are
+ * covered. `payerLamports` — the transaction fee, any associated-token-account
+ * rent and the min-wallet buffer — is charged to the fee payer.
+ * `transferLamports` is the native SOL leaving the source authority, 0 for an
+ * SPL transfer.
+ *
+ * `authorityBalance` is the source authority's own balance, and is null
+ * whenever nothing is charged to it separately: either the authority is itself
+ * the fee payer, or the transfer moves no SOL. Both costs then come off the one
+ * balance.
+ */
+export function transferSolShortfall({
+  payerBalance,
+  payerLamports,
+  transferLamports,
+  authorityBalance,
+}: {
+  payerBalance: number;
+  payerLamports: number;
+  transferLamports: number;
+  authorityBalance: number | null;
+}): SolShortfall | null {
+  if (authorityBalance === null) {
+    const required = payerLamports + transferLamports;
+    if (payerBalance >= required) return null;
+    return {
+      message:
+        transferLamports > 0
+          ? "Insufficient SOL balance for transfer and transaction fees"
+          : "Insufficient SOL balance for transaction fees",
+      required,
+      available: payerBalance,
+    };
+  }
+
+  if (payerBalance < payerLamports) {
+    return {
+      message: "Insufficient SOL balance for transaction fees",
+      required: payerLamports,
+      available: payerBalance,
+    };
+  }
+
+  if (authorityBalance < transferLamports) {
+    return {
+      message: "Insufficient SOL balance for transfer",
+      required: transferLamports,
+      available: authorityBalance,
+    };
+  }
+
+  return null;
+}

--- a/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
+++ b/packages/blockchain-api/src/server/api/routers/tokens/procedures/transfer.ts
@@ -1,15 +1,5 @@
 import { publicProcedure } from "../../../procedures";
-import {
-  PublicKey,
-  SystemProgram,
-  Connection,
-  TransactionInstruction,
-} from "@solana/web3.js";
-import {
-  createAssociatedTokenAccountIdempotentInstruction,
-  createTransferCheckedInstruction,
-  getAssociatedTokenAddressSync,
-} from "@solana/spl-token";
+import { PublicKey, Connection } from "@solana/web3.js";
 import {
   buildVersionedTransaction,
   serializeTransaction,
@@ -18,11 +8,7 @@ import {
   generateTransactionTag,
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
-import {
-  TOKEN_MINTS,
-  TOKEN_NAMES,
-  getTokenDecimals,
-} from "@/lib/constants/tokens";
+import { TOKEN_MINTS, TOKEN_NAMES } from "@/lib/constants/tokens";
 import {
   getTransactionFee,
   calculateRequiredBalance,
@@ -34,77 +20,27 @@ import {
   buildActionProposal,
   proposalTransactionData,
 } from "../../squads/procedures/helpers";
+import {
+  buildTransferInstructions,
+  transferSolShortfall,
+} from "./transfer-helpers";
 import BN from "bn.js";
-
-/**
- * Build the raw transfer instructions with `authority` as the source owner and
- * fee payer for any created associated token account. Shared by the direct
- * transfer path (authority = wallet) and the Squads propose path (authority =
- * vault).
- */
-async function buildTransferInstructions({
-  connection,
-  authority,
-  destination,
-  mint,
-  rawAmount,
-  isSol,
-}: {
-  connection: Connection;
-  authority: PublicKey;
-  destination: PublicKey;
-  mint: string;
-  rawAmount: bigint;
-  isSol: boolean;
-}): Promise<{ instructions: TransactionInstruction[]; needsAta: boolean }> {
-  if (isSol) {
-    return {
-      instructions: [
-        SystemProgram.transfer({
-          fromPubkey: authority,
-          toPubkey: destination,
-          lamports: rawAmount,
-        }),
-      ],
-      needsAta: false,
-    };
-  }
-
-  const mintKey = new PublicKey(mint);
-  const senderAta = getAssociatedTokenAddressSync(mintKey, authority, true);
-  const destAta = getAssociatedTokenAddressSync(mintKey, destination, true);
-  const [destAtaInfo, decimals] = await Promise.all([
-    connection.getAccountInfo(destAta),
-    getTokenDecimals(mint),
-  ]);
-  const needsAta = !destAtaInfo;
-
-  return {
-    instructions: [
-      createAssociatedTokenAccountIdempotentInstruction(
-        authority,
-        destAta,
-        destination,
-        mintKey
-      ),
-      createTransferCheckedInstruction(
-        senderAta,
-        mintKey,
-        destAta,
-        authority,
-        rawAmount,
-        decimals
-      ),
-    ],
-    needsAta,
-  };
-}
 
 export const transfer = publicProcedure.tokens.transfer.handler(
   async ({ input, errors }) => {
     const { walletAddress, destination, tokenAmount } = input;
 
-    const feePayer = new PublicKey(walletAddress);
+    // A Squads action is built from the vault, and the proposing member already
+    // pays the outer transaction's fee — both roles a fee payer could fill are
+    // taken, so naming one can only mean the caller expects something else.
+    if (input.feePayer && input.multisig) {
+      throw errors.BAD_REQUEST({
+        message: "feePayer is not supported with multisig",
+      });
+    }
+
+    const authority = new PublicKey(walletAddress);
+    const payer = input.feePayer ? new PublicKey(input.feePayer) : authority;
     const destKey = new PublicKey(destination);
     const connection = new Connection(process.env.SOLANA_RPC_URL!);
 
@@ -137,13 +73,14 @@ export const transfer = publicProcedure.tokens.transfer.handler(
         await buildActionProposal({
           connection,
           multisigPda,
-          member: feePayer,
+          member: authority,
           memo: input.memo,
           buildInstructions: async (vault) =>
             (
               await buildTransferInstructions({
                 connection,
                 authority: vault,
+                payer: vault,
                 destination: destKey,
                 mint: tokenAmount.mint,
                 rawAmount,
@@ -187,7 +124,8 @@ export const transfer = publicProcedure.tokens.transfer.handler(
     // ---- Direct transfer from the wallet ----
     const { instructions, needsAta } = await buildTransferInstructions({
       connection,
-      authority: feePayer,
+      authority,
+      payer,
       destination: destKey,
       mint: tokenAmount.mint,
       rawAmount,
@@ -196,7 +134,7 @@ export const transfer = publicProcedure.tokens.transfer.handler(
 
     const tx = await buildVersionedTransaction({
       connection,
-      draft: { instructions, feePayer, addressLookupTableAddresses: [] },
+      draft: { instructions, feePayer: payer, addressLookupTableAddresses: [] },
     });
 
     const tag = generateTransactionTag({
@@ -205,25 +143,31 @@ export const transfer = publicProcedure.tokens.transfer.handler(
       destination,
       mint: tokenAmount.mint,
       amount: tokenAmount.amount,
+      feePayer: input.feePayer,
     });
 
     // For SOL transfers, no rent. For SPL, ATA rent if needed
     const rentCost = needsAta ? RENT_COSTS.ATA : 0;
-    const [txFee, walletBalance] = await Promise.all([
+    // A native SOL transfer's lamports leave the authority, so its balance is
+    // its own check whenever a separate account pays the fee.
+    const authorityPaysTransfer = isSol && !payer.equals(authority);
+    const [txFee, payerBalance, authorityBalance] = await Promise.all([
       getTransactionFee(connection, tx),
-      connection.getBalance(feePayer),
+      connection.getBalance(payer),
+      authorityPaysTransfer ? connection.getBalance(authority) : null,
     ]);
     const estimatedSolFeeLamports = calculateRequiredBalance(txFee, rentCost);
 
-    const totalCost = isSol
-      ? Number(rawAmount) + estimatedSolFeeLamports
-      : estimatedSolFeeLamports;
-    if (walletBalance < totalCost) {
+    const shortfall = transferSolShortfall({
+      payerBalance,
+      payerLamports: estimatedSolFeeLamports,
+      transferLamports: isSol ? Number(rawAmount) : 0,
+      authorityBalance,
+    });
+    if (shortfall) {
       throw errors.INSUFFICIENT_FUNDS({
-        message: isSol
-          ? "Insufficient SOL balance for transfer and transaction fees"
-          : "Insufficient SOL balance for transaction fees",
-        data: { required: totalCost, available: walletBalance },
+        message: shortfall.message,
+        data: { required: shortfall.required, available: shortfall.available },
       });
     }
 

--- a/packages/blockchain-api/src/server/api/routers/transactions/procedures/submit.ts
+++ b/packages/blockchain-api/src/server/api/routers/transactions/procedures/submit.ts
@@ -13,6 +13,7 @@ import {
   shouldUseJitoBundle,
 } from "@/lib/utils/jito";
 import { predictSubmissionType } from "@/lib/utils/submission-helpers";
+import { verifiedFeePayer } from "@/lib/utils/transaction-payer";
 import { v4 as uuidv4 } from "uuid";
 import {
   JitoMissingTipError,
@@ -193,16 +194,26 @@ export const submit = publicProcedure.transactions.submit.handler(
       });
     }
 
-    // Extract payer from the first transaction
-    let payer: string;
+    // Attribute the batch to the first transaction's fee payer. The payer is
+    // recorded as history and is read back as the account that acted, so it is
+    // taken from the signature rather than from the account list: submission
+    // skips preflight, so an unsigned transaction would otherwise be persisted
+    // under whatever account it names.
+    let firstTransaction: VersionedTransaction;
     try {
-      const firstTransaction = VersionedTransaction.deserialize(
+      firstTransaction = VersionedTransaction.deserialize(
         Buffer.from(transactions[0].serializedTransaction, "base64"),
       );
-      payer = firstTransaction.message.staticAccountKeys[0].toBase58();
     } catch {
       throw errors.BAD_REQUEST({
         message: "Failed to decode transaction to extract payer",
+      });
+    }
+
+    const payer = verifiedFeePayer(firstTransaction);
+    if (!payer) {
+      throw errors.BAD_REQUEST({
+        message: "Transaction is not signed by its fee payer",
       });
     }
 

--- a/packages/blockchain-api/src/server/api/routers/welcomePacks/procedures/claim.ts
+++ b/packages/blockchain-api/src/server/api/routers/welcomePacks/procedures/claim.ts
@@ -6,6 +6,10 @@ import {
   serializeTransaction,
 } from "@/lib/utils/build-transaction";
 import {
+  CLAIM_APPROVAL_MESSAGES,
+  verifyClaimApproval,
+} from "@/lib/utils/claim-approval";
+import {
   generateTransactionTag,
   TRANSACTION_TYPES,
 } from "@/lib/utils/transaction-tags";
@@ -34,25 +38,36 @@ export const claim = publicProcedure.welcomePacks.claim.handler(
       });
     }
 
-    // Verify expiration
-    const currentTs = Math.floor(Date.now() / 1000);
-    if (currentTs > parseInt(expirationTs)) {
-      throw errors.EXPIRED({ message: "Invite has expired" });
-    }
+    const expiration = parseInt(expirationTs);
 
-    const signatureBytes = Buffer.from(signature, "base64");
-
-    const feePayerWallet = loadKeypair(process.env.FEE_PAYER_WALLET_PATH!);
-
-    // Initialize connection and programs
-    const { provider } = createSolanaConnection(
-      feePayerWallet.publicKey.toString()
-    );
+    // Reading the pack only reads accounts, so it runs under the claimer's
+    // address. The fee payer's key is loaded further down, once the approval it
+    // would be spent on has been verified.
+    const { provider } = createSolanaConnection(walletAddress);
     const program = await init(provider);
-    const tuktukProgram = await initTuktuk(provider);
     const welcomePack = await program.account.welcomePackV0.fetch(
       new PublicKey(packAddress)
     );
+
+    const approval = verifyClaimApproval({
+      uniqueId: welcomePack.uniqueId,
+      expirationTs: expiration,
+      owner: welcomePack.owner.toBytes(),
+      signatureBase64: signature,
+      now: Math.floor(Date.now() / 1000),
+    });
+    if (!approval.ok) {
+      if (approval.reason === "expired") {
+        throw errors.EXPIRED({ message: CLAIM_APPROVAL_MESSAGES.expired });
+      }
+      throw errors.BAD_REQUEST({
+        message: CLAIM_APPROVAL_MESSAGES[approval.reason],
+      });
+    }
+    const signatureBytes = approval.signature;
+
+    const feePayerWallet = loadKeypair(process.env.FEE_PAYER_WALLET_PATH!);
+    const tuktukProgram = await initTuktuk(provider);
 
     // Prepare claim transaction
     const {
@@ -67,7 +82,7 @@ export const claim = publicProcedure.welcomePacks.claim.handler(
         welcomePack: new PublicKey(packAddress),
         claimApproval: {
           uniqueId: welcomePack.uniqueId,
-          expirationTimestamp: new BN(parseInt(expirationTs)),
+          expirationTimestamp: new BN(expiration),
         },
         claimApprovalSignature: signatureBytes,
         payer: feePayerWallet.publicKey,

--- a/packages/blockchain-api/src/server/api/routers/welcomePacks/procedures/claim.ts
+++ b/packages/blockchain-api/src/server/api/routers/welcomePacks/procedures/claim.ts
@@ -6,8 +6,10 @@ import {
   serializeTransaction,
 } from "@/lib/utils/build-transaction";
 import {
+  checkApprovalWindow,
   CLAIM_APPROVAL_MESSAGES,
   verifyClaimApproval,
+  type ClaimApprovalRejection,
 } from "@/lib/utils/claim-approval";
 import {
   generateTransactionTag,
@@ -39,6 +41,24 @@ export const claim = publicProcedure.welcomePacks.claim.handler(
     }
 
     const expiration = parseInt(expirationTs);
+    const now = Math.floor(Date.now() / 1000);
+
+    // An expired approval is its own status here, so both points an approval
+    // can be refused from map the reason the same way.
+    const rejectApproval = (reason: ClaimApprovalRejection) =>
+      reason === "expired"
+        ? errors.EXPIRED({ message: CLAIM_APPROVAL_MESSAGES.expired })
+        : errors.BAD_REQUEST({ message: CLAIM_APPROVAL_MESSAGES[reason] });
+
+    // An expiry the program would not accept is refused on its own, before the
+    // pack is read.
+    const windowRejection = checkApprovalWindow({
+      expirationTs: expiration,
+      now,
+    });
+    if (windowRejection) {
+      throw rejectApproval(windowRejection);
+    }
 
     // Reading the pack only reads accounts, so it runs under the claimer's
     // address. The fee payer's key is loaded further down, once the approval it
@@ -46,7 +66,7 @@ export const claim = publicProcedure.welcomePacks.claim.handler(
     const { provider } = createSolanaConnection(walletAddress);
     const program = await init(provider);
     const welcomePack = await program.account.welcomePackV0.fetch(
-      new PublicKey(packAddress)
+      new PublicKey(packAddress),
     );
 
     const approval = verifyClaimApproval({
@@ -54,15 +74,10 @@ export const claim = publicProcedure.welcomePacks.claim.handler(
       expirationTs: expiration,
       owner: welcomePack.owner.toBytes(),
       signatureBase64: signature,
-      now: Math.floor(Date.now() / 1000),
+      now,
     });
     if (!approval.ok) {
-      if (approval.reason === "expired") {
-        throw errors.EXPIRED({ message: CLAIM_APPROVAL_MESSAGES.expired });
-      }
-      throw errors.BAD_REQUEST({
-        message: CLAIM_APPROVAL_MESSAGES[approval.reason],
-      });
+      throw rejectApproval(approval.reason);
     }
     const signatureBytes = approval.signature;
 
@@ -89,12 +104,12 @@ export const claim = publicProcedure.welcomePacks.claim.handler(
         getAssetFn: (_, assetId) =>
           getAsset(
             env.ASSET_ENDPOINT || program.provider.connection.rpcEndpoint,
-            assetId
+            assetId,
           ),
         getAssetProofFn: (_, assetId) =>
           getAssetProof(
             env.ASSET_ENDPOINT || program.provider.connection.rpcEndpoint,
-            assetId
+            assetId,
           ),
       })
     ).prepare();
@@ -109,10 +124,10 @@ export const claim = publicProcedure.welcomePacks.claim.handler(
             getAssociatedTokenAddressSync(
               rewardsMint!,
               new PublicKey(walletAddress),
-              true
+              true,
             ),
             new PublicKey(walletAddress),
-            rewardsMint!
+            rewardsMint!,
           ),
         ],
         feePayer: feePayerWallet.publicKey,
@@ -148,8 +163,8 @@ export const claim = publicProcedure.welcomePacks.claim.handler(
       },
       estimatedSolFee: await toTokenAmountOutput(
         new BN(0),
-        NATIVE_MINT.toBase58()
+        NATIVE_MINT.toBase58(),
       ),
     };
-  }
+  },
 );

--- a/packages/blockchain-api/tests/e2e/hotspot-updates.test.ts
+++ b/packages/blockchain-api/tests/e2e/hotspot-updates.test.ts
@@ -1,4 +1,9 @@
-import { Keypair, PublicKey } from "@solana/web3.js";
+import {
+  Keypair,
+  PublicKey,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { expect } from "chai";
 import { after, before, describe, it } from "mocha";
 import { isDefinedError } from "@orpc/client";
@@ -139,6 +144,62 @@ describe("hotspot-updates", () => {
         data?.transactionData?.transactions?.[0]?.serializedTransaction
       ).to.be.a("string");
       expect(data?.appliedTo?.mobile).to.equal(true);
+
+      // #then tx submits successfully
+      await signAndSubmitTransactionData(
+        ctx.connection,
+        data.transactionData,
+        ctx.payer
+      );
+    });
+
+    it("builds an owner-paid update when feePayer is owner", async () => {
+      // #given a Mobile hotspot the wallet owns
+      const entityPubKey = TEST_HOTSPOT_ENTITY_KEY;
+      const walletAddress = ctx.payer.publicKey.toBase58();
+
+      // #when asking for the update with the owner as fee payer
+      const { data, error } = await ctx.safeClient.hotspots.updateHotspotInfo({
+        deviceType: "mobile",
+        walletAddress,
+        entityPubKey,
+        feePayer: "owner",
+        deploymentInfo: {
+          type: "WIFI",
+          antenna: 2,
+          elevation: 11,
+          azimuth: 190,
+          mechanicalDownTilt: 6,
+          electricalDownTilt: 4,
+        },
+      });
+
+      if (error) {
+        expect.fail(`Unexpected error: ${JSON.stringify(error)}`);
+      }
+      expect(data?.appliedTo?.mobile).to.equal(true);
+
+      // #then the wallet is the sole signer and fee payer, and the DC would
+      // come out of its own DC account - no maker co-signature is involved.
+      const tx = VersionedTransaction.deserialize(
+        Buffer.from(
+          data.transactionData.transactions[0].serializedTransaction,
+          "base64"
+        )
+      );
+      expect(tx.message.header.numRequiredSignatures).to.equal(1);
+      expect(tx.message.staticAccountKeys[0].toBase58()).to.equal(
+        walletAddress
+      );
+      expect(
+        tx.message.staticAccountKeys.map((key) => key.toBase58())
+      ).to.include(
+        getAssociatedTokenAddressSync(
+          new PublicKey(TOKEN_MINTS.DC),
+          ctx.payer.publicKey,
+          true
+        ).toBase58()
+      );
 
       // #then tx submits successfully
       await signAndSubmitTransactionData(

--- a/packages/blockchain-api/tests/unit/asset-ownership.test.ts
+++ b/packages/blockchain-api/tests/unit/asset-ownership.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from "mocha";
 import {
   assertAssetOwner,
   assetOwnerAddress,
+  fetchOwnedAsset,
 } from "../../src/lib/utils/asset-ownership";
 
 const OWNER = new PublicKey("GZairnxHiWXk73YhsEtkGU2XnfGw3QcUsjJr8VW2R172");
@@ -16,8 +17,13 @@ const assetOwnedBy = (owner: PublicKey | string) =>
 
 /** The error builder the endpoints pass in, tagged so a test can recognise it. */
 class Unauthorized extends Error {}
+class NotFound extends Error {}
 const errors = {
   UNAUTHORIZED: ({ message }: { message: string }) => new Unauthorized(message),
+};
+const ownedErrors = {
+  ...errors,
+  NOT_FOUND: ({ message }: { message: string }) => new NotFound(message),
 };
 
 describe("assetOwnerAddress", () => {
@@ -27,7 +33,7 @@ describe("assetOwnerAddress", () => {
 
   it("reads an owner the asset endpoint left as a string", () => {
     expect(assetOwnerAddress(assetOwnedBy(OWNER.toBase58()))).to.equal(
-      OWNER.toBase58()
+      OWNER.toBase58(),
     );
   });
 });
@@ -40,7 +46,7 @@ describe("assertAssetOwner", () => {
         expectedOwner: OWNER.toBase58(),
         message: "Wallet does not own this hotspot",
         errors,
-      })
+      }),
     ).to.equal(OWNER.toBase58());
   });
 
@@ -51,7 +57,7 @@ describe("assertAssetOwner", () => {
         expectedOwner: INTRUDER.toBase58(),
         message: "Wallet does not own this hotspot",
         errors,
-      })
+      }),
     ).to.throw(Unauthorized, "Wallet does not own this hotspot");
   });
 
@@ -62,7 +68,7 @@ describe("assertAssetOwner", () => {
         expectedOwner: INTRUDER.toBase58(),
         message: "Multisig vault is not the owner of this hotspot",
         errors,
-      })
+      }),
     ).to.throw(Unauthorized, "Multisig vault is not the owner of this hotspot");
   });
 
@@ -73,7 +79,7 @@ describe("assertAssetOwner", () => {
         expectedOwner: OWNER.toBase58().slice(0, -1),
         message: "Wallet does not own this hotspot",
         errors,
-      })
+      }),
     ).to.throw(Unauthorized);
   });
 
@@ -84,7 +90,59 @@ describe("assertAssetOwner", () => {
         expectedOwner: INTRUDER.toBase58(),
         message: "Wallet does not own this hotspot",
         errors,
-      })
+      }),
     ).to.throw(Unauthorized);
+  });
+});
+
+describe("fetchOwnedAsset", () => {
+  const found = (asset: Asset) => async (_url: string, _assetId: PublicKey) =>
+    asset;
+  const missing = async (_url: string, _assetId: PublicKey) => undefined;
+
+  it("hands back the asset it fetched when the caller owns it", async () => {
+    const asset = assetOwnedBy(OWNER);
+    expect(
+      await fetchOwnedAsset({
+        assetEndpoint: "https://asset.endpoint",
+        assetId: OWNER,
+        expectedOwner: OWNER.toBase58(),
+        message: "Wallet does not own this hotspot",
+        errors: ownedErrors,
+        getAssetFn: found(asset),
+      }),
+    ).to.equal(asset);
+  });
+
+  it("refuses an asset the endpoint does not know", async () => {
+    try {
+      await fetchOwnedAsset({
+        assetEndpoint: "https://asset.endpoint",
+        assetId: OWNER,
+        expectedOwner: OWNER.toBase58(),
+        message: "Wallet does not own this hotspot",
+        errors: ownedErrors,
+        getAssetFn: missing,
+      });
+      expect.fail("did not throw");
+    } catch (e) {
+      expect(e).to.be.instanceOf(NotFound);
+    }
+  });
+
+  it("refuses a caller that is not the owner", async () => {
+    try {
+      await fetchOwnedAsset({
+        assetEndpoint: "https://asset.endpoint",
+        assetId: OWNER,
+        expectedOwner: INTRUDER.toBase58(),
+        message: "Wallet does not own this hotspot",
+        errors: ownedErrors,
+        getAssetFn: found(assetOwnedBy(OWNER)),
+      });
+      expect.fail("did not throw");
+    } catch (e) {
+      expect(e).to.be.instanceOf(Unauthorized);
+    }
   });
 });

--- a/packages/blockchain-api/tests/unit/asset-ownership.test.ts
+++ b/packages/blockchain-api/tests/unit/asset-ownership.test.ts
@@ -1,0 +1,90 @@
+import type { Asset } from "@helium/spl-utils";
+import { PublicKey } from "@solana/web3.js";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import {
+  assertAssetOwner,
+  assetOwnerAddress,
+} from "../../src/lib/utils/asset-ownership";
+
+const OWNER = new PublicKey("GZairnxHiWXk73YhsEtkGU2XnfGw3QcUsjJr8VW2R172");
+const INTRUDER = new PublicKey("ATGQKkmNat3N8ZXM2ChEKMNAQ45isPPfUpBrAnvX9J8R");
+
+/** The one field of a cNFT an ownership check reads. */
+const assetOwnedBy = (owner: PublicKey | string) =>
+  ({ ownership: { owner } }) as unknown as Asset;
+
+/** The error builder the endpoints pass in, tagged so a test can recognise it. */
+class Unauthorized extends Error {}
+const errors = {
+  UNAUTHORIZED: ({ message }: { message: string }) => new Unauthorized(message),
+};
+
+describe("assetOwnerAddress", () => {
+  it("reads an owner the asset endpoint already decoded", () => {
+    expect(assetOwnerAddress(assetOwnedBy(OWNER))).to.equal(OWNER.toBase58());
+  });
+
+  it("reads an owner the asset endpoint left as a string", () => {
+    expect(assetOwnerAddress(assetOwnedBy(OWNER.toBase58()))).to.equal(
+      OWNER.toBase58()
+    );
+  });
+});
+
+describe("assertAssetOwner", () => {
+  it("returns the owner it checked when the caller is that owner", () => {
+    expect(
+      assertAssetOwner({
+        asset: assetOwnedBy(OWNER),
+        expectedOwner: OWNER.toBase58(),
+        message: "Wallet does not own this hotspot",
+        errors,
+      })
+    ).to.equal(OWNER.toBase58());
+  });
+
+  it("refuses a caller that is not the owner", () => {
+    expect(() =>
+      assertAssetOwner({
+        asset: assetOwnedBy(OWNER),
+        expectedOwner: INTRUDER.toBase58(),
+        message: "Wallet does not own this hotspot",
+        errors,
+      })
+    ).to.throw(Unauthorized, "Wallet does not own this hotspot");
+  });
+
+  it("raises the endpoint's own wording", () => {
+    expect(() =>
+      assertAssetOwner({
+        asset: assetOwnedBy(OWNER),
+        expectedOwner: INTRUDER.toBase58(),
+        message: "Multisig vault is not the owner of this hotspot",
+        errors,
+      })
+    ).to.throw(Unauthorized, "Multisig vault is not the owner of this hotspot");
+  });
+
+  it("compares the whole address, not a prefix of it", () => {
+    expect(() =>
+      assertAssetOwner({
+        asset: assetOwnedBy(OWNER),
+        expectedOwner: OWNER.toBase58().slice(0, -1),
+        message: "Wallet does not own this hotspot",
+        errors,
+      })
+    ).to.throw(Unauthorized);
+  });
+
+  it("refuses a caller that is not the owner of a string-owned asset", () => {
+    expect(() =>
+      assertAssetOwner({
+        asset: assetOwnedBy(OWNER.toBase58()),
+        expectedOwner: INTRUDER.toBase58(),
+        message: "Wallet does not own this hotspot",
+        errors,
+      })
+    ).to.throw(Unauthorized);
+  });
+});

--- a/packages/blockchain-api/tests/unit/claim-approval.test.ts
+++ b/packages/blockchain-api/tests/unit/claim-approval.test.ts
@@ -2,6 +2,7 @@ import { PublicKey } from "@solana/web3.js";
 import { expect } from "chai";
 import { describe, it } from "mocha";
 import {
+  checkApprovalWindow,
   claimApprovalMessage,
   MAX_CLAIM_APPROVAL_SECONDS,
   verifyClaimApproval,
@@ -31,7 +32,7 @@ const SIGNATURE_BY_OTHER =
   "izvZY+3vc4EoavJ9ryybYEVW/KIb8ZxBjwbQjcSC5eYyALUW8S+lNCczg7RQda/CBPACEK3SABgw4DOmlLGNBA==";
 
 function check(
-  overrides: Partial<Parameters<typeof verifyClaimApproval>[0]> = {}
+  overrides: Partial<Parameters<typeof verifyClaimApproval>[0]> = {},
 ) {
   return verifyClaimApproval({
     uniqueId: UNIQUE_ID,
@@ -46,7 +47,7 @@ function check(
 describe("claimApprovalMessage", () => {
   it("spells the message the welcome-pack program rebuilds", () => {
     expect(claimApprovalMessage(UNIQUE_ID, EXPIRATION_TS)).to.equal(
-      "Approve invite 7 expiring 1800000000"
+      "Approve invite 7 expiring 1800000000",
     );
   });
 });
@@ -93,7 +94,7 @@ describe("verifyClaimApproval", () => {
     const tampered = Buffer.from(SIGNATURE, "base64");
     tampered[0] ^= 1;
     expect(
-      check({ signatureBase64: tampered.toString("base64") })
+      check({ signatureBase64: tampered.toString("base64") }),
     ).to.deep.equal({ ok: false, reason: "invalid_signature" });
   });
 
@@ -151,7 +152,68 @@ describe("verifyClaimApproval", () => {
     // signature says, so a caller cannot learn signature outcomes by sending
     // approvals the program would never accept.
     expect(
-      check({ now: EXPIRATION_TS + 1, signatureBase64: "" })
+      check({ now: EXPIRATION_TS + 1, signatureBase64: "" }),
     ).to.deep.equal({ ok: false, reason: "expired" });
+  });
+});
+
+describe("checkApprovalWindow", () => {
+  it("passes an expiry inside the window", () => {
+    expect(checkApprovalWindow({ expirationTs: EXPIRATION_TS, now: NOW })).to.be
+      .null;
+  });
+
+  it("refuses an expiry that is not a number", () => {
+    expect(checkApprovalWindow({ expirationTs: NaN, now: NOW })).to.equal(
+      "malformed_expiration",
+    );
+  });
+
+  it("refuses an expiry that has passed, and one expiring exactly now", () => {
+    expect(
+      checkApprovalWindow({
+        expirationTs: EXPIRATION_TS,
+        now: EXPIRATION_TS + 1,
+      }),
+    ).to.equal("expired");
+    expect(
+      checkApprovalWindow({ expirationTs: EXPIRATION_TS, now: EXPIRATION_TS }),
+    ).to.equal("expired");
+  });
+
+  it("refuses an expiry reaching past the program's window, at one second over", () => {
+    expect(
+      checkApprovalWindow({
+        expirationTs: NOW + MAX_CLAIM_APPROVAL_SECONDS + 1,
+        now: NOW,
+      }),
+    ).to.equal("window_too_long");
+    expect(
+      checkApprovalWindow({
+        expirationTs: NOW + MAX_CLAIM_APPROVAL_SECONDS,
+        now: NOW,
+      }),
+      "the bound itself is allowed",
+    ).to.be.null;
+  });
+
+  it("decides the same window rejections verifyClaimApproval reports", () => {
+    // One rule, so an endpoint checking the window early cannot answer
+    // differently from the full approval check that follows it.
+    const cases = [
+      { expirationTs: NaN, reason: "malformed_expiration" },
+      { expirationTs: NOW - 1, reason: "expired" },
+      {
+        expirationTs: NOW + MAX_CLAIM_APPROVAL_SECONDS + 1,
+        reason: "window_too_long",
+      },
+    ];
+    for (const { expirationTs, reason } of cases) {
+      expect(checkApprovalWindow({ expirationTs, now: NOW })).to.equal(reason);
+      expect(check({ expirationTs, now: NOW })).to.deep.equal({
+        ok: false,
+        reason,
+      });
+    }
   });
 });

--- a/packages/blockchain-api/tests/unit/claim-approval.test.ts
+++ b/packages/blockchain-api/tests/unit/claim-approval.test.ts
@@ -1,0 +1,157 @@
+import { PublicKey } from "@solana/web3.js";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import {
+  claimApprovalMessage,
+  MAX_CLAIM_APPROVAL_SECONDS,
+  verifyClaimApproval,
+} from "../../src/lib/utils/claim-approval";
+
+const UNIQUE_ID = 7;
+const EXPIRATION_TS = 1800000000;
+const NOW = EXPIRATION_TS - 60;
+
+/** The welcome pack's owner, the only key the program accepts an approval from. */
+const OWNER = new PublicKey("GmaDrppBC7P5ARKV8g3djiwP89vz1jLK23V2GBjuAEGB");
+
+/** A wallet that is not the pack's owner, whose signature must not be accepted. */
+const OTHER = new PublicKey("J2xccRtuG43drESLYznHhLhQkLTdfepcKYbiQ9BsJVaf");
+
+/**
+ * `OWNER`'s Ed25519 signature over `Approve invite 7 expiring 1800000000`, in
+ * the form the welcome-pack SDK's `claimApprovalSignature` produces and a
+ * client sends. A fixed signature rather than one made during the test, so a
+ * pass means this service reads what the signing side writes.
+ */
+const SIGNATURE =
+  "h7qqS/IALDNvOQC3Acphs6HIUd8e5YHJWvdBLBUIbLSiAgpoWvBBA8MUzjuM5vFNzk7VZ8TQvkBaz4ETKshDDw==";
+
+/** `OTHER`'s signature over the same message. Well formed, wrong signer. */
+const SIGNATURE_BY_OTHER =
+  "izvZY+3vc4EoavJ9ryybYEVW/KIb8ZxBjwbQjcSC5eYyALUW8S+lNCczg7RQda/CBPACEK3SABgw4DOmlLGNBA==";
+
+function check(
+  overrides: Partial<Parameters<typeof verifyClaimApproval>[0]> = {}
+) {
+  return verifyClaimApproval({
+    uniqueId: UNIQUE_ID,
+    expirationTs: EXPIRATION_TS,
+    owner: OWNER.toBytes(),
+    signatureBase64: SIGNATURE,
+    now: NOW,
+    ...overrides,
+  });
+}
+
+describe("claimApprovalMessage", () => {
+  it("spells the message the welcome-pack program rebuilds", () => {
+    expect(claimApprovalMessage(UNIQUE_ID, EXPIRATION_TS)).to.equal(
+      "Approve invite 7 expiring 1800000000"
+    );
+  });
+});
+
+describe("verifyClaimApproval", () => {
+  it("accepts the pack owner's signature and returns the bytes it verified", () => {
+    const result = check();
+    expect(result.ok).to.equal(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.signature.toString("base64")).to.equal(SIGNATURE);
+    expect(result.signature.length).to.equal(64);
+  });
+
+  it("refuses a signature by a wallet that is not the pack owner", () => {
+    expect(check({ signatureBase64: SIGNATURE_BY_OTHER })).to.deep.equal({
+      ok: false,
+      reason: "invalid_signature",
+    });
+  });
+
+  it("refuses the owner's signature checked against another key", () => {
+    expect(check({ owner: OTHER.toBytes() })).to.deep.equal({
+      ok: false,
+      reason: "invalid_signature",
+    });
+  });
+
+  it("refuses a signature over a different unique id", () => {
+    expect(check({ uniqueId: UNIQUE_ID + 1 })).to.deep.equal({
+      ok: false,
+      reason: "invalid_signature",
+    });
+  });
+
+  it("refuses a signature over a different expiry", () => {
+    // Inside the window, so only the message it was signed over differs.
+    expect(check({ expirationTs: EXPIRATION_TS - 1 })).to.deep.equal({
+      ok: false,
+      reason: "invalid_signature",
+    });
+  });
+
+  it("refuses a tampered signature", () => {
+    const tampered = Buffer.from(SIGNATURE, "base64");
+    tampered[0] ^= 1;
+    expect(
+      check({ signatureBase64: tampered.toString("base64") })
+    ).to.deep.equal({ ok: false, reason: "invalid_signature" });
+  });
+
+  it("refuses a signature that is not 64 bytes, rather than throwing", () => {
+    const short = Buffer.from(SIGNATURE, "base64").subarray(0, 32);
+    expect(check({ signatureBase64: short.toString("base64") })).to.deep.equal({
+      ok: false,
+      reason: "malformed_signature",
+    });
+    expect(check({ signatureBase64: "" })).to.deep.equal({
+      ok: false,
+      reason: "malformed_signature",
+    });
+    expect(check({ signatureBase64: "not base64 at all!!" })).to.deep.equal({
+      ok: false,
+      reason: "malformed_signature",
+    });
+  });
+
+  it("refuses an expiry that is not a number", () => {
+    expect(check({ expirationTs: NaN })).to.deep.equal({
+      ok: false,
+      reason: "malformed_expiration",
+    });
+  });
+
+  it("refuses an approval whose expiry has passed, and one expiring exactly now", () => {
+    expect(check({ now: EXPIRATION_TS + 1 })).to.deep.equal({
+      ok: false,
+      reason: "expired",
+    });
+    // The program requires the expiry to be strictly ahead of the clock.
+    expect(check({ now: EXPIRATION_TS })).to.deep.equal({
+      ok: false,
+      reason: "expired",
+    });
+  });
+
+  it("refuses an approval reaching further ahead than the program's window", () => {
+    const now = EXPIRATION_TS - MAX_CLAIM_APPROVAL_SECONDS;
+    // The whole window is still claimable.
+    expect(check({ now }).ok).to.equal(true);
+    expect(check({ now: now - 1 })).to.deep.equal({
+      ok: false,
+      reason: "window_too_long",
+    });
+  });
+
+  it("bounds the window at the 30 days the program allows", () => {
+    expect(MAX_CLAIM_APPROVAL_SECONDS).to.equal(30 * 24 * 60 * 60);
+  });
+
+  it("checks the window before it checks the signature", () => {
+    // An approval outside the window is refused for the window, whatever the
+    // signature says, so a caller cannot learn signature outcomes by sending
+    // approvals the program would never accept.
+    expect(
+      check({ now: EXPIRATION_TS + 1, signatureBase64: "" })
+    ).to.deep.equal({ ok: false, reason: "expired" });
+  });
+});

--- a/packages/blockchain-api/tests/unit/ed25519.test.ts
+++ b/packages/blockchain-api/tests/unit/ed25519.test.ts
@@ -1,0 +1,80 @@
+import { PublicKey } from "@solana/web3.js";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import {
+  ED25519_SIGNATURE_BYTES,
+  verifyEd25519,
+} from "../../src/lib/utils/ed25519";
+
+/** A Solana wallet and its signature over `MESSAGE`, produced by tweetnacl. */
+const SIGNER = new PublicKey("GmaDrppBC7P5ARKV8g3djiwP89vz1jLK23V2GBjuAEGB");
+const MESSAGE = Buffer.from("Approve invite 7 expiring 1800000000");
+const SIGNATURE = Buffer.from(
+  "h7qqS/IALDNvOQC3Acphs6HIUd8e5YHJWvdBLBUIbLSiAgpoWvBBA8MUzjuM5vFNzk7VZ8TQvkBaz4ETKshDDw==",
+  "base64"
+);
+
+describe("verifyEd25519", () => {
+  it("accepts a signature a Solana signer made over the message", () => {
+    expect(verifyEd25519(MESSAGE, SIGNATURE, SIGNER.toBytes())).to.equal(true);
+  });
+
+  it("refuses the signature over any other message", () => {
+    expect(
+      verifyEd25519(
+        Buffer.from("Approve invite 7 expiring 1800000001"),
+        SIGNATURE,
+        SIGNER.toBytes()
+      )
+    ).to.equal(false);
+    expect(verifyEd25519(Buffer.alloc(0), SIGNATURE, SIGNER.toBytes())).to.equal(
+      false
+    );
+  });
+
+  it("refuses a signature with any bit flipped", () => {
+    for (const index of [0, 31, 32, 63]) {
+      const tampered = Buffer.from(SIGNATURE);
+      tampered[index] ^= 1;
+      expect(
+        verifyEd25519(MESSAGE, tampered, SIGNER.toBytes()),
+        `byte ${index}`
+      ).to.equal(false);
+    }
+  });
+
+  it("refuses a signature under any other key", () => {
+    const other = new PublicKey("J2xccRtuG43drESLYznHhLhQkLTdfepcKYbiQ9BsJVaf");
+    expect(verifyEd25519(MESSAGE, SIGNATURE, other.toBytes())).to.equal(false);
+  });
+
+  it("answers false for a wrong-length signature rather than throwing", () => {
+    for (const length of [0, 32, 63, 65]) {
+      expect(
+        verifyEd25519(MESSAGE, Buffer.alloc(length), SIGNER.toBytes()),
+        `length ${length}`
+      ).to.equal(false);
+    }
+  });
+
+  it("answers false for a wrong-length key rather than throwing", () => {
+    for (const length of [0, 31, 33, 64]) {
+      expect(
+        verifyEd25519(MESSAGE, SIGNATURE, Buffer.alloc(length)),
+        `length ${length}`
+      ).to.equal(false);
+    }
+  });
+
+  it("answers false for a key that is not a point on the curve", () => {
+    // Every byte set is not a valid Ed25519 point encoding; the platform
+    // verifier rejects the key itself, which has to surface as a refusal.
+    expect(
+      verifyEd25519(MESSAGE, SIGNATURE, Buffer.alloc(32, 0xff))
+    ).to.equal(false);
+  });
+
+  it("states the signature size its callers check against", () => {
+    expect(ED25519_SIGNATURE_BYTES).to.equal(64);
+  });
+});

--- a/packages/blockchain-api/tests/unit/guarded-endpoints.test.ts
+++ b/packages/blockchain-api/tests/unit/guarded-endpoints.test.ts
@@ -63,22 +63,60 @@ describe("server code that calls a guard", () => {
       const loaded = callIndex(source, "loadKeypair");
 
       expect(verified, "verifyClaimApproval is not called").to.be.greaterThan(
-        -1
+        -1,
       );
       expect(loaded, "loadKeypair is not called").to.be.greaterThan(-1);
       expect(
         verified,
-        "the fee payer's key is loaded before the approval is verified"
+        "the fee payer's key is loaded before the approval is verified",
       ).to.be.lessThan(loaded);
     });
   }
+
+  for (const file of CLAIM_APPROVAL_GUARDED) {
+    it(`${file} refuses on the approval window before it reads anything`, () => {
+      const source = code(file);
+      const bound = source.match(
+        /const\s+(\w+)\s*=\s*checkApprovalWindow\s*\(/,
+      );
+      expect(bound, "checkApprovalWindow's result is not bound").to.not.be.null;
+
+      // A window that is checked and then discarded reads as a guarded
+      // endpoint and refuses nothing.
+      expect(
+        source,
+        "the window result is computed and not thrown on",
+      ).to.match(
+        new RegExp(`if\\s*\\(\\s*${bound![1]}\\s*\\)\\s*\\{\\s*throw\\b`),
+      );
+
+      const checked = source.search(/\bcheckApprovalWindow\s*\(/);
+      const firstAwait = source.search(/\bawait\b/);
+      expect(firstAwait, "the handler awaits nothing").to.be.greaterThan(-1);
+      // A window checked after a lookup makes the refusal depend on what the
+      // lookup found, so an expired approval for a pack that is gone is
+      // reported as missing rather than as expired.
+      expect(
+        checked,
+        "an account is read before the caller's expiry is checked",
+      ).to.be.lessThan(firstAwait);
+    });
+  }
+
+  it("routers/welcomePacks/procedures/claim.ts answers an expired approval with its own status", () => {
+    // This endpoint separates `expired` from the other refusals, so a caller
+    // can tell a stale invite from a bad one.
+    expect(code("routers/welcomePacks/procedures/claim.ts")).to.match(
+      /reason === "expired"[\s\S]{0,120}errors\.EXPIRED/,
+    );
+  });
 
   it("routers/transactions/procedures/submit.ts attributes a batch to a verified payer", () => {
     expect(
       callIndex(
         code("routers/transactions/procedures/submit.ts"),
-        "verifiedFeePayer"
-      )
+        "verifiedFeePayer",
+      ),
     ).to.be.greaterThan(-1);
   });
 
@@ -88,7 +126,7 @@ describe("server code that calls a guard", () => {
     expect(callIndex(source, "summarizeProcedureInput")).to.be.greaterThan(-1);
     expect(
       source,
-      "an input serialized whole puts every field it carries in the log"
+      "an input serialized whole puts every field it carries in the log",
     ).to.not.match(/JSON\.stringify\s*\(\s*input\b/);
   });
 });

--- a/packages/blockchain-api/tests/unit/guarded-endpoints.test.ts
+++ b/packages/blockchain-api/tests/unit/guarded-endpoints.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+
+/**
+ * The server code reached only through a Next handler, a database and a Solana
+ * RPC, so a unit test cannot call it. What it can do is hold each caller to the
+ * guard it is required to call: the guards are covered by their own tests, and
+ * a guard nothing calls guards nothing.
+ */
+const API = join(__dirname, "../../src/server/api");
+
+/** Endpoints that may only build a transaction for the cNFT's owner. */
+const ASSET_OWNER_GUARDED = [
+  "routers/hotspots/procedures/hotspot-cnft.ts",
+  "routers/hotspots/procedures/updateHotspotInfo.ts",
+  "routers/hotspots/procedures/updateRewardsDestination.ts",
+  "routers/hotspots/procedures/createSplit.ts",
+  "routers/hotspots/procedures/deleteSplit.ts",
+  "routers/reward-contract/procedures/create.ts",
+];
+
+/** Endpoints that spend this service's own fee payer on a claim approval. */
+const CLAIM_APPROVAL_GUARDED = [
+  "routers/reward-contract/procedures/claim.ts",
+  "routers/welcomePacks/procedures/claim.ts",
+];
+
+/**
+ * Source with comments removed, so a guard named in prose does not read as a
+ * guard that is called. `:` before `//` keeps a URL in a string intact.
+ */
+function code(relativePath: string): string {
+  return readFileSync(join(API, relativePath), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+/** Where a call to `name` starts, or -1. */
+function callIndex(source: string, name: string): number {
+  return source.search(new RegExp(`\\b${name}\\s*\\(`));
+}
+
+describe("server code that calls a guard", () => {
+  // The counts are asserted so this enumeration cannot quietly lose an entry
+  // and go on passing over the endpoints it still names.
+  it("covers every endpoint that has a guard to call", () => {
+    expect(ASSET_OWNER_GUARDED).to.have.lengthOf(6);
+    expect(CLAIM_APPROVAL_GUARDED).to.have.lengthOf(2);
+  });
+
+  for (const file of ASSET_OWNER_GUARDED) {
+    it(`${file} checks the caller owns the asset`, () => {
+      expect(callIndex(code(file), "assertAssetOwner")).to.be.greaterThan(-1);
+    });
+  }
+
+  for (const file of CLAIM_APPROVAL_GUARDED) {
+    it(`${file} verifies the approval before loading the fee payer's key`, () => {
+      const source = code(file);
+      const verified = callIndex(source, "verifyClaimApproval");
+      const loaded = callIndex(source, "loadKeypair");
+
+      expect(verified, "verifyClaimApproval is not called").to.be.greaterThan(
+        -1
+      );
+      expect(loaded, "loadKeypair is not called").to.be.greaterThan(-1);
+      expect(
+        verified,
+        "the fee payer's key is loaded before the approval is verified"
+      ).to.be.lessThan(loaded);
+    });
+  }
+
+  it("routers/transactions/procedures/submit.ts attributes a batch to a verified payer", () => {
+    expect(
+      callIndex(
+        code("routers/transactions/procedures/submit.ts"),
+        "verifiedFeePayer"
+      )
+    ).to.be.greaterThan(-1);
+  });
+
+  it("procedures.ts logs an input through the allowlist and never whole", () => {
+    const source = code("procedures.ts");
+
+    expect(callIndex(source, "summarizeProcedureInput")).to.be.greaterThan(-1);
+    expect(
+      source,
+      "an input serialized whole puts every field it carries in the log"
+    ).to.not.match(/JSON\.stringify\s*\(\s*input\b/);
+  });
+});

--- a/packages/blockchain-api/tests/unit/guarded-endpoints.test.ts
+++ b/packages/blockchain-api/tests/unit/guarded-endpoints.test.ts
@@ -52,7 +52,14 @@ describe("server code that calls a guard", () => {
 
   for (const file of ASSET_OWNER_GUARDED) {
     it(`${file} checks the caller owns the asset`, () => {
-      expect(callIndex(code(file), "assertAssetOwner")).to.be.greaterThan(-1);
+      // Either guard suffices: fetchOwnedAsset calls assertAssetOwner itself.
+      const source = code(file);
+      expect(
+        Math.max(
+          callIndex(source, "assertAssetOwner"),
+          callIndex(source, "fetchOwnedAsset"),
+        ),
+      ).to.be.greaterThan(-1);
     });
   }
 

--- a/packages/blockchain-api/tests/unit/log-input.test.ts
+++ b/packages/blockchain-api/tests/unit/log-input.test.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { CreateBankAccountInputSchema } from "../../../blockchain-api-client/src/schemas/fiat";
+import { summarizeProcedureInput } from "../../src/lib/utils/log-input";
+
+/** A filled-in `fiat.createBankAccount` input, the worst case for the log. */
+const BANK_ACCOUNT = CreateBankAccountInputSchema.parse({
+  currency: "usd",
+  account_type: "checking",
+  bank_name: "Example Bank",
+  account_name: "Primary",
+  first_name: "Ada",
+  last_name: "Lovelace",
+  account: {
+    account_number: "000123456789",
+    routing_number: "021000021",
+    checking_or_savings: "checking",
+  },
+  address: {
+    street_line_1: "1 Analytical Engine Way",
+    city: "London",
+    state: "LDN",
+    postal_code: "NW1",
+    country: "GB",
+  },
+});
+
+/** Every string anywhere in a value, so a test can assert none of it is logged. */
+function strings(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (value === null || typeof value !== "object") return [];
+  return Object.values(value as Record<string, unknown>).flatMap(strings);
+}
+
+describe("summarizeProcedureInput", () => {
+  it("logs nothing for an input with no fields", () => {
+    expect(summarizeProcedureInput({})).to.equal("");
+    expect(summarizeProcedureInput(undefined)).to.equal("");
+    expect(summarizeProcedureInput(null)).to.equal("");
+    expect(summarizeProcedureInput("a string")).to.equal("");
+  });
+
+  it("logs the value of an allowlisted field", () => {
+    expect(
+      summarizeProcedureInput({ walletAddress: "GZairnxHiWXk73Yhs" })
+    ).to.equal(' {walletAddress="GZairnxHiWXk73Yhs"}');
+  });
+
+  it("logs an unlisted field by name only", () => {
+    expect(summarizeProcedureInput({ secretToken: "s3cret" })).to.equal(
+      " {secretToken}"
+    );
+  });
+
+  it("keeps the order and separates the fields", () => {
+    expect(
+      summarizeProcedureInput({ walletAddress: "abc", amount: "5" })
+    ).to.equal(' {walletAddress="abc", amount}');
+  });
+
+  it("logs no part of a bank account, not even the fields it lists", () => {
+    const line = summarizeProcedureInput(BANK_ACCOUNT);
+
+    for (const secret of strings(BANK_ACCOUNT)) {
+      expect(line, `leaked ${secret}`).to.not.contain(secret);
+    }
+    expect(line).to.contain("account_name");
+    expect(line).to.contain("account");
+    expect(line).to.contain("address");
+  });
+
+  it("stops logging a listed field whose value stops being a scalar", () => {
+    // A schema that nests something under a name that used to hold a string
+    // does not start logging what it nested.
+    expect(
+      summarizeProcedureInput({ owner: { address: "GZairnxHiWXk73Yhs" } })
+    ).to.equal(" {owner}");
+    expect(summarizeProcedureInput({ owner: ["GZairnxHiWXk73Yhs"] })).to.equal(
+      " {owner}"
+    );
+  });
+
+  it("logs a listed field's scalar value whatever its type", () => {
+    expect(
+      summarizeProcedureInput({ parallel: true, simulate: false, type: 3 })
+    ).to.equal(" {parallel=true, simulate=false, type=3}");
+  });
+
+  it("does not take a value from Object.prototype for an unlisted name", () => {
+    expect(
+      summarizeProcedureInput({ constructor: "x", toString: "y" })
+    ).to.equal(" {constructor, toString}");
+  });
+});

--- a/packages/blockchain-api/tests/unit/mint-recipient-tag.test.ts
+++ b/packages/blockchain-api/tests/unit/mint-recipient-tag.test.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "../../src/lib/utils/transaction-tags";
+
+const OWNER = "GZairnxHiWXk73YhsEtkGU2XnfGw3QcUsjJr8VW2R172";
+const RECIPIENT = "ATGQKkmNat3N8ZXM2ChEKMNAQ45isPPfUpBrAnvX9J8R";
+
+/** The tag the DC mint endpoint builds for an amount and a recipient. */
+const mintTag = (recipient?: string) =>
+  generateTransactionTag({
+    type: TRANSACTION_TYPES.MINT_DATA_CREDITS,
+    userAddress: OWNER,
+    dcAmount: "100000",
+    hntAmount: undefined,
+    recipient: recipient && recipient !== OWNER ? recipient : undefined,
+  });
+
+describe("data credits mint transaction tag", () => {
+  it("distinguishes two mints that differ only in where the credits land", () => {
+    expect(mintTag(RECIPIENT)).to.not.equal(mintTag(undefined));
+  });
+
+  it("gives a mint to the owner's own account the tag it had without a recipient", () => {
+    expect(mintTag(OWNER)).to.equal(mintTag(undefined));
+  });
+
+  it("gives the same mint the same tag", () => {
+    expect(mintTag(RECIPIENT)).to.equal(mintTag(RECIPIENT));
+  });
+});

--- a/packages/blockchain-api/tests/unit/swap-destination-tag.test.ts
+++ b/packages/blockchain-api/tests/unit/swap-destination-tag.test.ts
@@ -1,0 +1,42 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import {
+  generateTransactionTag,
+  TRANSACTION_TYPES,
+} from "../../src/lib/utils/transaction-tags";
+
+const USER = "GZairnxHiWXk73YhsEtkGU2XnfGw3QcUsjJr8VW2R172";
+const HNT_MINT = "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux";
+const WSOL_MINT = "So11111111111111111111111111111111111111112";
+
+/** The tag the swap endpoint builds for a quote and a destination. */
+const swapTag = (destinationTokenAccount?: string) =>
+  generateTransactionTag({
+    type: TRANSACTION_TYPES.SWAP,
+    userAddress: USER,
+    inputMint: HNT_MINT,
+    outputMint: WSOL_MINT,
+    amount: "100000000",
+    destinationTokenAccount,
+  });
+
+describe("swap transaction tag", () => {
+  it("distinguishes two swaps that differ only in where the output lands", () => {
+    const first = swapTag("8Ta7Q1zP1cTNyKLLcCG6ehAA5H6Pjq4hLpwjDNDkKTGF");
+    const second = swapTag("ATGQKkmNat3N8ZXM2ChEKMNAQ45isPPfUpBrAnvX9J8R");
+
+    expect(first).to.not.equal(second);
+  });
+
+  it("distinguishes a swap to a named destination from one to the signer's own", () => {
+    expect(swapTag("8Ta7Q1zP1cTNyKLLcCG6ehAA5H6Pjq4hLpwjDNDkKTGF")).to.not.equal(
+      swapTag(undefined)
+    );
+  });
+
+  it("gives the same swap the same tag", () => {
+    expect(swapTag("8Ta7Q1zP1cTNyKLLcCG6ehAA5H6Pjq4hLpwjDNDkKTGF")).to.equal(
+      swapTag("8Ta7Q1zP1cTNyKLLcCG6ehAA5H6Pjq4hLpwjDNDkKTGF")
+    );
+  });
+});

--- a/packages/blockchain-api/tests/unit/token-transfer-endpoint.test.ts
+++ b/packages/blockchain-api/tests/unit/token-transfer-endpoint.test.ts
@@ -1,0 +1,255 @@
+import { createServer, Server } from "http";
+import { AddressInfo } from "net";
+import { ASSOCIATED_TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import { VersionedTransaction } from "@solana/web3.js";
+import { call, ORPCError } from "@orpc/server";
+import { expect } from "chai";
+import { after, afterEach, before, describe, it } from "mocha";
+import { MIN_WALLET_RENT_LAMPORTS } from "../../src/lib/utils/balance-validation";
+
+/**
+ * Type-only, so naming the handler here does not import it: the module reads a
+ * validated env at load, which only exists once `before` has set one up.
+ */
+type TransferModule =
+  typeof import("../../src/server/api/routers/tokens/procedures/transfer");
+
+const WALLET = "GZairnxHiWXk73YhsEtkGU2XnfGw3QcUsjJr8VW2R172";
+const FEE_PAYER = "ATGQKkmNat3N8ZXM2ChEKMNAQ45isPPfUpBrAnvX9J8R";
+const DESTINATION = "8Ta7Q1zP1cTNyKLLcCG6ehAA5H6Pjq4hLpwjDNDkKTGF";
+const MULTISIG = "7iudHEnL3sjaGU62A6zH1CfeDLbKqAZ9FpBkbAQfTvDS";
+const HNT_MINT = "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux";
+const WSOL_MINT = "So11111111111111111111111111111111111111112";
+
+/** Lamports the stub reports per address, rewritten by the balance tests. */
+const balances = new Map<string, number>();
+const DEFAULT_BALANCE = 5_000_000_000;
+/** What the stub's getFeeForMessage charges for any transaction. */
+const STUB_TX_FEE = 10000;
+
+const withContext = (value: unknown) => ({
+  context: { apiVersion: "2.0.0", slot: 1 },
+  value,
+});
+
+/**
+ * The RPC answers the transfer endpoint needs. Everything it does not answer —
+ * simulation, priority-fee estimation — the build path already treats as
+ * unavailable and falls back from, so the transaction is still produced.
+ */
+function rpcResult(method: string, params: unknown[]): unknown {
+  switch (method) {
+    case "getLatestBlockhash":
+      return withContext({
+        blockhash: "11111111111111111111111111111111",
+        lastValidBlockHeight: 1000,
+      });
+    case "getAccountInfo":
+      return withContext(null);
+    case "getBalance":
+      return withContext(balances.get(params[0] as string) ?? DEFAULT_BALANCE);
+    case "getFeeForMessage":
+      return withContext(STUB_TX_FEE);
+    case "getRecentPrioritizationFees":
+      return [];
+    default:
+      return undefined;
+  }
+}
+
+interface JsonRpcRequest {
+  id: unknown;
+  method: string;
+  params: unknown[];
+}
+
+let server: Server;
+
+function startStubRpc(): Promise<string> {
+  return new Promise((resolve) => {
+    server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        const answer = ({ id, method, params }: JsonRpcRequest) => {
+          const result = rpcResult(method, params ?? []);
+          return result === undefined
+            ? {
+                jsonrpc: "2.0",
+                id,
+                error: { code: -32601, message: `unstubbed: ${method}` },
+              }
+            : { jsonrpc: "2.0", id, result };
+        };
+        const parsed = JSON.parse(body);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify(
+            Array.isArray(parsed) ? parsed.map(answer) : answer(parsed)
+          )
+        );
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/** The transfer request, with only the fields a case varies spelled out. */
+const request = (extra: Record<string, unknown> = {}) => ({
+  walletAddress: WALLET,
+  destination: DESTINATION,
+  tokenAmount: { amount: "100000000", mint: HNT_MINT },
+  ...extra,
+});
+
+describe("POST /tokens/transfer fee payer", () => {
+  let transfer: TransferModule["transfer"];
+
+  const transferred = async (input: ReturnType<typeof request>) => {
+    const result = await call(transfer, input);
+    return {
+      tag: result.transactionData.tag,
+      tx: VersionedTransaction.deserialize(
+        Buffer.from(
+          result.transactionData.transactions[0].serializedTransaction,
+          "base64"
+        )
+      ),
+    };
+  };
+
+  /** Every account the built transaction requires a signature from. */
+  const signers = (tx: VersionedTransaction) =>
+    tx.message.staticAccountKeys
+      .slice(0, tx.message.header.numRequiredSignatures)
+      .map((key) => key.toBase58());
+
+  /** The account funding the recipient's associated token account. */
+  const ataFunder = (tx: VersionedTransaction) => {
+    const keys = tx.message.staticAccountKeys;
+    const createAta = tx.message.compiledInstructions.find((ix) =>
+      keys[ix.programIdIndex].equals(ASSOCIATED_TOKEN_PROGRAM_ID)
+    );
+    if (!createAta) throw new Error("no associated-token instruction");
+    return keys[createAta.accountKeyIndexes[0]].toBase58();
+  };
+
+  before(async () => {
+    // Every server variable the env schema requires without a default, set
+    // here rather than read from a file so the run does not depend on a
+    // developer's local environment. The RPC url points at the stub.
+    process.env.PG_USER = "test";
+    process.env.PG_NAME = "test";
+    process.env.PG_HOST = "localhost";
+    process.env.PG_PORT = "5432";
+    process.env.PRIVY_APP_SECRET = "test";
+    process.env.BRIDGE_API_KEY = "test";
+    process.env.JUPITER_API_KEY = "test";
+    process.env.NEXT_PUBLIC_PRIVY_APP_ID = "test";
+    process.env.NO_PG = "true";
+    process.env.SOLANA_RPC_URL = await startStubRpc();
+    ({ transfer } = await import(
+      "../../src/server/api/routers/tokens/procedures/transfer"
+    ));
+  });
+
+  after(() => {
+    server?.closeAllConnections?.();
+    server?.close();
+  });
+
+  afterEach(() => balances.clear());
+
+  it("pays from the wallet and needs one signature when none is named", async () => {
+    const { tx } = await transferred(request());
+    expect(signers(tx)).to.deep.eq([WALLET]);
+    expect(ataFunder(tx)).to.eq(WALLET);
+  });
+
+  it("pays from the named fee payer and needs both signatures", async () => {
+    const { tx } = await transferred(request({ feePayer: FEE_PAYER }));
+    expect(signers(tx)).to.deep.eq([FEE_PAYER, WALLET]);
+  });
+
+  it("funds the recipient's token account from the named fee payer", async () => {
+    const { tx } = await transferred(request({ feePayer: FEE_PAYER }));
+    expect(ataFunder(tx)).to.eq(FEE_PAYER);
+  });
+
+  it("tags a fee-payer transfer apart from the same transfer without one", async () => {
+    const plain = await transferred(request());
+    const paid = await transferred(request({ feePayer: FEE_PAYER }));
+    expect(paid.tag).to.not.eq(plain.tag);
+  });
+
+  it("charges a SOL transfer to the wallet, not the fee payer", async () => {
+    balances.set(WALLET, 99_999_999);
+    const error = await call(
+      transfer,
+      request({
+        feePayer: FEE_PAYER,
+        tokenAmount: { amount: "100000000", mint: WSOL_MINT },
+      })
+    ).catch((e) => e);
+
+    expect(error).to.be.instanceOf(ORPCError);
+    expect((error as ORPCError<string, unknown>).code).to.eq(
+      "INSUFFICIENT_FUNDS"
+    );
+    expect((error as ORPCError<string, unknown>).message).to.eq(
+      "Insufficient SOL balance for transfer"
+    );
+    expect((error as ORPCError<string, { required: number }>).data).to.deep.eq({
+      required: 100_000_000,
+      available: 99_999_999,
+    });
+  });
+
+  it("charges the fee to the fee payer without the transfer amount", async () => {
+    balances.set(FEE_PAYER, 1000);
+    const error = await call(
+      transfer,
+      request({
+        feePayer: FEE_PAYER,
+        tokenAmount: { amount: "100000000", mint: WSOL_MINT },
+      })
+    ).catch((e) => e);
+
+    expect((error as ORPCError<string, unknown>).message).to.eq(
+      "Insufficient SOL balance for transaction fees"
+    );
+    // The stub's fee plus the min-wallet buffer, and not a lamport of the
+    // 100_000_000 being transferred.
+    expect((error as ORPCError<string, unknown>).data).to.deep.eq({
+      required: STUB_TX_FEE + MIN_WALLET_RENT_LAMPORTS,
+      available: 1000,
+    });
+  });
+
+  it("proposes through the vault when only multisig is given", async () => {
+    const error = await call(
+      transfer,
+      request({ multisig: MULTISIG })
+    ).catch((e) => e);
+
+    // The propose path reads the multisig account, which the stub does not
+    // serve — far enough to prove input validation let it through.
+    expect((error as ORPCError<string, unknown>).code).to.not.eq("BAD_REQUEST");
+  });
+
+  it("refuses a fee payer alongside a multisig", async () => {
+    const error = await call(
+      transfer,
+      request({ feePayer: FEE_PAYER, multisig: MULTISIG })
+    ).catch((e) => e);
+
+    expect(error).to.be.instanceOf(ORPCError);
+    expect((error as ORPCError<string, unknown>).code).to.eq("BAD_REQUEST");
+    expect((error as ORPCError<string, unknown>).message).to.eq(
+      "feePayer is not supported with multisig"
+    );
+  });
+});

--- a/packages/blockchain-api/tests/unit/token-transfer-fee-payer.test.ts
+++ b/packages/blockchain-api/tests/unit/token-transfer-fee-payer.test.ts
@@ -1,0 +1,334 @@
+import { Connection, PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { toVersionedTx } from "../../../spl-utils/src/transaction";
+import { TransferInputSchema } from "../../../blockchain-api-client/src/schemas/tokens";
+import {
+  buildTransferInstructions,
+  transferSolShortfall,
+} from "../../src/server/api/routers/tokens/procedures/transfer-helpers";
+import { generateTransactionTag } from "../../src/lib/utils/transaction-tags";
+
+const AUTHORITY = new PublicKey("GZairnxHiWXk73YhsEtkGU2XnfGw3QcUsjJr8VW2R172");
+const PAYER = new PublicKey("ATGQKkmNat3N8ZXM2ChEKMNAQ45isPPfUpBrAnvX9J8R");
+const DESTINATION = new PublicKey(
+  "8Ta7Q1zP1cTNyKLLcCG6ehAA5H6Pjq4hLpwjDNDkKTGF"
+);
+const HNT_MINT = "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux";
+const WSOL_MINT = "So11111111111111111111111111111111111111112";
+const AMOUNT = BigInt(100000000);
+
+/** A fixed blockhash, so a compiled message is a byte-for-byte constant. */
+const BLOCKHASH = "11111111111111111111111111111111";
+
+/**
+ * The compiled messages the endpoint produced before it took a fee payer,
+ * captured by running the previous instruction builder against these same
+ * fixed inputs. An omitted `feePayer` has to reproduce them exactly.
+ */
+const MESSAGE_WITHOUT_FEE_PAYER = {
+  spl: "gAEABQjnOATfO2FjSIwKETu5VcjeMIFSGdfTdWFp1bNOCQYAzSdWOdDIf1xzj9P/Z4jbcymxZX3P/RbstVSmQHM5J3N8sILxMPPz9aoitDahb5EssExJtLp4lxutNQc9sZcJV0GMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WW7QWPIqzDgiyi7wtCocDkW1Iu1jJ/sP5uGy8tqyB0BcCnMgk5GFYffdf8vsSr2FE97KGpZ/etejnWO0HtiTgIsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAwYAAQQFBgcBAQcEAgUBAAoMAOH1BQAAAAAIAA==",
+  sol: "gAEAAQPnOATfO2FjSIwKETu5VcjeMIFSGdfTdWFp1bNOCQYAzW7QWPIqzDgiyi7wtCocDkW1Iu1jJ/sP5uGy8tqyB0BcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAECAgABDAIAAAAA4fUFAAAAAAA=",
+};
+
+/** A connection whose only answer is that the recipient has no token account. */
+const noRecipientAta = {
+  getAccountInfo: async () => null,
+} as unknown as Connection;
+
+/** The message the endpoint compiles, through the same helper it uses. */
+function compiledMessage(
+  instructions: TransactionInstruction[],
+  feePayer: PublicKey
+) {
+  return toVersionedTx({
+    instructions,
+    feePayer,
+    recentBlockhash: BLOCKHASH,
+    addressLookupTables: [],
+  }).message;
+}
+
+/** The compiled message's bytes, for comparison against a fixture. */
+function messageBase64(
+  instructions: TransactionInstruction[],
+  feePayer: PublicKey
+) {
+  const bytes = compiledMessage(instructions, feePayer).serialize();
+  return Buffer.from(bytes).toString("base64");
+}
+
+/** Every account a compiled message requires a signature from. */
+function signerKeys(instructions: TransactionInstruction[], payer: PublicKey) {
+  const message = compiledMessage(instructions, payer);
+  return message.staticAccountKeys
+    .slice(0, message.header.numRequiredSignatures)
+    .map((key) => key.toBase58());
+}
+
+/** The accounts one instruction requires a signature from. */
+function instructionSigners(instruction: TransactionInstruction) {
+  return instruction.keys
+    .filter((key) => key.isSigner)
+    .map((key) => key.pubkey.toBase58());
+}
+
+const splTransfer = (payer: PublicKey) =>
+  buildTransferInstructions({
+    connection: noRecipientAta,
+    authority: AUTHORITY,
+    payer,
+    destination: DESTINATION,
+    mint: HNT_MINT,
+    rawAmount: AMOUNT,
+    isSol: false,
+  });
+
+const solTransfer = (payer: PublicKey) =>
+  buildTransferInstructions({
+    connection: noRecipientAta,
+    authority: AUTHORITY,
+    payer,
+    destination: DESTINATION,
+    mint: WSOL_MINT,
+    rawAmount: AMOUNT,
+    isSol: true,
+  });
+
+describe("TransferInputSchema feePayer", () => {
+  const base = {
+    walletAddress: AUTHORITY.toBase58(),
+    destination: DESTINATION.toBase58(),
+    tokenAmount: { amount: "100000000", mint: HNT_MINT },
+  };
+
+  it("is absent when the caller omits it", () => {
+    expect(TransferInputSchema.parse(base).feePayer).to.eq(undefined);
+  });
+
+  it("accepts a wallet address", () => {
+    const parsed = TransferInputSchema.parse({
+      ...base,
+      feePayer: PAYER.toBase58(),
+    });
+    expect(parsed.feePayer).to.eq(PAYER.toBase58());
+  });
+
+  it("rejects an address that is not base58 of the right length", () => {
+    const parsed = TransferInputSchema.safeParse({
+      ...base,
+      feePayer: "not-a-wallet",
+    });
+    expect(parsed.success).to.eq(false);
+  });
+
+});
+
+describe("buildTransferInstructions without a separate fee payer", () => {
+  it("compiles the SPL transfer to the same message as before", async () => {
+    const { instructions, needsAta } = await splTransfer(AUTHORITY);
+    expect(needsAta).to.eq(true);
+    expect(messageBase64(instructions, AUTHORITY)).to.eq(
+      MESSAGE_WITHOUT_FEE_PAYER.spl
+    );
+  });
+
+  it("compiles the SOL transfer to the same message as before", async () => {
+    const { instructions } = await solTransfer(AUTHORITY);
+    expect(messageBase64(instructions, AUTHORITY)).to.eq(
+      MESSAGE_WITHOUT_FEE_PAYER.sol
+    );
+  });
+
+  it("needs the wallet's signature and nothing else", async () => {
+    const { instructions } = await splTransfer(AUTHORITY);
+    expect(signerKeys(instructions, AUTHORITY)).to.deep.eq([
+      AUTHORITY.toBase58(),
+    ]);
+  });
+});
+
+describe("buildTransferInstructions with a separate fee payer", () => {
+  it("funds the recipient's token account from the fee payer", async () => {
+    const { instructions } = await splTransfer(PAYER);
+    const [createAta] = instructions;
+    expect(instructionSigners(createAta)).to.deep.eq([PAYER.toBase58()]);
+  });
+
+  it("keeps the wallet as the source authority", async () => {
+    const { instructions } = await splTransfer(PAYER);
+    const [, transferChecked] = instructions;
+    expect(instructionSigners(transferChecked)).to.deep.eq([
+      AUTHORITY.toBase58(),
+    ]);
+    expect(transferChecked.keys[0].pubkey.toBase58()).to.eq(
+      getAssociatedTokenAddressSync(
+        new PublicKey(HNT_MINT),
+        AUTHORITY,
+        true
+      ).toBase58()
+    );
+  });
+
+  it("requires both signatures, with the fee payer first", async () => {
+    const { instructions } = await splTransfer(PAYER);
+    expect(signerKeys(instructions, PAYER)).to.deep.eq([
+      PAYER.toBase58(),
+      AUTHORITY.toBase58(),
+    ]);
+  });
+
+  it("still moves native SOL out of the wallet, not the fee payer", async () => {
+    const { instructions } = await solTransfer(PAYER);
+    expect(instructions).to.have.length(1);
+    expect(instructionSigners(instructions[0])).to.deep.eq([
+      AUTHORITY.toBase58(),
+    ]);
+    expect(signerKeys(instructions, PAYER)).to.deep.eq([
+      PAYER.toBase58(),
+      AUTHORITY.toBase58(),
+    ]);
+  });
+});
+
+describe("transferSolShortfall", () => {
+  const FEE = 940880;
+
+  describe("when the wallet pays its own fee", () => {
+    it("charges fee only for an SPL transfer", () => {
+      expect(
+        transferSolShortfall({
+          payerBalance: FEE,
+          payerLamports: FEE,
+          transferLamports: 0,
+          authorityBalance: null,
+        })
+      ).to.eq(null);
+
+      expect(
+        transferSolShortfall({
+          payerBalance: FEE - 1,
+          payerLamports: FEE,
+          transferLamports: 0,
+          authorityBalance: null,
+        })
+      ).to.deep.eq({
+        message: "Insufficient SOL balance for transaction fees",
+        required: FEE,
+        available: FEE - 1,
+      });
+    });
+
+    it("charges fee plus the transfer for a SOL transfer", () => {
+      expect(
+        transferSolShortfall({
+          payerBalance: FEE + 500,
+          payerLamports: FEE,
+          transferLamports: 500,
+          authorityBalance: null,
+        })
+      ).to.eq(null);
+
+      expect(
+        transferSolShortfall({
+          payerBalance: FEE + 499,
+          payerLamports: FEE,
+          transferLamports: 500,
+          authorityBalance: null,
+        })
+      ).to.deep.eq({
+        message: "Insufficient SOL balance for transfer and transaction fees",
+        required: FEE + 500,
+        available: FEE + 499,
+      });
+    });
+  });
+
+  describe("when a separate account pays the fee", () => {
+    it("charges the transfer to the wallet and the fee to the payer", () => {
+      expect(
+        transferSolShortfall({
+          payerBalance: FEE,
+          payerLamports: FEE,
+          transferLamports: 500,
+          authorityBalance: 500,
+        })
+      ).to.eq(null);
+    });
+
+    it("lets the wallet be emptied to exactly zero", () => {
+      expect(
+        transferSolShortfall({
+          payerBalance: FEE,
+          payerLamports: FEE,
+          transferLamports: 1234,
+          authorityBalance: 1234,
+        })
+      ).to.eq(null);
+    });
+
+    it("reports the payer's shortfall without the transfer amount", () => {
+      expect(
+        transferSolShortfall({
+          payerBalance: FEE - 1,
+          payerLamports: FEE,
+          transferLamports: 500,
+          authorityBalance: 500,
+        })
+      ).to.deep.eq({
+        message: "Insufficient SOL balance for transaction fees",
+        required: FEE,
+        available: FEE - 1,
+      });
+    });
+
+    it("reports the wallet's shortfall against the transfer alone", () => {
+      expect(
+        transferSolShortfall({
+          payerBalance: FEE,
+          payerLamports: FEE,
+          transferLamports: 500,
+          authorityBalance: 499,
+        })
+      ).to.deep.eq({
+        message: "Insufficient SOL balance for transfer",
+        required: 500,
+        available: 499,
+      });
+    });
+
+    it("does not charge an SPL transfer to the wallet's SOL balance", () => {
+      expect(
+        transferSolShortfall({
+          payerBalance: FEE,
+          payerLamports: FEE,
+          transferLamports: 0,
+          authorityBalance: null,
+        })
+      ).to.eq(null);
+    });
+  });
+});
+
+describe("token transfer tag", () => {
+  const params = {
+    type: "token_transfer",
+    walletAddress: AUTHORITY.toBase58(),
+    destination: DESTINATION.toBase58(),
+    mint: HNT_MINT,
+    amount: "100000000",
+  };
+
+  it("is unchanged when no fee payer is named", () => {
+    expect(generateTransactionTag({ ...params, feePayer: undefined })).to.eq(
+      generateTransactionTag(params)
+    );
+  });
+
+  it("differs once a fee payer is named", () => {
+    expect(
+      generateTransactionTag({ ...params, feePayer: PAYER.toBase58() })
+    ).to.not.eq(generateTransactionTag(params));
+  });
+});

--- a/packages/blockchain-api/tests/unit/transaction-payer.test.ts
+++ b/packages/blockchain-api/tests/unit/transaction-payer.test.ts
@@ -1,0 +1,104 @@
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { verifiedFeePayer } from "../../src/lib/utils/transaction-payer";
+
+/** A fixed blockhash, so a compiled message is a byte-for-byte constant. */
+const BLOCKHASH = "11111111111111111111111111111111";
+
+/** Keypairs derived from constants, so every run signs the same bytes. */
+const FEE_PAYER = Keypair.fromSeed(Buffer.alloc(32, 1));
+const AUTHORITY = Keypair.fromSeed(Buffer.alloc(32, 2));
+const DESTINATION = new PublicKey(
+  "8Ta7Q1zP1cTNyKLLcCG6ehAA5H6Pjq4hLpwjDNDkKTGF"
+);
+
+/**
+ * A SOL transfer out of `AUTHORITY`, paid for by `payer`. Naming a payer other
+ * than the source is what `/tokens/transfer` does when it is given a
+ * third-party fee payer, and it compiles to two required signatures with the
+ * payer first.
+ */
+function transfer(payer: PublicKey, lamports = 1000) {
+  return new VersionedTransaction(
+    new TransactionMessage({
+      payerKey: payer,
+      recentBlockhash: BLOCKHASH,
+      instructions: [
+        SystemProgram.transfer({
+          fromPubkey: AUTHORITY.publicKey,
+          toPubkey: DESTINATION,
+          lamports,
+        }),
+      ],
+    }).compileToV0Message()
+  );
+}
+
+describe("verifiedFeePayer", () => {
+  it("names the fee payer of a transaction it signed", () => {
+    const tx = transfer(AUTHORITY.publicKey);
+    tx.sign([AUTHORITY]);
+    expect(verifiedFeePayer(tx)).to.equal(AUTHORITY.publicKey.toBase58());
+  });
+
+  it("accepts a two-signature transaction with a third-party fee payer", () => {
+    const tx = transfer(FEE_PAYER.publicKey);
+    expect(tx.message.header.numRequiredSignatures).to.equal(2);
+    expect(tx.message.staticAccountKeys[0].toBase58()).to.equal(
+      FEE_PAYER.publicKey.toBase58()
+    );
+
+    tx.sign([FEE_PAYER, AUTHORITY]);
+    expect(verifiedFeePayer(tx)).to.equal(FEE_PAYER.publicKey.toBase58());
+  });
+
+  it("refuses an unsigned transaction", () => {
+    expect(verifiedFeePayer(transfer(AUTHORITY.publicKey))).to.equal(null);
+    expect(verifiedFeePayer(transfer(FEE_PAYER.publicKey))).to.equal(null);
+  });
+
+  it("refuses a transaction every account but the fee payer signed", () => {
+    const tx = transfer(FEE_PAYER.publicKey);
+    tx.sign([AUTHORITY]);
+    expect(verifiedFeePayer(tx)).to.equal(null);
+  });
+
+  it("refuses a signature made over a different transaction", () => {
+    const signed = transfer(FEE_PAYER.publicKey, 1000);
+    signed.sign([FEE_PAYER, AUTHORITY]);
+
+    const altered = transfer(FEE_PAYER.publicKey, 2000);
+    altered.signatures = signed.signatures;
+    expect(verifiedFeePayer(altered)).to.equal(null);
+  });
+
+  it("refuses a signature that is somebody else's", () => {
+    const tx = transfer(FEE_PAYER.publicKey);
+    const authoritySigned = transfer(FEE_PAYER.publicKey);
+    authoritySigned.sign([AUTHORITY]);
+
+    // The authority's signature over the same message, in the fee payer's slot.
+    tx.signatures[0] = authoritySigned.signatures[1];
+    expect(verifiedFeePayer(tx)).to.equal(null);
+  });
+
+  it("refuses a truncated or absent signature rather than throwing", () => {
+    const tx = transfer(AUTHORITY.publicKey);
+    tx.sign([AUTHORITY]);
+
+    const truncated = transfer(AUTHORITY.publicKey);
+    truncated.signatures = [tx.signatures[0].subarray(0, 32)];
+    expect(verifiedFeePayer(truncated)).to.equal(null);
+
+    const none = transfer(AUTHORITY.publicKey);
+    none.signatures = [];
+    expect(verifiedFeePayer(none)).to.equal(null);
+  });
+});

--- a/packages/blockchain-api/tests/unit/update-info-owner.test.ts
+++ b/packages/blockchain-api/tests/unit/update-info-owner.test.ts
@@ -1,0 +1,567 @@
+import { AnchorProvider, BN, Program } from "@coral-xyz/anchor";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import {
+  iotInfoKey,
+  mobileInfoKey,
+  rewardableEntityConfigKey,
+} from "@helium/helium-entity-manager-sdk";
+import { subDaoKey } from "@helium/helium-sub-daos-sdk";
+import {
+  DC_MINT,
+  IOT_MINT,
+  MOBILE_MINT,
+} from "../../../spl-utils/src/constants";
+import heliumEntityManagerIdl from "../../../spl-utils/src/idl/helium_entity_manager.json";
+import { UpdateHotspotInfoInputSchema } from "../../../blockchain-api-client/src/schemas/hotspots";
+import {
+  assertDcCovered,
+  assertNotDelegated,
+  buildOwnerPaidUpdateInstruction,
+  dcBurnerFor,
+  hotspotInfoKey,
+  locationAssertDcFee,
+  locationStakingFee,
+  resizeTopUpLamports,
+  toOnChainElevation,
+  toOnChainGain,
+  withPreservedWifiSerial,
+} from "../../src/server/api/routers/hotspots/procedures/update-info-owner";
+
+const ENTITY_KEY = "1trSusfTpxRQ9QuLXFAtfsgKcJppYmMj6ZZKMRfmyQ8dABLuFXQ";
+const OWNER = new PublicKey("GZairnxHiWXk73YhsEtkGU2XnfGw3QcUsjJr8VW2R172");
+const MERKLE_TREE = new PublicKey(
+  "8Ta7Q1zP1cTNyKLLcCG6ehAA5H6Pjq4hLpwjDNDkKTGF"
+);
+
+/**
+ * The info PDAs derived straight from the SDK, so an assertion about the
+ * instruction's info account cannot be satisfied by the same derivation the
+ * builder used.
+ */
+const EXPECTED_MOBILE_INFO = mobileInfoKey(
+  rewardableEntityConfigKey(subDaoKey(MOBILE_MINT)[0], "MOBILE")[0],
+  ENTITY_KEY
+)[0];
+const EXPECTED_IOT_INFO = iotInfoKey(
+  rewardableEntityConfigKey(subDaoKey(IOT_MINT)[0], "IOT")[0],
+  ENTITY_KEY
+)[0];
+
+const PROOF_ARGS = {
+  dataHash: new Array(32).fill(1),
+  creatorHash: new Array(32).fill(2),
+  root: new Array(32).fill(3),
+  index: 7,
+};
+
+/**
+ * The HEM program built against the checked-in IDL and an RPC endpoint that
+ * refuses connections: every account the instruction needs is supplied by the
+ * builder, so a passing test also proves the build takes no RPC round-trip.
+ */
+function hemProgram() {
+  const connection = new Connection("http://127.0.0.1:1/no-rpc-in-unit-tests");
+  const wallet = {
+    publicKey: OWNER,
+    signTransaction: async () => {
+      throw new Error("unit test wallet cannot sign");
+    },
+    signAllTransactions: async () => {
+      throw new Error("unit test wallet cannot sign");
+    },
+  };
+  return new Program(
+    heliumEntityManagerIdl as never,
+    new AnchorProvider(
+      connection,
+      wallet as never,
+      AnchorProvider.defaultOptions()
+    )
+    // The production program is built the same way, from the on-chain IDL.
+  ) as unknown as Parameters<
+    typeof buildOwnerPaidUpdateInstruction
+  >[0]["program"];
+}
+
+/** Position of a named account in an instruction, read off the IDL itself. */
+function accountIndex(instruction: string, account: string): number {
+  const idlIx = (
+    heliumEntityManagerIdl as unknown as {
+      instructions: { name: string; accounts: { name: string }[] }[];
+    }
+  ).instructions.find((ix) => ix.name === instruction);
+  if (!idlIx) throw new Error(`no ${instruction} in the IDL`);
+  const index = idlIx.accounts.findIndex((a) => a.name === account);
+  if (index < 0) throw new Error(`no ${account} on ${instruction}`);
+  return index;
+}
+
+const validInput = (extra: Record<string, unknown> = {}) => ({
+  deviceType: "iot" as const,
+  entityPubKey: ENTITY_KEY,
+  walletAddress: OWNER.toBase58(),
+  ...extra,
+});
+
+describe("UpdateHotspotInfoInputSchema feePayer", () => {
+  it("defaults to maker so existing callers keep the relayed behavior", () => {
+    const parsed = UpdateHotspotInfoInputSchema.parse(validInput());
+    expect(parsed.feePayer).to.eq("maker");
+  });
+
+  it("defaults to maker on the mobile branch too", () => {
+    const parsed = UpdateHotspotInfoInputSchema.parse({
+      deviceType: "mobile",
+      entityPubKey: ENTITY_KEY,
+      walletAddress: OWNER.toBase58(),
+    });
+    expect(parsed.feePayer).to.eq("maker");
+  });
+
+  it("accepts owner", () => {
+    const parsed = UpdateHotspotInfoInputSchema.parse(
+      validInput({ feePayer: "owner" })
+    );
+    expect(parsed.feePayer).to.eq("owner");
+  });
+
+  it("rejects a fee payer that is neither maker nor owner", () => {
+    expect(
+      UpdateHotspotInfoInputSchema.safeParse(validInput({ feePayer: "dao" }))
+        .success
+    ).to.eq(false);
+  });
+});
+
+describe("buildOwnerPaidUpdateInstruction", () => {
+  it("makes the owner the payer, DC fee payer and leaf owner (mobile)", async () => {
+    const ix = await buildOwnerPaidUpdateInstruction({
+      program: hemProgram(),
+      owner: OWNER,
+      entityKey: ENTITY_KEY,
+      merkleTree: MERKLE_TREE,
+      proofArgs: PROOF_ARGS,
+      remainingAccounts: [],
+      update: { network: "mobile", location: new BN(1234), deploymentInfo: null },
+    });
+
+    const at = (name: string) =>
+      ix.keys[accountIndex("update_mobile_info_v0", name)];
+    expect(at("payer").pubkey.toBase58()).to.eq(OWNER.toBase58());
+    expect(at("dc_fee_payer").pubkey.toBase58()).to.eq(OWNER.toBase58());
+    expect(at("hotspot_owner").pubkey.toBase58()).to.eq(OWNER.toBase58());
+    expect(at("dc_burner").pubkey.toBase58()).to.eq(
+      getAssociatedTokenAddressSync(DC_MINT, OWNER, true).toBase58()
+    );
+    // The burner is the owner's DC token account, not the owner itself.
+    expect(at("dc_burner").pubkey.toBase58()).to.not.eq(OWNER.toBase58());
+    expect(at("dc_mint").pubkey.toBase58()).to.eq(DC_MINT.toBase58());
+    expect(at("merkle_tree").pubkey.toBase58()).to.eq(MERKLE_TREE.toBase58());
+    expect(at("mobile_info").pubkey.toBase58()).to.eq(
+      EXPECTED_MOBILE_INFO.toBase58()
+    );
+  });
+
+  it("makes the owner the payer, DC fee payer and leaf owner (iot)", async () => {
+    const ix = await buildOwnerPaidUpdateInstruction({
+      program: hemProgram(),
+      owner: OWNER,
+      entityKey: ENTITY_KEY,
+      merkleTree: MERKLE_TREE,
+      proofArgs: PROOF_ARGS,
+      remainingAccounts: [],
+      update: {
+        network: "iot",
+        location: new BN(1234),
+        elevation: 5,
+        gain: 12,
+      },
+    });
+
+    const at = (name: string) =>
+      ix.keys[accountIndex("update_iot_info_v0", name)];
+    expect(at("payer").pubkey.toBase58()).to.eq(OWNER.toBase58());
+    expect(at("dc_fee_payer").pubkey.toBase58()).to.eq(OWNER.toBase58());
+    expect(at("hotspot_owner").pubkey.toBase58()).to.eq(OWNER.toBase58());
+    expect(at("dc_burner").pubkey.toBase58()).to.eq(
+      dcBurnerFor(OWNER).toBase58()
+    );
+    expect(at("iot_info").pubkey.toBase58()).to.eq(
+      EXPECTED_IOT_INFO.toBase58()
+    );
+  });
+
+  it("appends the merkle proof after the instruction's own accounts", async () => {
+    const proof = [
+      Keypair.generate().publicKey,
+      Keypair.generate().publicKey,
+    ].map((pubkey) => ({ pubkey, isSigner: false, isWritable: false }));
+
+    const ix = await buildOwnerPaidUpdateInstruction({
+      program: hemProgram(),
+      owner: OWNER,
+      entityKey: ENTITY_KEY,
+      merkleTree: MERKLE_TREE,
+      proofArgs: PROOF_ARGS,
+      remainingAccounts: proof,
+      update: { network: "mobile", location: null, deploymentInfo: null },
+    });
+
+    expect(ix.keys.slice(-2).map((k) => k.pubkey.toBase58())).to.deep.eq(
+      proof.map((p) => p.pubkey.toBase58())
+    );
+  });
+
+  it("appends the merkle proof on the iot branch too", async () => {
+    const proof = [
+      Keypair.generate().publicKey,
+      Keypair.generate().publicKey,
+    ].map((pubkey) => ({ pubkey, isSigner: false, isWritable: false }));
+
+    const ix = await buildOwnerPaidUpdateInstruction({
+      program: hemProgram(),
+      owner: OWNER,
+      entityKey: ENTITY_KEY,
+      merkleTree: MERKLE_TREE,
+      proofArgs: PROOF_ARGS,
+      remainingAccounts: proof,
+      update: { network: "iot", location: null, elevation: null, gain: null },
+    });
+
+    expect(ix.keys.slice(-2).map((k) => k.pubkey.toBase58())).to.deep.eq(
+      proof.map((p) => p.pubkey.toBase58())
+    );
+  });
+
+  it("targets the helium entity manager program", async () => {
+    const ix = await buildOwnerPaidUpdateInstruction({
+      program: hemProgram(),
+      owner: OWNER,
+      entityKey: ENTITY_KEY,
+      merkleTree: MERKLE_TREE,
+      proofArgs: PROOF_ARGS,
+      remainingAccounts: [],
+      update: { network: "mobile", location: null, deploymentInfo: null },
+    });
+    expect(ix.programId.toBase58()).to.eq(
+      "hemjuPXBpNvggtaUnN1MwT3wrdhttKEfosTcc2P9Pg8"
+    );
+  });
+});
+
+describe("hotspotInfoKey", () => {
+  it("derives the iot_info PDA for an iot hotspot", () => {
+    expect(hotspotInfoKey("iot", ENTITY_KEY).toBase58()).to.eq(
+      EXPECTED_IOT_INFO.toBase58()
+    );
+  });
+
+  it("derives the mobile_info PDA for a mobile hotspot", () => {
+    expect(hotspotInfoKey("mobile", ENTITY_KEY).toBase58()).to.eq(
+      EXPECTED_MOBILE_INFO.toBase58()
+    );
+  });
+});
+
+describe("assertNotDelegated", () => {
+  const errors = {
+    CONFLICT: (opts: { message: string }) => new Error(opts.message),
+  };
+  const owner = OWNER.toBase58();
+
+  it("refuses a hotspot delegated to another authority", () => {
+    const delegate = Keypair.generate().publicKey;
+    expect(() => assertNotDelegated({ owner, delegate, errors })).to.throw(
+      /delegated to another authority/
+    );
+  });
+
+  it("refuses when the delegate arrives as a base58 string", () => {
+    expect(() =>
+      assertNotDelegated({
+        owner,
+        delegate: Keypair.generate().publicKey.toBase58(),
+        errors,
+      })
+    ).to.throw(/delegated to another authority/);
+  });
+
+  it("allows an undelegated hotspot", () => {
+    expect(() =>
+      assertNotDelegated({ owner, delegate: null, errors })
+    ).to.not.throw();
+  });
+
+  it("allows a leaf whose delegate is the owner itself", () => {
+    expect(() =>
+      assertNotDelegated({ owner, delegate: OWNER, errors })
+    ).to.not.throw();
+  });
+});
+
+describe("assertDcCovered", () => {
+  const errors = {
+    INSUFFICIENT_FUNDS: (opts: {
+      message: string;
+      data: { required: number; available: number };
+    }) => Object.assign(new Error(opts.message), { data: opts.data }),
+  };
+
+  it("refuses when the owner holds less DC than the burn needs", () => {
+    expect(() =>
+      assertDcCovered({
+        required: new BN(1000),
+        available: BigInt(999),
+        errors,
+      })
+    ).to.throw(/Insufficient DC balance/);
+  });
+
+  it("allows an exact balance", () => {
+    expect(() =>
+      assertDcCovered({
+        required: new BN(1000),
+        available: BigInt(1000),
+        errors,
+      })
+    ).to.not.throw();
+  });
+
+  it("reports the shortfall in its data", () => {
+    try {
+      assertDcCovered({ required: new BN(7), available: BigInt(2), errors });
+      expect.fail("expected a refusal");
+    } catch (e) {
+      expect((e as { data: unknown }).data).to.deep.eq({
+        required: 7,
+        available: 2,
+      });
+    }
+  });
+});
+
+describe("locationAssertDcFee", () => {
+  const fee = new BN(500000);
+
+  it("charges the staking fee for a first location assert", () => {
+    expect(
+      locationAssertDcFee({
+        newLocation: new BN(10),
+        currentLocation: null,
+        stakingFee: fee,
+      }).toString()
+    ).to.eq("500000");
+  });
+
+  it("charges nothing when the asserted location is already stored", () => {
+    expect(
+      locationAssertDcFee({
+        newLocation: new BN(10),
+        currentLocation: new BN(10),
+        stakingFee: fee,
+      }).isZero()
+    ).to.eq(true);
+  });
+
+  it("charges the fee when the location moves", () => {
+    expect(
+      locationAssertDcFee({
+        newLocation: new BN(11),
+        currentLocation: new BN(10),
+        stakingFee: fee,
+      }).toString()
+    ).to.eq("500000");
+  });
+
+  it("charges nothing when no location is asserted", () => {
+    expect(
+      locationAssertDcFee({
+        newLocation: null,
+        currentLocation: new BN(10),
+        stakingFee: fee,
+      }).isZero()
+    ).to.eq(true);
+  });
+
+  it("charges nothing when the settings carry no fee", () => {
+    expect(
+      locationAssertDcFee({
+        newLocation: new BN(10),
+        currentLocation: null,
+        stakingFee: null,
+      }).isZero()
+    ).to.eq(true);
+  });
+});
+
+describe("locationStakingFee", () => {
+  it("uses the full-hotspot fee for a full IoT hotspot", () => {
+    const fee = locationStakingFee(
+      {
+        iotConfig: {
+          fullLocationStakingFee: new BN(100),
+          dataonlyLocationStakingFee: new BN(10),
+        },
+      },
+      { network: "iot", isFullHotspot: true }
+    );
+    expect(fee?.toString()).to.eq("100");
+  });
+
+  it("uses the data-only fee for a data-only IoT hotspot", () => {
+    const fee = locationStakingFee(
+      {
+        iotConfig: {
+          fullLocationStakingFee: new BN(100),
+          dataonlyLocationStakingFee: new BN(10),
+        },
+      },
+      { network: "iot", isFullHotspot: false }
+    );
+    expect(fee?.toString()).to.eq("10");
+  });
+
+  it("picks the mobile fee matching the hotspot's device type", () => {
+    const fee = locationStakingFee(
+      {
+        mobileConfigV2: {
+          feesByDevice: [
+            { deviceType: { cbrs: {} }, locationStakingFee: new BN(1) },
+            { deviceType: { wifiIndoor: {} }, locationStakingFee: new BN(2) },
+          ],
+        },
+      },
+      { network: "mobile", deviceType: { wifiIndoor: {} } }
+    );
+    expect(fee?.toString()).to.eq("2");
+  });
+
+  it("falls back to the v1 fee table", () => {
+    const fee = locationStakingFee(
+      {
+        mobileConfigV1: {
+          feesByDevice: [
+            { deviceType: { wifiOutdoor: {} }, locationStakingFee: new BN(9) },
+          ],
+        },
+      },
+      { network: "mobile", deviceType: { wifiOutdoor: {} } }
+    );
+    expect(fee?.toString()).to.eq("9");
+  });
+
+  it("returns null when the device type has no entry", () => {
+    expect(
+      locationStakingFee(
+        {
+          mobileConfigV2: {
+            feesByDevice: [
+              { deviceType: { cbrs: {} }, locationStakingFee: new BN(1) },
+            ],
+          },
+        },
+        { network: "mobile", deviceType: { wifiDataOnly: {} } }
+      )
+    ).to.eq(null);
+  });
+
+  it("returns null when the hotspot's device type is unreadable", () => {
+    expect(
+      locationStakingFee(
+        {
+          mobileConfigV2: {
+            feesByDevice: [
+              { deviceType: {}, locationStakingFee: new BN(1) },
+            ],
+          },
+        },
+        { network: "mobile", deviceType: {} }
+      )
+    ).to.eq(null);
+  });
+
+  it("returns null for an IoT hotspot on mobile settings", () => {
+    expect(
+      locationStakingFee(
+        { mobileConfig: { fullLocationStakingFee: new BN(5) } },
+        { network: "iot", isFullHotspot: true }
+      )
+    ).to.eq(null);
+  });
+});
+
+describe("resizeTopUpLamports", () => {
+  it("charges the difference when the account is short of rent", () => {
+    expect(resizeTopUpLamports(2_000_000, 1_500_000)).to.eq(500_000);
+  });
+
+  it("charges nothing when the account is already funded", () => {
+    expect(resizeTopUpLamports(2_000_000, 2_000_000)).to.eq(0);
+  });
+
+  it("charges nothing when the account shrinks below its balance", () => {
+    expect(resizeTopUpLamports(1_000_000, 2_000_000)).to.eq(0);
+  });
+});
+
+describe("withPreservedWifiSerial", () => {
+  const existing = { wifiInfoV0: { serial: "SERIAL-123" } };
+
+  it("carries the stored serial into an update that omits it", () => {
+    expect(
+      withPreservedWifiSerial({ wifiInfoV0: { serial: null } }, existing)
+        .wifiInfoV0?.serial
+    ).to.eq("SERIAL-123");
+  });
+
+  it("carries the stored serial into an update that sends an empty one", () => {
+    expect(
+      withPreservedWifiSerial({ wifiInfoV0: { serial: "" } }, existing)
+        .wifiInfoV0?.serial
+    ).to.eq("SERIAL-123");
+  });
+
+  it("keeps a serial the update does supply", () => {
+    expect(
+      withPreservedWifiSerial({ wifiInfoV0: { serial: "NEW-456" } }, existing)
+        .wifiInfoV0?.serial
+    ).to.eq("NEW-456");
+  });
+
+  it("leaves the serial unset when nothing is stored", () => {
+    expect(
+      withPreservedWifiSerial({ wifiInfoV0: { serial: null } }, undefined)
+        .wifiInfoV0?.serial
+    ).to.eq(null);
+  });
+
+  it("passes a non-wifi deployment info through untouched", () => {
+    const cbrs = { cbrsInfoV0: { radioInfos: [] } };
+    expect(withPreservedWifiSerial(cbrs, existing)).to.deep.eq(cbrs);
+  });
+});
+
+describe("on-chain unit conversion", () => {
+  it("stores gain as tenths of a dBi", () => {
+    expect(toOnChainGain(1.2)).to.eq(12);
+  });
+
+  it("truncates rather than rounds a fractional gain", () => {
+    expect(toOnChainGain(1.29)).to.eq(12);
+  });
+
+  it("leaves an unset gain unset", () => {
+    expect(toOnChainGain(undefined)).to.eq(null);
+  });
+
+  it("stores elevation as whole meters", () => {
+    expect(toOnChainElevation(12.7)).to.eq(12);
+  });
+
+  it("leaves an unset elevation unset", () => {
+    expect(toOnChainElevation(undefined)).to.eq(null);
+  });
+});


### PR DESCRIPTION
Three related changes to who pays for a transaction, who is allowed to ask for
one, and what the service verifies before it acts.

## Owner-paid updates (`20ac79e`)

`POST /hotspots/update-info` relays the onboarding server, which co-signs so the
maker burns the DC. A caller asserting on behalf of the owner needs the owner to
pay. `feePayer` defaults to `"maker"` and that path is unchanged; `"owner"`
builds `UpdateIotInfoV0` / `UpdateMobileInfoV0` here, with `payer`,
`dc_fee_payer` and `dc_burner` all the owner, and accounts for the DC burn and
any `mobile_info` resize in the balance check and reported fee. A hotspot whose
leaf delegate differs from its owner is refused with a 409, since the update
requires `owner == delegate == hotspot_owner`.

## Third-party fee payer on transfers (`754e1c1`)

`POST /tokens/transfer` had one `walletAddress` acting as both source authority
and fee payer, so a caller draining a wallet to zero could not use it: the
wallet has no SOL left for the fee or for the recipient's ATA rent. The optional
`feePayer` keeps `walletAddress` as the authority and moves the fee and the ATA
funding to a separate account. Absent, behaviour is unchanged.

Two consequences worth knowing. The transaction then requires **two
signatures**, and the response envelope has no field announcing that — a caller
knows because it sent `feePayer`. And `submit` derives a batch's payer from
account 0, so these transfers are recorded under the fee payer rather than the
wallet. `feePayer` combined with `multisig` is refused: in propose mode the
vault is the authority and the proposing member is already the outer fee payer,
so both roles are taken.

## Verify and authorize before acting (`6be95fd`)

From a security review of the service. Each was confirmed in source.

**The service spent its own signing key on unverified input.** Both claim
endpoints loaded `FEE_PAYER_WALLET_PATH` and signed before checking the
delegate signature they were handed, so any caller could make the service sign
and pay for a transaction the program would reject. The signature is now
verified against the pack owner over the message the program builds, before the
key is loaded, and the approval window is bounded by the program's own
`MAX_CLAIM_APPROVAL_SECONDS`.

**`updateRewardsDestination`, `createSplit` and `deleteSplit` had no ownership
check**, while four sibling endpoints each hand-rolled one. All six now call a
single `assertAssetOwner`. Without it the service assembled a ready-to-sign,
caller-funded transaction redirecting any hotspot's future rewards. The
signature of the true owner was always still required, so this was never direct
theft; it removes the service as a factory for them. `createSplit` and
`deleteSplit` also now read the asset on-chain rather than trusting a database
row that can lag.

**Submission attributed a batch to an unverified fee payer.** `payer` came from
account 0 of the submitted bytes with no signature check, and submission uses
`skipPreflight`, so history rows could be written against any wallet with
attacker-chosen metadata. The fee payer's signature is now verified over the
message. It checks that signature specifically rather than the signature count,
so the two-signature transfers above still pass.

**Three visibility fixes.** The swap output account now appears in the
description, metadata and tag, so two swaps differing only in destination no
longer produce the same tag. `dc mint` names a recipient that differs from the
owner. And the request logger moved from `JSON.stringify(input)` to a
scalar-only allowlist, having been writing bank account and routing numbers to
stdout.

## Coverage

179 unit tests, from a baseline of 122. Guards are mutation-tested one at a
time: 16 of 16 caught for the transfer fee payer, 24 of 30 for owner-paid
updates, 23 of 25 here.

The gaps are stated rather than smoothed over. The six uncaught on owner-paid
updates are handler consumption sites no unit test can reach; an e2e case covers
them and has not been run. The two uncaught here are equivalent mutations,
measured across 264 input combinations with zero behavioural difference rather
than assumed. And because `@/` aliases do not resolve under the unit runner,
the ownership and signature guards are pinned at their call sites by a source
scan, which would not notice a guard called with the wrong arguments.

No part of this has been exercised against a live cluster.

## Also worth a maintainer's decision

A swap `destinationTokenAccount` not owned by the signer is now visible but
still permitted; refusing it is a policy call. `reward-contract/delete.ts`
compares against the reward contract's delegate rather than the cNFT owner, so
it was deliberately left out of the ownership consolidation. And this branch
changes the published `@helium/blockchain-api` client package without a
changeset.
