### PR TITLE
chore(helium-sub-daos): make the top-up mint-once gate falsifiable

### DIFF
--- a/programs/helium-sub-daos/src/backstop.rs
+++ b/programs/helium-sub-daos/src/backstop.rs
@@ -289,6 +289,27 @@ pub fn staker_overflow(deployer_pool: u64, deployer_cap_hnt: u64) -> u64 {
   deployer_pool.saturating_sub(deployer_cap_hnt)
 }
 
+/// Whether this `issue_rewards_v0` pass mints the epoch's backstop top-up.
+///
+/// The top-up is a DAO-level amount, sized once by `calculate_utility_score_v0` and recorded
+/// once in `total_rewards`, so exactly one pass may mint it. `is_mobile` selects that pass in
+/// production. Under a `TESTING` build `is_mobile` is every sub-DAO, so the epoch's first pass
+/// is used instead: N sub-DAOs would otherwise mint N top-ups against the one the epoch
+/// recorded. `num_rewards_issued` is incremented after the mints, so 0 identifies the first.
+///
+/// In production the Mobile pass mints it whatever position it settles in: `issue_rewards_v0`
+/// is permissionless and the passes may arrive in any order.
+pub fn mints_top_up(is_mobile: bool, num_rewards_issued: u32) -> bool {
+  mints_top_up_with(is_mobile, crate::TESTING, num_rewards_issued)
+}
+
+/// The same decision over an explicit `testing`, which only the tests below supply: `TESTING`
+/// is false under `cargo test`, so the first-pass arm is reachable no other way. Private, so
+/// the value production runs on is the constant `mints_top_up` closes over.
+fn mints_top_up_with(is_mobile: bool, testing: bool, num_rewards_issued: u32) -> bool {
+  is_mobile && (!testing || num_rewards_issued == 0)
+}
+
 #[cfg(test)]
 // HNT amounts are written as whole-HNT then 8 decimals (e.g. 1_644_00000000) for
 // readability against the spec's HNT figures; same precedent as the treasury mint
@@ -509,6 +530,64 @@ mod tests {
     let pool = 10_000_00000000;
     assert_eq!(staker_overflow(pool, 1), pool - 1);
     assert!(staker_overflow(pool, 1) <= pool);
+  }
+
+  #[test]
+  fn the_mobile_pass_mints_whatever_position_it_settles_in() {
+    // issue_rewards_v0 is permissionless with no ordering guarantee, so in production the
+    // Mobile pass may be the epoch's first or arrive after any number of others. 0 is the
+    // ordinary mainnet case and is asserted here rather than only through the wrapper.
+    for already_issued in [0u32, 1, 2, 7] {
+      assert!(
+        mints_top_up_with(true, false, already_issued),
+        "num_rewards_issued {already_issued}: the Mobile pass mints the top-up whatever \
+         order it arrives in"
+      );
+    }
+  }
+
+  #[test]
+  fn only_the_first_pass_mints_under_testing() {
+    // Under TESTING every sub-DAO is a Mobile pass, and the epoch records one top-up, so
+    // one pass mints it: the first.
+    assert!(mints_top_up_with(true, true, 0), "the first pass mints it");
+    for already_issued in [1u32, 2, 7] {
+      assert!(
+        !mints_top_up_with(true, true, already_issued),
+        "num_rewards_issued {already_issued}: later passes must not mint it again"
+      );
+    }
+  }
+
+  #[test]
+  fn the_wrapper_passes_the_build_s_own_testing_value() {
+    // mints_top_up closes TESTING over, so this is what pins that it forwards the build's
+    // own value. Each arm asserts what its build promises, and each catches one substituted
+    // literal: the default build catches `true`, a TESTING build catches `false`. CI runs
+    // `cargo test` without TESTING, so the second arm is exercised only locally.
+    assert!(mints_top_up(true, 0), "the first pass always mints it");
+    if crate::TESTING {
+      assert!(
+        !mints_top_up(true, 3),
+        "under TESTING only the epoch's first pass mints it"
+      );
+    } else {
+      assert!(
+        mints_top_up(true, 3),
+        "in production the Mobile pass mints it whatever order it arrives in"
+      );
+    }
+    assert!(!mints_top_up(false, 0), "and still only the Mobile pass");
+  }
+
+  #[test]
+  fn a_non_mobile_pass_never_mints() {
+    // The top-up supports Mobile data deployers, so no other sub-DAO's pass carries it --
+    // in production that is the whole of the gate.
+    for already_issued in [0u32, 1, 7] {
+      assert!(!mints_top_up_with(false, false, already_issued));
+      assert!(!mints_top_up_with(false, true, already_issued));
+    }
   }
 
   #[test]

--- a/programs/helium-sub-daos/src/instructions/issue_rewards_v0.rs
+++ b/programs/helium-sub-daos/src/instructions/issue_rewards_v0.rs
@@ -235,19 +235,9 @@ pub fn handler(ctx: Context<IssueRewardsV0>, args: IssueRewardsArgsV0) -> Result
   //   key off the DAO-level delegation_rewards_issued. A zero ceiling (no carrier burn
   //   this epoch, or no price oracle) disables it.
   let is_mobile = TESTING || ctx.accounts.sub_dao.key() == crate::backstop::MOBILE_SUB_DAO;
-  // The top-up is a DAO-level amount, sized once per epoch and recorded once in
-  // total_rewards, so exactly one pass may mint it. In production is_mobile already selects
-  // one pass. Under TESTING it selects every sub-DAO, so pin it to the epoch's first pass
-  // there (num_rewards_issued is incremented after the mints below): N sub-DAOs would
-  // otherwise mint N top-ups against the one the epoch recorded.
-  //
-  // The `!TESTING ||` is load-bearing and must not be simplified away. This instruction is
-  // permissionless and the passes may arrive in any order, so in production the Mobile pass
-  // is not necessarily the first: gating on num_rewards_issued alone would mint no top-up
-  // whenever any other sub-DAO settled first, silently under-delivering the floor against a
-  // total_rewards that already counted it.
+  // Exactly one pass per epoch mints the DAO-level top-up; mints_top_up decides which.
   let is_top_up_pass =
-    is_mobile && (!TESTING || ctx.accounts.dao_epoch_info.num_rewards_issued == 0);
+    crate::backstop::mints_top_up(is_mobile, ctx.accounts.dao_epoch_info.num_rewards_issued);
   let top_up = if is_top_up_pass { backstop_top_up } else { 0 };
   // What the escrow mint would be before the cap redirect: the deployer portion of the
   // split (rewards_amount - delegator slice) plus the direct top-up.


### PR DESCRIPTION
Covers the gate deciding which `issue_rewards_v0` pass mints the epoch's DAO-level backstop top-up. Every suite issues rewards for a single sub-DAO, so `num_rewards_issued` is 0 on the only pass and the condition is a no-op — removing it changes no test. #1270 records the gap; this closes it.

No behaviour change: the expression and the constant it reads are the ones already in `issue_rewards_v0`.

## Shape

```rust
pub fn mints_top_up(is_mobile: bool, num_rewards_issued: u32) -> bool {
  mints_top_up_with(is_mobile, crate::TESTING, num_rewards_issued)
}

fn mints_top_up_with(is_mobile: bool, testing: bool, num_rewards_issued: u32) -> bool {
  is_mobile && (!testing || num_rewards_issued == 0)
}
```

`TESTING` is `option_env!("TESTING").is_some()`, so it is false under `cargo test` and the first-pass arm is reachable no other way. `mints_top_up_with` is that seam and is private, so the value production runs on is the constant `mints_top_up` closes over rather than anything a caller supplies.

## Coverage

Mutations applied one at a time, restoring from a pre-mutation copy and confirming the diff is byte-identical afterwards. Each reddens the named test with the count back at the 40 baseline.

| Mutation | Test that fails |
| --- | --- |
| drop `is_mobile` | `a_non_mobile_pass_never_mints` |
| invert `!testing` | `only_the_first_pass_mints_under_testing` |
| drop the testing conjunct | `only_the_first_pass_mints_under_testing` |
| `n == 0` → `n <= 1` | `only_the_first_pass_mints_under_testing` |
| literal for `crate::TESTING` | `the_wrapper_passes_the_build_s_own_testing_value` |

The suite is green under both `cargo test` and `TESTING=true cargo test`.

## Coverage limits, stated

The wrapper test branches on `crate::TESTING`, and each arm catches one substituted literal: the default build catches `true`, a TESTING build catches `false`. CI runs `cargo test` without `TESTING`, so the second arm is exercised only locally. Mechanizing it means a second `cargo test --lib` step under `TESTING`, which also flips `utils.rs:66` and the `TESTING ||` relaxations across the suite — a workflow change, kept out of this one.

Passing a literal `0` for `num_rewards_issued` in the wrapper is unfalsifiable in the default build, where `!testing` short-circuits the conjunct so the argument is never read; it is caught under `TESTING=true`.

The call site itself is pinned only by the localnet `backstop floor delivery` test, which collapses if the top-up stops being minted. Nothing catches it being minted on a pass that should not carry it, because no suite runs two sub-DAO passes in one epoch and checks the DAO-level total. That is unchanged by this PR and is the reason the unit tests here are the only thing pinning the mint-once rule at all.

## Scope

`get_percent_at` carries an unrelated bounds-check gap, reachable only through the decommissioned `hst_emission_schedule` and failing closed. Left for its own change.
