### PR TITLE
fix: remove closed wormhole guardian set accounts from localnet fixtures

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -167,22 +167,6 @@ address = "GPQNABq6s63uqzHRwZN9e2GcxtzG4yLP5AnJer7DkB9E"  # State controller IDL
 filename = "accounts/GPQNABq6s63uqzHRwZN9e2GcxtzG4yLP5AnJer7DkB9E.json"
 
 [[test.validator.account]]
-address = "5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn"  # Wormhole guardian set index 4
-filename = "accounts/5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn.json"
-
-[[test.validator.account]]
-address = "HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni"  # Wormhole guardian set index 5
-filename = "accounts/HTczusLJSAhMJKYrxLjSUUyW7YDsBuyfBG8Tj1KJsgni.json"
-
-[[test.validator.account]]
-address = "HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf"  # Wormhole guardian set index 6
-filename = "accounts/HstYgN21fgNmutTVXjBw54n4ryvP3WrCFbMAjnbdbTzf.json"
-
-[[test.validator.account]]
-address = "6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D"  # Wormhole guardian set index 7
-filename = "accounts/6GaHgiaQg9Pg346xHq9m7vQ9rJtnH83gQKqJoiAxQa7D.json"
-
-[[test.validator.account]]
 address = "DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b"
 filename = "accounts/DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b.json"
 


### PR DESCRIPTION
## Problem

Build Anchor fails on every PR since the localnet-accounts weekly cache key rolled to 2026-36: `scripts/fetch-localnet-accounts.sh` can no longer dump the Wormhole guardian set accounts listed in `Anchor.toml`.

Pyth closed the guardian set accounts (indexes 4–7) on the legacy wormhole deploy `HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ` (verified null on both the public and Helium RPCs), and unkeyed Hermes now returns `unauthorized`.

## Fix

Remove the four dead `[[test.validator.account]]` entries. Nothing in the test suite posts VAAs against these guardian sets — tests only read price-update accounts cloned from mainnet (`He5mh…`, `4Ddm…`, `6HAuq…`), which still exist. The wormhole program itself stays in `[[test.genesis]]`.

Verified locally: `./scripts/fetch-localnet-accounts.sh` completes cleanly for all 25 remaining entries.

## Heads-up (not addressed here)

The pro crank instance (rec2HH receiver via the `HDw2E7P8…` wormhole deploy) is unaffected and posting fresh updates to `He5mh`/`6HAuq`. But the legacy rec5-owned feed `4Ddm…` has had no publish since 2026-08-21, and with the `HDwcJ…` guardian sets closed, a legacy-default `tuktuk-pyth-service` instance can no longer verify VAAs at all.