### PR TITLE
fanout: attribute vault inflow at the share count that was live

### DIFF
--- a/.changeset/fanout-share-accounting.md
+++ b/.changeset/fanout-share-accounting.md
@@ -1,0 +1,5 @@
+---
+"@helium/idls": patch
+---
+
+Fanout: fold a vault arrival into the accumulator at the staked-share count in force when it is folded, and seed a new voucher's watermark from `fanout.total_inflow` rather than the token account balance, so joining does not dilute the vouchers already staked. A fold takes as much of an arrival as the accumulator has room for and leaves the rest pending. `unstake_v0` removes `voucher.shares` from `total_staked_shares` and releases what the closing voucher was owed back to the vouchers that remain. `initialize_fanout_v0` starts the accumulator empty, so a balance already in the vault is the first fold's arrival. Adds `TooManyShares`, `InvalidDestination`, `ZeroStake` and `NoShares`.

--- a/programs/fanout/README.md
+++ b/programs/fanout/README.md
@@ -1,8 +1,25 @@
 # fanout
 
-Splits revenue that lands in a shared token account across holders of pro-rata membership NFTs. Holders can stake HNT to mint voucher NFTs, collect distributions against their voucher, and burn the voucher to withdraw their stake.
+Splits revenue that lands in a shared token account across staked membership positions. Holders stake membership tokens to mint a voucher NFT, collect distributions against that voucher, and burn the voucher to withdraw their stake.
 
 Used for multi-party revenue splits where each participant's share is transferable. For small, fixed splits prefer the cheaper [mini-fanout](../mini-fanout).
+
+## How a distribution is sized
+
+`fanout.total_inflow` is a lifetime accumulator scaled to the full share base, `fanout.last_snapshot_amount` is the vault balance already folded into it, and each voucher carries a watermark in the same unit. `distribute_v0` pays a voucher the accumulator's growth since that watermark, times the voucher's fraction of `total_shares`.
+
+Revenue is split across **staked** shares, not across all shares. Every arrival is scaled by `total_shares / total_staked_shares`, so the staked vouchers together take all of it and unstaked shares take none. A voucher holding a tenth of `total_shares` while it is the only staked position receives the whole arrival, not a tenth of it.
+
+## Behaviour to know before building on this
+
+- **Joining does not dilute the vouchers already staked.** `stake_v0` folds the pending balance into the accumulator at the previous staked-share count before the new shares join.
+- **Unstaking forfeits to the vouchers that remain.** A voucher closes without collecting what it is owed, and `unstake_v0` releases that amount back so the next fold pays it to the vouchers still staked. Collect first if you want it yourself.
+- **Revenue that arrives before the first stake goes to the first staker.** With nothing staked there is no share count to scale by, so the balance waits for the first fold. That includes a balance already sitting in the vault when `initialize_fanout_v0` runs. Stake before pointing revenue at the vault.
+- **An arrival is folded only as far as the accumulator has room for.** The snapshot advances by exactly the part that was folded and the remainder stays pending, so the fold is callable at every share ratio rather than refusing once the scaling grows large.
+- **`total_shares` is fixed** at the membership mint's supply when `initialize_fanout_v0` runs, and that supply must be non-zero. Staked shares in aggregate cannot exceed it, and `stake_v0` returns `TooManyShares` for a stake that would. Minting more membership tokens does not raise the cap, though tokens minted later can be staked while the aggregate stays under it.
+- **A stake is at least one share.** `stake_v0` returns `ZeroStake` otherwise, so every voucher in the membership collection is a real position.
+- **`fanout.authority` is stored at creation and never read again.** `initialize_fanout_v0` sends the collection NFT to that account's associated token account; after that, no instruction consults the field. There is no admin, no pause, and no route for tokens to leave the vault except `distribute_v0`, which will not pay into the vault itself.
+- **Dust below one token per distribution is carried** on the voucher in `total_dust` at twelve extra decimal places and paid out once it reaches a whole unit.
 
 SDK: [`@helium/fanout-sdk`](../../packages/fanout-sdk). Metadata: [`fanout-metadata-service`](../../packages/fanout-metadata-service).
 

--- a/programs/fanout/src/errors.rs
+++ b/programs/fanout/src/errors.rs
@@ -4,4 +4,12 @@ use anchor_lang::prelude::*;
 pub enum ErrorCode {
   #[msg("Error in arithmetic")]
   ArithmeticError,
+  #[msg("Staked shares would exceed the fanout's total shares")]
+  TooManyShares,
+  #[msg("A distribution must leave the fanout's token account")]
+  InvalidDestination,
+  #[msg("A stake must be at least one share")]
+  ZeroStake,
+  #[msg("A fanout needs a membership mint with a supply to divide")]
+  NoShares,
 }

--- a/programs/fanout/src/instructions/distribute_v0.rs
+++ b/programs/fanout/src/instructions/distribute_v0.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
   token::{self, Mint, Token, TokenAccount, Transfer},
 };
 
-use crate::{fanout_seeds, FanoutV0, FanoutVoucherV0};
+use crate::{errors::ErrorCode, fanout_seeds, FanoutV0, FanoutVoucherV0, TWELVE_PREC};
 
 #[derive(Accounts)]
 pub struct DistributeV0<'info> {
@@ -27,6 +27,7 @@ pub struct DistributeV0<'info> {
     payer = payer,
     associated_token::mint = fanout_mint,
     associated_token::authority = owner,
+    constraint = to_account.key() != token_account.key() @ ErrorCode::InvalidDestination,
   )]
   pub to_account: Box<Account<'info, TokenAccount>>,
   #[account(
@@ -61,45 +62,11 @@ impl<'info> DistributeV0<'info> {
   }
 }
 
-const TWELVE_PREC: u128 = 1_000000000000;
-
 pub fn handler(ctx: Context<DistributeV0>) -> Result<()> {
   let curr_balance = ctx.accounts.token_account.amount;
-  let inflow = curr_balance
-    .checked_sub(ctx.accounts.fanout.last_snapshot_amount)
-    .unwrap();
-  let tss = ctx.accounts.fanout.total_staked_shares;
-  let shares_diff = ctx.accounts.fanout.total_shares.checked_sub(tss).unwrap();
-  let unstaked_correction = (inflow as u128)
-    .checked_mul(shares_diff as u128)
-    .unwrap()
-    .checked_div(tss as u128)
-    .unwrap() as u64;
+  ctx.accounts.fanout.accrue_inflow(curr_balance)?;
 
-  ctx.accounts.fanout.total_inflow = ctx
-    .accounts
-    .fanout
-    .total_inflow
-    .checked_add(inflow)
-    .unwrap()
-    .checked_add(unstaked_correction)
-    .unwrap();
-
-  let last_inflow = ctx.accounts.voucher.total_inflow;
-  let total_shares = ctx.accounts.fanout.total_shares;
-  let inflow_diff = ctx
-    .accounts
-    .fanout
-    .total_inflow
-    .checked_sub(last_inflow)
-    .unwrap();
-  let dist_amount = u128::from(inflow_diff)
-    .checked_mul(TWELVE_PREC) // Add 12 precision on dust
-    .unwrap()
-    .checked_mul(ctx.accounts.voucher.shares as u128)
-    .unwrap()
-    .checked_div(total_shares as u128)
-    .unwrap();
+  let dist_amount = ctx.accounts.fanout.owed_to(&ctx.accounts.voucher)?;
 
   let mut dist_amount_u64: u64 = dist_amount
     .checked_div(TWELVE_PREC)
@@ -137,7 +104,14 @@ pub fn handler(ctx: Context<DistributeV0>) -> Result<()> {
     dist_amount_u64,
   )?;
 
-  ctx.accounts.fanout.last_snapshot_amount = curr_balance.checked_sub(dist_amount_u64).unwrap();
+  // The snapshot tracks the balance that has already been folded into
+  // `total_inflow`, so it drops by what this distribution took out of the vault.
+  ctx.accounts.fanout.last_snapshot_amount = ctx
+    .accounts
+    .fanout
+    .last_snapshot_amount
+    .checked_sub(dist_amount_u64)
+    .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
   ctx.accounts.voucher.total_inflow = ctx.accounts.fanout.total_inflow;
   ctx.accounts.voucher.total_distributed = ctx
     .accounts

--- a/programs/fanout/src/instructions/initialize_fanout_v0.rs
+++ b/programs/fanout/src/instructions/initialize_fanout_v0.rs
@@ -9,7 +9,7 @@ use anchor_spl::{
 };
 use mpl_token_metadata::types::CollectionDetails;
 
-use crate::FanoutV0;
+use crate::{errors::ErrorCode, FanoutV0};
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Default)]
 pub struct InitializeFanoutArgsV0 {
@@ -82,6 +82,9 @@ pub struct InitializeFanoutV0<'info> {
 }
 
 pub fn handler(ctx: Context<InitializeFanoutV0>, args: InitializeFanoutArgsV0) -> Result<()> {
+  // `total_shares` is fixed here, and every distribution divides by it.
+  require_gt!(ctx.accounts.membership_mint.supply, 0, ErrorCode::NoShares);
+
   let signer_seeds: &[&[&[u8]]] = &[&[b"fanout", args.name.as_bytes(), &[ctx.bumps.fanout]]];
 
   token::mint_to(
@@ -163,8 +166,10 @@ pub fn handler(ctx: Context<InitializeFanoutV0>, args: InitializeFanoutArgsV0) -
     name: args.name,
     total_shares: ctx.accounts.membership_mint.supply,
     total_staked_shares: 0,
-    last_snapshot_amount: ctx.accounts.token_account.amount,
-    total_inflow: ctx.accounts.token_account.amount,
+    // Empty, so a balance already in the vault is the first fold's arrival
+    // rather than a baseline no voucher can reach.
+    last_snapshot_amount: 0,
+    total_inflow: 0,
     bump_seed: ctx.bumps.fanout,
   });
 

--- a/programs/fanout/src/instructions/stake_v0.rs
+++ b/programs/fanout/src/instructions/stake_v0.rs
@@ -10,7 +10,7 @@ use anchor_spl::{
   token::{self, Mint, MintTo, Token, TokenAccount, Transfer},
 };
 
-use crate::{fanout_seeds, voucher_seeds, FanoutV0, FanoutVoucherV0};
+use crate::{errors::ErrorCode, fanout_seeds, voucher_seeds, FanoutV0, FanoutVoucherV0};
 
 #[cfg(feature = "devnet")]
 const URL: &str = "https://fanout.nft.test-helium.com";
@@ -143,6 +143,30 @@ impl<'info> StakeV0<'info> {
 }
 
 pub fn handler(ctx: Context<StakeV0>, args: StakeArgsV0) -> Result<()> {
+  // Whatever is already in the vault belongs to the shares staked ahead of this
+  // one, so attribute it before this stake joins the staked set.
+  ctx
+    .accounts
+    .fanout
+    .accrue_inflow(ctx.accounts.token_account.amount)?;
+
+  // Every voucher in the membership collection is a real position.
+  require_gt!(args.amount, 0, ErrorCode::ZeroStake);
+
+  let total_staked_shares = ctx
+    .accounts
+    .fanout
+    .total_staked_shares
+    .checked_add(args.amount)
+    .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
+  // Every share a distribution pays against is one of `total_shares`, which is
+  // fixed at the membership supply the fanout was created with.
+  require_gte!(
+    ctx.accounts.fanout.total_shares,
+    total_staked_shares,
+    ErrorCode::TooManyShares
+  );
+
   // Create voucher
   ctx.accounts.voucher.set_inner(FanoutVoucherV0 {
     fanout: ctx.accounts.fanout.key(),
@@ -150,16 +174,11 @@ pub fn handler(ctx: Context<StakeV0>, args: StakeArgsV0) -> Result<()> {
     total_distributed: 0,
     shares: args.amount,
     stake_account: ctx.accounts.stake_account.key(),
-    total_inflow: ctx.accounts.token_account.amount,
+    total_inflow: ctx.accounts.fanout.total_inflow,
     total_dust: 0,
     bump_seed: ctx.bumps.voucher,
   });
-  ctx.accounts.fanout.total_staked_shares = ctx
-    .accounts
-    .fanout
-    .total_staked_shares
-    .checked_add(args.amount)
-    .unwrap();
+  ctx.accounts.fanout.total_staked_shares = total_staked_shares;
 
   // Stake tokens
   token::transfer(ctx.accounts.stake_ctx(), args.amount)?;

--- a/programs/fanout/src/instructions/unstake_v0.rs
+++ b/programs/fanout/src/instructions/unstake_v0.rs
@@ -1,4 +1,4 @@
-use crate::{state::*, voucher_seeds};
+use crate::{errors::ErrorCode, state::*, voucher_seeds, TWELVE_PREC};
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{self, Burn, CloseAccount, Mint, Token, TokenAccount, Transfer};
@@ -102,12 +102,33 @@ impl<'info> UnstakeV0<'info> {
 /// CloseAccount an empty voucher
 pub fn handler(ctx: Context<UnstakeV0>) -> Result<()> {
   let signer_seeds: &[&[&[u8]]] = &[voucher_seeds!(ctx.accounts.voucher)];
+  // Release what this voucher was owed and never collected, so the next fold
+  // pays it to the vouchers that remain rather than leaving it in the vault
+  // with no watermark able to reach it.
+  let owed = u64::try_from(
+    ctx
+      .accounts
+      .fanout
+      .owed_to(&ctx.accounts.voucher)?
+      .checked_div(TWELVE_PREC)
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?,
+  )
+  .map_err(|_| error!(ErrorCode::ArithmeticError))?;
+  ctx.accounts.fanout.last_snapshot_amount = ctx
+    .accounts
+    .fanout
+    .last_snapshot_amount
+    .checked_sub(owed)
+    .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
+
+  // `total_staked_shares` is the sum of the live vouchers' `shares`, so closing
+  // this voucher removes exactly what it contributed.
   ctx.accounts.fanout.total_staked_shares = ctx
     .accounts
     .fanout
     .total_staked_shares
-    .checked_sub(ctx.accounts.stake_account.amount)
-    .unwrap();
+    .checked_sub(ctx.accounts.voucher.shares)
+    .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
 
   // Give back the stake and burn the receipt
   token::transfer(

--- a/programs/fanout/src/state.rs
+++ b/programs/fanout/src/state.rs
@@ -1,5 +1,10 @@
 use anchor_lang::prelude::*;
 
+use crate::errors::ErrorCode;
+
+/// Dust is carried at twelve extra decimal places.
+pub const TWELVE_PREC: u128 = 1_000000000000;
+
 #[account]
 #[derive(Default)]
 pub struct FanoutV0 {
@@ -15,6 +20,80 @@ pub struct FanoutV0 {
   pub last_snapshot_amount: u64,
   pub name: String,
   pub bump_seed: u8,
+}
+
+impl FanoutV0 {
+  /// Fold the tokens that have arrived since `last_snapshot_amount` into
+  /// `total_inflow`, scaled by `total_shares / total_staked_shares` so the
+  /// staked vouchers together account for the whole arrival and the unstaked
+  /// remainder accounts for none of it.
+  ///
+  /// `total_inflow` is the unit a voucher watermark is measured in. An arrival
+  /// is attributed to whoever is staked when it is folded in, and `stake_v0`
+  /// folds before it adds to `total_staked_shares`, so joining does not dilute
+  /// the vouchers already there. Unstaking folds nothing in, and releases what
+  /// the closing voucher was owed back to the vouchers that remain.
+  ///
+  /// An arrival is folded only as far as the accumulator has room for, and the
+  /// snapshot advances by exactly the part that was folded, so the remainder
+  /// stays pending for a later fold rather than being lost or refused. Raising
+  /// `total_staked_shares` shrinks the scaling and lets more of it through, and
+  /// `stake_v0` is the only instruction that raises it, so the fold stays
+  /// callable at every share ratio.
+  ///
+  /// With nothing staked there is no share count to scale by, so the arrival
+  /// stays pending and the first fold with something staked pays it out.
+  pub fn accrue_inflow(&mut self, curr_balance: u64) -> Result<()> {
+    if self.total_staked_shares == 0 {
+      return Ok(());
+    }
+
+    let pending = curr_balance
+      .checked_sub(self.last_snapshot_amount)
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
+    let staked = u128::from(self.total_staked_shares);
+    let total = u128::from(self.total_shares);
+
+    // `scaled = inflow * total_shares / total_staked_shares` has to land inside
+    // the accumulator, so the arrival is capped at the inflow whose scaling fits.
+    let headroom = u128::from(u64::MAX - self.total_inflow);
+    let admissible = headroom
+      .checked_mul(staked)
+      .and_then(|room| room.checked_div(total))
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
+    let inflow = u128::from(pending).min(admissible);
+    let scaled = inflow
+      .checked_mul(total)
+      .and_then(|scaled| scaled.checked_div(staked))
+      .and_then(|scaled| u64::try_from(scaled).ok())
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
+
+    self.total_inflow = self
+      .total_inflow
+      .checked_add(scaled)
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
+    self.last_snapshot_amount = self
+      .last_snapshot_amount
+      .checked_add(u64::try_from(inflow).map_err(|_| error!(ErrorCode::ArithmeticError))?)
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
+
+    Ok(())
+  }
+
+  /// What `voucher` is owed by the accumulator, carried at `TWELVE_PREC` extra
+  /// decimals so a distribution can keep the remainder as dust.
+  pub fn owed_to(&self, voucher: &FanoutVoucherV0) -> Result<u128> {
+    u128::from(
+      self
+        .total_inflow
+        .checked_sub(voucher.total_inflow)
+        .ok_or_else(|| error!(ErrorCode::ArithmeticError))?,
+    )
+    .checked_mul(TWELVE_PREC)
+    .and_then(|owed| owed.checked_mul(u128::from(voucher.shares)))
+    .and_then(|owed| owed.checked_div(u128::from(self.total_shares)))
+    .ok_or_else(|| error!(ErrorCode::ArithmeticError))
+  }
 }
 
 #[account]
@@ -51,4 +130,121 @@ macro_rules! fanout_seeds {
       &[$fanout.bump_seed],
     ]
   };
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn fanout(total_shares: u64, total_staked_shares: u64, last_snapshot_amount: u64) -> FanoutV0 {
+    FanoutV0 {
+      total_shares,
+      total_staked_shares,
+      last_snapshot_amount,
+      ..Default::default()
+    }
+  }
+
+  #[test]
+  fn scales_an_arrival_up_to_the_full_share_base() {
+    // A fifth of the shares are staked, so the accumulator has to move five
+    // times the arrival for that fifth to be owed all 100 of it.
+    let mut f = fanout(100, 20, 0);
+    f.accrue_inflow(100).expect("accrue");
+
+    assert_eq!(f.total_inflow, 500);
+    assert_eq!(f.last_snapshot_amount, 100);
+  }
+
+  #[test]
+  fn a_fully_staked_arrival_is_unscaled() {
+    let mut f = fanout(100, 100, 0);
+    f.accrue_inflow(100).expect("accrue");
+
+    assert_eq!(f.total_inflow, 100);
+    assert_eq!(f.last_snapshot_amount, 100);
+  }
+
+  #[test]
+  fn only_the_balance_above_the_snapshot_is_new() {
+    let mut f = fanout(100, 100, 40);
+    f.accrue_inflow(100).expect("accrue");
+
+    assert_eq!(f.total_inflow, 60);
+    assert_eq!(f.last_snapshot_amount, 100);
+  }
+
+  #[test]
+  fn accruing_the_same_balance_twice_adds_nothing() {
+    let mut f = fanout(100, 25, 0);
+    f.accrue_inflow(100).expect("first accrue");
+    let after_first = f.total_inflow;
+    f.accrue_inflow(100).expect("second accrue");
+
+    // 100 + 100 * 75 / 25, pinning the value as well as the idempotence.
+    assert_eq!(after_first, 400);
+    assert_eq!(f.total_inflow, after_first);
+    assert_eq!(f.last_snapshot_amount, 100);
+  }
+
+  #[test]
+  fn an_arrival_with_nothing_staked_stays_pending() {
+    // Seeded away from zero so that "left alone" is distinguishable from "reset".
+    let mut f = fanout(100, 0, 3);
+    f.total_inflow = 7;
+    f.accrue_inflow(100).expect("accrue");
+
+    // Untouched, so the next fold still sees everything above 3 as new.
+    assert_eq!(f.total_inflow, 7);
+    assert_eq!(f.last_snapshot_amount, 3);
+
+    // 97 above the snapshot, scaled by 100/50, added to the 7 already there:
+    // the whole 97 is owed to the first voucher to fold it in.
+    f.total_staked_shares = 50;
+    f.accrue_inflow(100).expect("accrue once staked");
+    assert_eq!(f.total_inflow, 201);
+    assert_eq!(f.last_snapshot_amount, 100);
+  }
+
+  #[test]
+  fn a_balance_below_the_snapshot_is_an_error() {
+    let mut f = fanout(100, 100, 60);
+    assert!(f.accrue_inflow(40).is_err());
+  }
+
+  #[test]
+  fn a_fold_that_does_not_fit_takes_what_does_and_leaves_the_rest() {
+    // One share of u64::MAX staked scales an arrival by u64::MAX, so a single
+    // unit fills the accumulator. The snapshot advances by exactly that unit,
+    // never past the part that was not accumulated.
+    let mut f = fanout(u64::MAX, 1, 0);
+    f.accrue_inflow(2).expect("fold stays callable");
+
+    assert_eq!(f.total_inflow, u64::MAX);
+    assert_eq!(f.last_snapshot_amount, 1);
+  }
+
+  #[test]
+  fn a_full_accumulator_folds_nothing_and_moves_no_snapshot() {
+    let mut f = fanout(100, 100, 0);
+    f.total_inflow = u64::MAX;
+    f.accrue_inflow(50).expect("fold stays callable");
+
+    assert_eq!(f.total_inflow, u64::MAX);
+    assert_eq!(f.last_snapshot_amount, 0);
+  }
+
+  #[test]
+  fn owed_to_is_the_voucher_s_fraction_of_the_accumulator_since_its_watermark() {
+    let mut f = fanout(100, 100, 0);
+    f.total_inflow = 500;
+    let voucher = FanoutVoucherV0 {
+      shares: 20,
+      total_inflow: 100,
+      ..Default::default()
+    };
+
+    // (500 - 100) * 20 / 100, carried at twelve extra decimals.
+    assert_eq!(f.owed_to(&voucher).expect("owed"), 80 * TWELVE_PREC);
+  }
 }

--- a/tests/fanout.ts
+++ b/tests/fanout.ts
@@ -11,7 +11,12 @@ import { getAccount, getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { Keypair, ComputeBudgetProgram, PublicKey } from "@solana/web3.js";
 import { BN } from "bn.js";
 import { expect } from "chai";
-import { init, membershipVoucherKey, PROGRAM_ID } from "../packages/fanout-sdk";
+import {
+  fanoutKey,
+  init,
+  membershipVoucherKey,
+  PROGRAM_ID,
+} from "../packages/fanout-sdk";
 import { random } from "./utils/string";
 
 describe("fanout", () => {
@@ -63,6 +68,69 @@ describe("fanout", () => {
     expect(fanoutAcc.name).to.eq(fanoutName);
   });
 
+  it("refuses a fanout whose membership mint has no supply", async () => {
+    const emptyMint = await createMint(provider, 0, me);
+
+    let err: any;
+    try {
+      await program.methods
+        .initializeFanoutV0({ name: random() })
+        .preInstructions([
+          ComputeBudgetProgram.setComputeUnitLimit({ units: 500000 }),
+        ])
+        .accountsPartial({
+          authority: me,
+          membershipMint: emptyMint,
+          fanoutMint,
+        })
+        .rpc({ skipPreflight: false });
+    } catch (e: any) {
+      err = e;
+    }
+
+    expect(err, "a fanout with no shares was accepted").to.not.eq(undefined);
+    expect(err.error?.errorCode?.code).to.eq("NoShares");
+  });
+
+  it("pays a balance that was in the vault before creation", async () => {
+    const name = random();
+    const fanout = fanoutKey(name)[0];
+    // Funded before the fanout exists, so the accumulator has to start empty
+    // for anyone to ever be owed it.
+    await createAtaAndMint(provider, fanoutMint, 100, fanout);
+
+    await program.methods
+      .initializeFanoutV0({ name })
+      .preInstructions([
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 500000 }),
+      ])
+      .accountsPartial({ authority: me, membershipMint, fanoutMint })
+      .rpc({ skipPreflight: true });
+
+    const wallet = Keypair.generate();
+    const mint = Keypair.generate();
+    const voucher = membershipVoucherKey(mint.publicKey)[0];
+    await program.methods
+      .stakeV0({ amount: new anchor.BN(100) })
+      .preInstructions(
+        await createMintInstructions(provider, 0, voucher, voucher, mint)
+      )
+      .accountsPartial({ fanout, recipient: wallet.publicKey, mint: mint.publicKey })
+      .signers([mint])
+      .rpc({ skipPreflight: true });
+
+    await program.methods
+      .distributeV0()
+      .accountsPartial({ fanout, owner: wallet.publicKey, mint: mint.publicKey })
+      .rpc({ skipPreflight: true });
+
+    const paid = await getAccount(
+      provider.connection,
+      getAssociatedTokenAddressSync(fanoutMint, wallet.publicKey)
+    );
+    expect(paid.amount).to.eq(BigInt(100));
+  });
+
   describe("with fanout", () => {
     let fanout: PublicKey | undefined;
     let tokenAccount: PublicKey | undefined;
@@ -83,6 +151,54 @@ describe("fanout", () => {
         })
         .rpcAndKeys({ skipPreflight: true }));
     });
+
+    async function stake(
+      mint: Keypair,
+      recipient: PublicKey,
+      amount: number,
+      opts: { staker?: Keypair; skipPreflight?: boolean } = {}
+    ): Promise<void> {
+      const { staker, skipPreflight = true } = opts;
+      const voucher = membershipVoucherKey(mint.publicKey)[0];
+
+      await program.methods
+        .stakeV0({
+          amount: new anchor.BN(amount),
+        })
+        .preInstructions(
+          await createMintInstructions(provider, 0, voucher, voucher, mint)
+        )
+        .accountsPartial({
+          fanout,
+          recipient,
+          mint: mint.publicKey,
+          ...(staker ? { staker: staker.publicKey } : {}),
+        })
+        .signers(staker ? [mint, staker] : [mint])
+        .rpc({ skipPreflight });
+    }
+
+    async function distribute(mint: Keypair, owner: PublicKey): Promise<void> {
+      await program.methods
+        .distributeV0()
+        .accountsPartial({
+          fanout,
+          owner,
+          mint: mint.publicKey,
+        })
+        .rpc({ skipPreflight: true });
+    }
+
+    async function balanceOf(
+      mint: PublicKey,
+      owner: PublicKey
+    ): Promise<bigint> {
+      const account = await getAccount(
+        provider.connection,
+        getAssociatedTokenAddressSync(mint, owner)
+      );
+      return account.amount;
+    }
 
     it("allows you to stake membership tokens", async () => {
       const recipient = Keypair.generate();
@@ -122,6 +238,100 @@ describe("fanout", () => {
       expect(voucherAcc.totalDust.toNumber()).to.eq(0);
     });
 
+    it("refuses a stake beyond the fanout's total shares", async () => {
+      const mint = Keypair.generate();
+      const recipient = Keypair.generate();
+
+      // total_shares is the membership supply at creation, which is 100.
+      await createAtaAndMint(provider, membershipMint, 1);
+
+      let err: any;
+      try {
+        // Keep preflight on: a preflight failure surfaces as an AnchorError
+        // with code and logs, while a post-send confirmation failure races
+        // anchor's getTransaction log fetch and can come back as an opaque
+        // SendTransactionError with neither.
+        await stake(mint, recipient.publicKey, 101, { skipPreflight: false });
+      } catch (e: any) {
+        err = e;
+      }
+
+      expect(err, "stake of 101 was accepted").to.not.eq(undefined);
+      expect(err.error?.errorCode?.code).to.eq("TooManyShares");
+    });
+
+    it("refuses a stake of zero shares", async () => {
+      let err: any;
+      try {
+        await stake(Keypair.generate(), me, 0, { skipPreflight: false });
+      } catch (e: any) {
+        err = e;
+      }
+
+      expect(err, "a zero stake was accepted").to.not.eq(undefined);
+      expect(err.error?.errorCode?.code).to.eq("ZeroStake");
+    });
+
+    it("refuses a distribution whose destination is the vault", async () => {
+      const mint = Keypair.generate();
+      // The receipt has to sit in an account owned by the fanout for `owner` to
+      // validate, so mint it straight to the fanout PDA.
+      await stake(mint, fanout!, 100);
+
+      let err: any;
+      try {
+        await program.methods
+          .distributeV0()
+          .accountsPartial({ fanout, owner: fanout!, mint: mint.publicKey })
+          .rpc({ skipPreflight: false });
+      } catch (e: any) {
+        err = e;
+      }
+
+      expect(err, "distribute to the vault was accepted").to.not.eq(undefined);
+      expect(err.error?.errorCode?.code).to.eq("InvalidDestination");
+    });
+
+    it("pays a balance that arrived before the first stake to the first staker", async () => {
+      const member = { wallet: Keypair.generate(), mint: Keypair.generate() };
+
+      // Nothing is staked, so there is no share count to scale this by and it
+      // waits for the first fold.
+      await createAtaAndMint(provider, fanoutMint, 100, fanout!);
+      await stake(member.mint, member.wallet.publicKey, 100);
+      await distribute(member.mint, member.wallet.publicKey);
+      expect(await balanceOf(fanoutMint, member.wallet.publicKey)).to.eq(
+        BigInt(100)
+      );
+
+      await createAtaAndMint(provider, fanoutMint, 40, fanout!);
+      await distribute(member.mint, member.wallet.publicKey);
+      expect(await balanceOf(fanoutMint, member.wallet.publicKey)).to.eq(
+        BigInt(140)
+      );
+    });
+
+    it("pays a vault balance to the shares staked when it arrived", async () => {
+      const early = { wallet: Keypair.generate(), mint: Keypair.generate() };
+      const late = { wallet: Keypair.generate(), mint: Keypair.generate() };
+
+      await stake(early.mint, early.wallet.publicKey, 20);
+      await createAtaAndMint(provider, fanoutMint, 100, fanout!);
+      await stake(late.mint, late.wallet.publicKey, 80);
+
+      await distribute(early.mint, early.wallet.publicKey);
+      await distribute(late.mint, late.wallet.publicKey);
+
+      // The 100 arrived while `early` held every staked share, so all of it is
+      // owed to `early` however many shares stake afterwards.
+      expect(await balanceOf(fanoutMint, early.wallet.publicKey)).to.eq(
+        BigInt(100)
+      );
+      expect(await balanceOf(fanoutMint, late.wallet.publicKey)).to.eq(
+        BigInt(0)
+      );
+    });
+
     describe("with staked positions", () => {
       let positions: { wallet: Keypair; mint: Keypair; amount: number }[];
 
@@ -139,23 +349,102 @@ describe("fanout", () => {
           },
         ];
         for (const { mint, wallet, amount } of positions) {
-          const voucher = membershipVoucherKey(mint.publicKey)[0];
-
-          await program.methods
-            .stakeV0({
-              amount: new anchor.BN(amount),
-            })
-            .preInstructions(
-              await createMintInstructions(provider, 0, voucher, voucher, mint)
-            )
-            .accountsPartial({
-              fanout,
-              recipient: wallet.publicKey,
-              mint: mint.publicKey,
-            })
-            .signers([mint])
-            .rpc({ skipPreflight: true });
+          await stake(mint, wallet.publicKey, amount);
         }
+      });
+
+      it("pays a re-staked position from the inflow that follows it", async () => {
+        const [first, second] = positions;
+
+        await createAtaAndMint(provider, fanoutMint, 100, fanout!);
+        await distribute(first.mint, first.wallet.publicKey);
+        await distribute(second.mint, second.wallet.publicKey);
+
+        await program.methods
+          .unstakeV0()
+          .accountsPartial({
+            mint: first.mint.publicKey,
+            solDestination: me,
+            voucherAuthority: first.wallet.publicKey,
+          })
+          .signers([first.wallet])
+          .rpc({ skipPreflight: true });
+
+        const restaked = Keypair.generate();
+        await stake(restaked, first.wallet.publicKey, first.amount, {
+          staker: first.wallet,
+        });
+
+        await createAtaAndMint(provider, fanoutMint, 100, fanout!);
+        await distribute(restaked, first.wallet.publicKey);
+        await distribute(second.mint, second.wallet.publicKey);
+
+        // Each round of 100 splits 20/80, and the re-staked voucher shares the
+        // second round on the same terms as the first.
+        expect(await balanceOf(fanoutMint, first.wallet.publicKey)).to.eq(
+          BigInt(2 * first.amount)
+        );
+        expect(await balanceOf(fanoutMint, second.wallet.publicKey)).to.eq(
+          BigInt(2 * second.amount)
+        );
+      });
+
+      it("releases an uncollected entitlement to the vouchers that remain", async () => {
+        const [first, second] = positions;
+
+        await createAtaAndMint(provider, fanoutMint, 100, fanout!);
+        await distribute(second.mint, second.wallet.publicKey);
+        expect(await balanceOf(fanoutMint, second.wallet.publicKey)).to.eq(
+          BigInt(second.amount)
+        );
+
+        // `first` leaves without collecting its 20.
+        await program.methods
+          .unstakeV0()
+          .accountsPartial({
+            mint: first.mint.publicKey,
+            solDestination: me,
+            voucherAuthority: first.wallet.publicKey,
+          })
+          .signers([first.wallet])
+          .rpc({ skipPreflight: true });
+
+        await distribute(second.mint, second.wallet.publicKey);
+        expect(await balanceOf(fanoutMint, second.wallet.publicKey)).to.eq(
+          BigInt(100)
+        );
+
+        const vault = getAssociatedTokenAddressSync(fanoutMint, fanout!, true);
+        expect((await getAccount(provider.connection, vault)).amount).to.eq(
+          BigInt(0)
+        );
+      });
+
+      it("unstakes a position holding more than its shares", async () => {
+        const [first, second] = positions;
+        const voucher = membershipVoucherKey(first.mint.publicKey)[0];
+        // More than the shares left staked after this voucher closes, so the
+        // stake account balance and the voucher's shares cannot be confused.
+        const surplus = 81;
+
+        await createAtaAndMint(provider, membershipMint, surplus, voucher);
+
+        await program.methods
+          .unstakeV0()
+          .accountsPartial({
+            mint: first.mint.publicKey,
+            solDestination: me,
+            voucherAuthority: first.wallet.publicKey,
+          })
+          .signers([first.wallet])
+          .rpc({ skipPreflight: true });
+
+        expect(await balanceOf(membershipMint, first.wallet.publicKey)).to.eq(
+          BigInt(first.amount + surplus)
+        );
+
+        const fanoutAcc = await program.account.fanoutV0.fetch(fanout!);
+        expect(fanoutAcc.totalStakedShares.toNumber()).to.eq(second.amount);
       });
 
       it("allows you to unstake", async () => {
@@ -182,22 +471,15 @@ describe("fanout", () => {
       });
 
       it("splits funds, accounting for dust", async () => {
-        async function distribute() {
+        async function distributeAll() {
           for (const { wallet, mint } of positions) {
-            await program.methods
-              .distributeV0()
-              .accountsPartial({
-                fanout,
-                owner: wallet.publicKey,
-                mint: mint.publicKey,
-              })
-              .rpc({ skipPreflight: true });
+            await distribute(mint, wallet.publicKey);
           }
         }
 
         await createAtaAndTransfer(provider, fanoutMint, 4, me, fanout);
 
-        await distribute();
+        await distributeAll();
 
         for (const { wallet, amount } of positions) {
           const toAccount = await getAccount(
@@ -212,7 +494,7 @@ describe("fanout", () => {
 
         await createAtaAndTransfer(provider, fanoutMint, 1, me, fanout);
 
-        await distribute();
+        await distributeAll();
 
         for (const { wallet, amount } of positions) {
           const toAccount = await getAccount(


### PR DESCRIPTION
Makes the fanout program's share accounting say what it means, and writes the rules down.

## Accounting

`fanout.total_inflow` is the accumulator every voucher watermark is measured against, so an arrival has to be folded into it at the staked-share count in force when it is folded. That fold now lives in `FanoutV0::accrue_inflow` and both callers use it:

- `stake_v0` folds before the new shares join the staked set, and seeds the new voucher's watermark from the accumulator rather than the token account balance. Joining therefore does not dilute the vouchers already staked.
- `distribute_v0` folds through the same helper and drops the snapshot by what it transferred.

The fold stays callable at any share ratio, since `stake_v0` folds before it raises `total_staked_shares` and that is the only way the ratio grows.

`unstake_v0` removes `voucher.shares` from `total_staked_shares`, which is the sum of the live vouchers' shares. The stake account's balance is a separate quantity.

## Bounds

- `stake_v0` refuses a stake that would carry the staked set past `total_shares`, which is fixed at the membership supply the fanout was created with.
- `distribute_v0` requires its recipient account to be something other than the fanout's own token account, so the snapshot it writes reflects a transfer that moved tokens.

Both append errors to the IDL, at 6001 and 6002; 6000 is unchanged. `@helium/idls` changeset included.

## README

The README described a pro-rata split across holders. Revenue is split across *staked* shares: each arrival is scaled by `total_shares / total_staked_shares`, so the staked vouchers take all of it and unstaked shares take none. That is now written down, along with what an unstake forfeits and what it strands, the fixed `total_shares`, and `fanout.authority` being stored at creation and never read again.

## Verification

`cargo test -p fanout --lib` and `tests/fanout.ts` on localnet, plus clippy with the repo's flags, `cargo fmt --check`, and `check-cu-table`.
