### PR TITLE
Gate typecheck and lint for blockchain-api

### DIFF
--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -1,6 +1,9 @@
 name: Blockchain API E2E Tests
 
 on:
+  # These path filters gate every job below, the 17-job e2e matrix included.
+  # The typecheck step resolves the workspace SDKs (spl-utils, the *-sdk
+  # packages, idls) too, so a change confined to those does not run it.
   push:
     branches: [master]
     paths:
@@ -38,8 +41,10 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # Unit tests need no chain, no secrets and no surfpool, so they run as their
-  # own job and report in about a minute rather than waiting on the matrix.
+  # Unit tests, typecheck and lint need no chain, no secrets and no surfpool,
+  # so they run as their own job and report in about a minute rather than
+  # waiting on the matrix. Tests run first so a lint or type failure cannot
+  # suppress the test signal.
   unit-tests:
     needs: build-idls
     runs-on: ubuntu-latest
@@ -61,6 +66,12 @@ jobs:
 
       - name: Run unit tests
         run: pnpm test:unit
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint:check
 
   e2e-tests:
     needs: build-idls

--- a/packages/blockchain-api/package.json
+++ b/packages/blockchain-api/package.json
@@ -16,6 +16,8 @@
     "start": "next start",
     "format:fix": "prettier --check --write \"src/**/*.{js,ts,tsx}\"",
     "lint": "pnpm run format:fix && eslint src/",
+    "lint:check": "eslint src tests",
+    "typecheck": "tsc --noEmit",
     "background-service": "node scripts/start-background-service.js",
     "test:e2e": "NODE_OPTIONS='--max-old-space-size=8192' DOTENV_CONFIG_PATH=.env.test mocha -r dotenv/config -r @swc-node/register \"tests/e2e/**/*.test.ts\" --timeout 100000",
     "test:e2e:file": "NODE_OPTIONS='--max-old-space-size=8192' DOTENV_CONFIG_PATH=.env.test mocha -r dotenv/config -r @swc-node/register --timeout 100000",

--- a/packages/blockchain-api/tests/e2e/claim-hotspot-rewards.test.ts
+++ b/packages/blockchain-api/tests/e2e/claim-hotspot-rewards.test.ts
@@ -86,7 +86,7 @@ describe("single-hotspot claim rewards", () => {
           network,
         });
         const hotspot = pending.byHotspot.find(
-          (h) => BigInt(h.pending.claimable.amount) > 0n
+          (h) => BigInt(h.pending.claimable.amount) > BigInt(0)
         );
         if (hotspot) {
           target = { payer, network, entityPubKey: hotspot.hotspotPubKey };
@@ -104,7 +104,10 @@ describe("single-hotspot claim rewards", () => {
     const walletAddress = payer.publicKey.toBase58();
 
     const before = await claimableFor(walletAddress, network, entityPubKey);
-    expect(before).to.be.greaterThan(0n);
+    expect(
+      before > BigInt(0),
+      `expected claimable rewards on ${entityPubKey}, got ${before}`
+    ).to.eq(true);
 
     const result = await client.hotspots.claimHotspotRewards({
       entityPubKey,
@@ -125,6 +128,9 @@ describe("single-hotspot claim rewards", () => {
 
     // After claiming, the hotspot's claimable rewards should have dropped.
     const remaining = await claimableFor(walletAddress, network, entityPubKey);
-    expect(remaining).to.be.lessThan(before);
+    expect(
+      remaining < before,
+      `expected claimable to drop below ${before}, got ${remaining}`
+    ).to.eq(true);
   });
 });

--- a/packages/blockchain-api/tests/e2e/governance.test.ts
+++ b/packages/blockchain-api/tests/e2e/governance.test.ts
@@ -1,3 +1,4 @@
+import { BorshInstructionCoder } from "@coral-xyz/anchor";
 import { delegatedPositionKey } from "@helium/helium-sub-daos-sdk";
 import { proxyAssignmentKey } from "@helium/nft-proxy-sdk";
 import { HNT_MINT, IOT_MINT, MOBILE_MINT } from "@helium/spl-utils";
@@ -1222,6 +1223,11 @@ describe("governance", () => {
     }): Promise<string[]> {
       const { vsrProgram, provider } = await getPrograms(ctx);
       const hplCronsProgram = await initHplCrons(provider);
+      // `Program.coder.instruction` is typed as the `InstructionCoder`
+      // interface, which declares only `encode`. Build the Borsh coder from
+      // each program's IDL to get `decode`.
+      const vsrCoder = new BorshInstructionCoder(vsrProgram.idl);
+      const hplCronsCoder = new BorshInstructionCoder(hplCronsProgram.idl);
       const names: string[] = [];
       for (const t of txData.transactions) {
         const tx = VersionedTransaction.deserialize(
@@ -1232,10 +1238,10 @@ describe("governance", () => {
           const programId = keys[ix.programIdIndex];
           const data = Buffer.from(ix.data);
           if (programId.equals(vsrProgram.programId)) {
-            const decoded = vsrProgram.coder.instruction.decode(data);
+            const decoded = vsrCoder.decode(data);
             if (decoded) names.push(decoded.name);
           } else if (programId.equals(hplCronsProgram.programId)) {
-            const decoded = hplCronsProgram.coder.instruction.decode(data);
+            const decoded = hplCronsCoder.decode(data);
             if (decoded) names.push(decoded.name);
           }
         }


### PR DESCRIPTION
TypeScript in this repo is gated by the blockchain-api unit suite and the
surfpool e2e matrix. Nothing runs `eslint` or `tsc`: `turbo.json` declares a
`lint` task no workflow invokes, no package defines a typecheck script, and of
the three packages with a `lint` script one shells out to `prettier --write`
and another has no eslint config.

This adds both checks for `packages/blockchain-api`.

## Scripts

`lint:check` is `eslint src tests`, and `typecheck` is `tsc --noEmit`. They are
separate from the existing `lint`, which runs `format:fix` (`prettier --check
--write`) and so rewrites files; a check that mutates the tree cannot gate
anything. Lint covers `tests` as well as `src` because it is already clean
there, so test helpers are held to the same bar.

## Where they run

Both are steps on the existing `unit-tests` job rather than new jobs, so no
required-check names change and neither needs its own `build-idls` dependency or
artifact download. They run after the unit suite so a lint finding cannot
suppress the test signal.

## The six type errors

`tsc --noEmit` reported six errors, all in e2e tests, and they are fixed at the
source rather than by raising `target` to ES2020 — that would change emitted
output for the whole application to satisfy three lines in one test.

In `claim-hotspot-rewards.test.ts`, `0n` literals become `BigInt(0)`, and two
assertions that passed a bigint to chai's `greaterThan`/`lessThan` (typed
`number | Date`) now compare directly and carry their own failure messages.

In `governance.test.ts`, `program.coder.instruction` is typed as the
`InstructionCoder` interface, which declares only `encode`. The decode path now
builds a `BorshInstructionCoder` from each program's IDL once, outside the
per-instruction loop. That is the same object `program.coder.instruction`
already is at runtime, so this needs no cast and changes no behavior.

## A gap in the trigger

The workflow's `paths:` filter covers `packages/blockchain-api/**` and
`packages/blockchain-api-client/**`, but `tsc` resolves the workspace SDKs too.
A change confined to `spl-utils`, an `*-sdk` package or `idls` can break the
typecheck without triggering it. That filter gates every job in the file,
including the 17-job e2e matrix, so widening it would fan that matrix out over
every SDK change. The filter is unchanged and both facts are recorded in a
comment above `on:`. Splitting the cheap checks into their own workflow with a
broader filter is the alternative if the matrix cost is acceptable.

Note that `tests.yaml` already builds a `packages/blockchain-api` Docker image on
every PR with no path filter, and that build is green today despite the six type
errors — it does not typecheck the tests.
