### PR TITLE
fix(tests): derive the sus SOL-change expectation from the chain

### DIFF
--- a/tests/sus.ts
+++ b/tests/sus.ts
@@ -14,6 +14,7 @@ import {
   SPL_NOOP_PROGRAM_ID,
 } from "@solana/spl-account-compression";
 import {
+  ACCOUNT_SIZE,
   createAssociatedTokenAccountIdempotentInstruction,
   createTransferInstruction,
   getAssociatedTokenAddressSync,
@@ -85,9 +86,20 @@ describe("sus", () => {
     expect(writableAccounts[2].owner?.toBase58()).to.eq(SUS.toBase58());
     expect(writableAccounts[2].metadata?.decimals).to.eq(8);
 
-    console.log(balanceChanges[0]);
+    // SUS funds the token account this transaction creates and pays the fee, so its SOL
+    // change is the rent-exempt minimum for that account plus the fee. Both are cluster
+    // parameters read from the chain rather than written here: the rent-exempt minimum for a
+    // token account is a devnet setting that moves, and a literal cannot track it. `sus`
+    // reports the change it observes in simulation, so the two are computed independently.
+    const [rentExemption, feeResponse] = await Promise.all([
+      connection.getMinimumBalanceForRentExemption(ACCOUNT_SIZE),
+      connection.getFeeForMessage(transaction.compileMessage()),
+    ]);
+    expect(feeResponse.value, "fee for the simulated message").to.not.be.null;
+    const expectedSolChange = BigInt(-(rentExemption + feeResponse.value!));
+
     expect(balanceChanges[0].owner.toBase58()).to.eq(SUS.toBase58());
-    expect(balanceChanges[0].amount).to.eq(BigInt(-2044280));
+    expect(balanceChanges[0].amount).to.eq(expectedSolChange);
 
     expect(balanceChanges[1].owner.toBase58()).to.eq(
       PublicKey.default.toBase58()


### PR DESCRIPTION
`tests/sus.ts` asserts the SOL a fee payer spends creating a token account against a literal, `-2044280`. That figure is a rent-exempt minimum plus a fee, and the rent-exempt minimum is a cluster parameter: devnet returns 1,855,569 for a 165-byte token account where the literal assumes 2,039,280.

```
getMinimumBalanceForRentExemption(165) -> 1855569   solana-rpc.web.test-helium.com
getMinimumBalanceForRentExemption(165) -> 1855569   api.devnet.solana.com
```

So the test fails on every branch regardless of its diff, with the same `expected -1860569n to equal -2044280n` — confirmed on two unrelated branches an hour and a half apart, which is what distinguishes a stale fixture from a flake.

## The change

Read both terms from the chain rather than writing them here:

```ts
const [rentExemption, feeResponse] = await Promise.all([
  connection.getMinimumBalanceForRentExemption(ACCOUNT_SIZE),
  connection.getFeeForMessage(transaction.compileMessage()),
]);
const expectedSolChange = BigInt(-(rentExemption + feeResponse.value!));
```

The assertion keeps its content because the two sides are computed independently: `sus` reports the balance change it observes in simulation, while the expectation is built from the rent and fee the cluster reports.

## Verified

Run against live devnet, passing. Then mutated:

| Mutation | Result |
| --- | --- |
| substitute the old `2039280` literal | fails — this test would have caught the drift |
| drop the fee term | fails — the fee term is load-bearing |
| assert the observed value against itself | passes — the control, showing a tautology would slip through and this assertion is not one |

The fee is also read rather than assumed, so a base-fee change cannot reintroduce the same class of failure.
