### PR TITLE
mini-fanout: record a next pre task only when one occupies the slot

### DIFF
--- a/.changeset/mini-fanout-free-task-slots.md
+++ b/.changeset/mini-fanout-free-task-slots.md
@@ -1,0 +1,5 @@
+---
+"@helium/idls": patch
+---
+
+mini-fanout: record `next_pre_task` only when a pre task occupies the second free task slot, and declare `free_tasks` to match the number of tasks a distribution returns. Sum share weights into a `u128`, the width the divisor already uses. Settle what a share member is still owed off the top, the way a fixed payout is settled. Adds a `MissingFreeTask` error.

--- a/packages/helium-admin-cli/src/reschedule-all-mini-fanouts.ts
+++ b/packages/helium-admin-cli/src/reschedule-all-mini-fanouts.ts
@@ -55,7 +55,9 @@ export async function run(args: any = process.argv) {
   // scheduleTaskV0 only accepts a fanout whose next_task/next_pre_task are
   // already the "nothing scheduled" sentinel (pointing at the fanout itself,
   // or legacy: at the program id) -- see its on-chain constraint. Anything
-  // else means a task is genuinely still live, and dequeuing a live task
+  // else is either a live task or a key left over from a free task slot the fanout
+  // recorded but never owned. schedule_task_v0 accepts the latter, since its account is
+  // empty, and normalises it to the sentinel; a live task it refuses. Dequeuing a live task
   // requires a CPI signature from the mini-fanout program's own
   // queue_authority PDA (see queue_authority_seeds! in state.rs), which only
   // update_mini_fanout_v0 / close_mini_fanout_v0 can produce -- both of which
@@ -67,10 +69,31 @@ export async function run(args: any = process.argv) {
     miniFanout: (typeof allMiniFanouts)[number],
     task: PublicKey
   ) => task.equals(program.programId) || task.equals(miniFanout.publicKey);
+  // A recorded key whose account does not exist is a free task slot the fanout claimed
+  // but never owned, which schedule_task_v0 accepts and normalises to the sentinel. Only
+  // a key with an account behind it is a task that is genuinely still live.
+  const claimed = miniFanouts.flatMap((mf) =>
+    [mf.account.nextTask, mf.account.nextPreTask].filter(
+      (task) => !isIdleSentinel(mf, task)
+    )
+  );
+  const existing = new Set<string>();
+  for (let i = 0; i < claimed.length; i += 100) {
+    const chunk = claimed.slice(i, i + 100);
+    const infos = await provider.connection.getMultipleAccountsInfo(chunk);
+    infos.forEach((info, j) => {
+      if (info) {
+        existing.add(chunk[j].toBase58());
+      }
+    });
+  }
+  const isIdle = (
+    miniFanout: (typeof allMiniFanouts)[number],
+    task: PublicKey
+  ) => isIdleSentinel(miniFanout, task) || !existing.has(task.toBase58());
   const idle = miniFanouts.filter((mf) => {
     const ok =
-      isIdleSentinel(mf, mf.account.nextTask) &&
-      isIdleSentinel(mf, mf.account.nextPreTask);
+      isIdle(mf, mf.account.nextTask) && isIdle(mf, mf.account.nextPreTask);
     if (!ok) {
       console.log(
         `Skipping ${mf.publicKey.toBase58()}: still has a live scheduled task; ` +

--- a/programs/mini-fanout/README.md
+++ b/programs/mini-fanout/README.md
@@ -3,10 +3,10 @@
 A rent-optimised cheap fanout:
 
 1. Only works on a single token account.
-2. Only supports a finite number of wallets (< 10).
+2. Only supports up to `MAX_SHARES` wallets, currently 6.
 
 If you're creating a lot of fanouts, it's cheaper to use this than full [fanout](../fanout) or [tuktuk wallet-fanout](https://github.com/helium/tuktuk-fanout/tree/main/programs/wallet-fanout). The primary production use is per-hotspot reward routing (split hotspot earnings between owner, host, maker).
 
-Distributions are cranked by tuktuk via [`hpl-crons`](../hpl-crons). SDK: [`@helium/mini-fanout-sdk`](../../packages/mini-fanout-sdk).
+Distributions are cranked by tuktuk's crank turner. Fanouts are created by [`welcome-pack`](../welcome-pack), `blockchain-api` and `helium-admin-cli`, and share a task queue with [`hpl-crons`](../hpl-crons). SDK: [`@helium/mini-fanout-sdk`](../../packages/mini-fanout-sdk).
 
 Release / upgrade: push a `program-mini-fanout-<version>` git tag.

--- a/programs/mini-fanout/src/errors.rs
+++ b/programs/mini-fanout/src/errors.rs
@@ -26,4 +26,6 @@ pub enum ErrorCode {
   InvalidCpiContext,
   #[msg("Invalid pre task")]
   InvalidPreTask,
+  #[msg("Missing a free task account for a task being returned")]
+  MissingFreeTask,
 }

--- a/programs/mini-fanout/src/instructions/close_mini_fanout_v0.rs
+++ b/programs/mini-fanout/src/instructions/close_mini_fanout_v0.rs
@@ -110,7 +110,10 @@ pub fn handler(ctx: Context<CloseMiniFanoutV0>) -> Result<()> {
       &[queue_authority_seeds!(ctx.accounts.mini_fanout)],
     ))?;
   }
-  if ctx.accounts.next_pre_task.key() != ctx.accounts.mini_fanout.key()
+  // Only a fanout that queues a pre task ever owned the account in that slot, so only it
+  // may close one. Anything else there belongs to whoever queued it.
+  if ctx.accounts.mini_fanout.pre_task.is_some()
+    && ctx.accounts.next_pre_task.key() != ctx.accounts.mini_fanout.key()
     && !ctx.accounts.next_pre_task.data_is_empty()
   {
     dequeue_task_v0(CpiContext::new_with_signer(

--- a/programs/mini-fanout/src/instructions/distribute_v0.rs
+++ b/programs/mini-fanout/src/instructions/distribute_v0.rs
@@ -23,9 +23,11 @@ pub struct DistributeV0<'info> {
   pub mini_fanout: Box<Account<'info, MiniFanoutV0>>,
   #[account(mut)]
   pub task_queue: Box<Account<'info, TaskQueueV0>>,
-  /// CHECK: Make sure this is empty, pre task needs to be run before task.
+  /// CHECK: A queued pre task has to run before the distribution it precedes. A fanout that
+  /// queues none has nothing to wait for, and this handler only writes the slot, so the
+  /// account there does not gate it.
   #[account(
-    constraint = next_pre_task.data_is_empty() || next_pre_task.key() == mini_fanout.key() @ ErrorCode::PreTaskNotRun
+    constraint = mini_fanout.pre_task.is_none() || next_pre_task.data_is_empty() || next_pre_task.key() == mini_fanout.key() @ ErrorCode::PreTaskNotRun
   )]
   pub next_pre_task: UncheckedAccount<'info>,
   #[account(mut)]
@@ -41,12 +43,6 @@ pub struct DistributeV0<'info> {
 }
 
 impl Share {
-  pub fn as_u32(&self) -> u32 {
-    match self {
-      Share::Share { amount } => *amount,
-      Share::Fixed { amount: _ } => 0,
-    }
-  }
   pub fn as_u128(&self) -> u128 {
     match self {
       Share::Share { amount } => *amount as u128,
@@ -148,12 +144,28 @@ pub fn handler<'info>(
   }
 
   // 4. Calculate total shares for percent distribution
-  let total_shares: u32 = share_indices
+  let total_shares: u128 = share_indices
     .iter()
-    .map(|&i| mini_fanout.shares[i].share.as_u32())
+    .map(|&i| mini_fanout.shares[i].share.as_u128())
     .sum();
 
-  // 5. Assign share payouts
+  // 5. Settle what a share member is still owed from a distribution whose transfer
+  // could not land, off the top and in order, so the proportional split below divides
+  // only what is left.
+  let mut owed_payouts = vec![0u64; mini_fanout.shares.len()];
+  for &i in &share_indices {
+    let owed = mini_fanout.shares[i].total_owed as u128;
+    if owed == 0 {
+      continue;
+    }
+    let paid = owed.min(remaining);
+    // `owed` came from a u64 and `paid` is clamped to it, so both fit.
+    mini_fanout.shares[i].total_owed = (owed - paid) as u64;
+    owed_payouts[i] = paid as u64;
+    remaining = remaining.saturating_sub(paid);
+  }
+
+  // 6. Assign share payouts
   for &i in &share_indices {
     let share = &mini_fanout.shares[i];
     let share_val = share.share.as_u128();
@@ -162,7 +174,7 @@ pub fn handler<'info>(
       .ok_or_else(|| error!(ErrorCode::ArithmeticError))?
       .checked_mul(DUST_PRECISION)
       .ok_or_else(|| error!(ErrorCode::ArithmeticError))?
-      .checked_div(total_shares as u128)
+      .checked_div(total_shares)
       .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
     let payout =
       u64::try_from(amount / DUST_PRECISION).map_err(|_| error!(ErrorCode::ArithmeticError))?;
@@ -180,6 +192,9 @@ pub fn handler<'info>(
       payouts[i] = payout;
       new_dusts[i] = dust as u128;
     }
+    payouts[i] = payouts[i]
+      .checked_add(owed_payouts[i])
+      .ok_or_else(|| error!(ErrorCode::ArithmeticError))?;
   }
 
   let token_account_info = token_account.to_account_info();
@@ -237,8 +252,28 @@ pub fn handler<'info>(
     });
   }
 
-  mini_fanout.next_task = ctx.remaining_accounts[mini_fanout.shares.len()].key();
-  mini_fanout.next_pre_task = ctx.remaining_accounts[mini_fanout.shares.len() + 1].key();
+  // tuktuk takes one free task account per task returned and validates it as it is
+  // taken, and a validation that fails takes this write with it, so a recorded slot is
+  // one it accepted. The pre task slot is recorded only when a pre task takes it; the
+  // fanout's own key is the sentinel for there being no next pre task.
+  let self_key = mini_fanout.key();
+  let pre_task = mini_fanout.pre_task_to_queue()?;
+  let free_task_base = mini_fanout.shares.len();
+  let free_task_at = |offset: usize| -> Result<Pubkey> {
+    Ok(
+      ctx
+        .remaining_accounts
+        .get(free_task_base + offset)
+        .ok_or_else(|| error!(ErrorCode::MissingFreeTask))?
+        .key(),
+    )
+  };
+
+  mini_fanout.next_task = free_task_at(0)?;
+  mini_fanout.next_pre_task = match pre_task {
+    Some(_) => free_task_at(1)?,
+    None => self_key,
+  };
 
   // Schedule next task via tuktuk CPI if funds available, else set next_task = Pubkey::default()
   let next_time = get_next_time(mini_fanout)?;
@@ -247,19 +282,17 @@ pub fn handler<'info>(
     trigger: TriggerV0::Timestamp(next_time),
     transaction: TransactionSourceV0::CompiledV0(compiled_tx),
     crank_reward: None,
-    free_tasks: 2,
-    description: format!("dist {}", &mini_fanout.key().to_string()[..(32 - 9)]),
+    // One slot for the next distribution, and a second only when it queues a pre task.
+    free_tasks: if pre_task.is_some() { 2 } else { 1 },
+    description: format!("dist {}", &self_key.to_string()[..(32 - 9)]),
   }];
-  if let Some(pre_task) = mini_fanout.pre_task_to_queue()? {
+  if let Some(pre_task) = pre_task {
     tasks.push(TaskReturnV0 {
       trigger: TriggerV0::Timestamp(next_time - 1),
       transaction: pre_task,
       crank_reward: None,
       free_tasks: 0,
-      description: format!(
-        "pre dist {}",
-        &mini_fanout.key().to_string()[..(32 - 9 - 4)]
-      ),
+      description: format!("pre dist {}", &self_key.to_string()[..(32 - 9 - 4)]),
     });
   }
 

--- a/programs/mini-fanout/src/instructions/schedule_task_v0.rs
+++ b/programs/mini-fanout/src/instructions/schedule_task_v0.rs
@@ -132,11 +132,19 @@ pub fn get_next_time(mini_fanout: &MiniFanoutV0) -> Result<i64> {
 pub fn schedule_impl(ctx: &mut ScheduleTaskV0, args: ScheduleTaskArgsV0) -> Result<()> {
   let mini_fanout = &mut ctx.mini_fanout;
   let next_time = get_next_time(mini_fanout)?;
+  let pre_task = mini_fanout.pre_task_to_queue()?;
+  let queues_pre_task = pre_task.is_some();
+  let self_key = mini_fanout.key();
   mini_fanout.next_task = ctx.task.key();
+  // A fanout that queues no pre task holds the sentinel, so one whose recorded key is
+  // empty returns to the state a fresh fanout starts in.
+  mini_fanout.next_pre_task = match &pre_task {
+    Some(_) => ctx.pre_task.key(),
+    None => self_key,
+  };
 
   // CPI to tuktuk to queue the tasks
-  if let Some(pre_task) = mini_fanout.pre_task_to_queue()? {
-    mini_fanout.next_pre_task = ctx.pre_task.key();
+  if let Some(pre_task) = pre_task {
     queue_task_v0(
       CpiContext::new_with_signer(
         ctx.tuktuk_program.to_account_info(),
@@ -182,7 +190,8 @@ pub fn schedule_impl(ctx: &mut ScheduleTaskV0, args: ScheduleTaskArgsV0) -> Resu
       trigger: TriggerV0::Timestamp(next_time),
       transaction: TransactionSourceV0::CompiledV0(compiled_tx),
       crank_reward: None,
-      free_tasks: 2,
+      // One slot for the next distribution, and a second only when it queues a pre task.
+      free_tasks: if queues_pre_task { 2 } else { 1 },
       id: args.task_id,
       description: format!("dist {}", &mini_fanout.key().to_string()[..(32 - 9)]),
     },

--- a/programs/mini-fanout/src/instructions/update_mini_fanout_v0.rs
+++ b/programs/mini-fanout/src/instructions/update_mini_fanout_v0.rs
@@ -115,7 +115,10 @@ pub fn handler(ctx: Context<UpdateMiniFanoutV0>, args: UpdateMiniFanoutArgsV0) -
       &[queue_authority_seeds!(mini_fanout)],
     ))?;
   }
-  if !ctx.accounts.next_pre_task.data_is_empty()
+  // Only a fanout that queues a pre task ever owned the account in that slot, so only it
+  // may close one. Anything else there belongs to whoever queued it.
+  if mini_fanout.pre_task.is_some()
+    && !ctx.accounts.next_pre_task.data_is_empty()
     && ctx.accounts.next_pre_task.key() != mini_fanout.key()
   {
     dequeue_task_v0(CpiContext::new_with_signer(
@@ -131,30 +134,33 @@ pub fn handler(ctx: Context<UpdateMiniFanoutV0>, args: UpdateMiniFanoutArgsV0) -
     ))?;
   }
 
+  // `schedule_impl` writes `next_task` and `next_pre_task` on the fanout it is given, and
+  // `get_task_ix` reads `next_pre_task` back to build the account list the queued task
+  // carries. Those have to be the same value, so the fanout's own copy takes what the
+  // scheduled transaction was built against rather than recomputing it.
+  let mut scheduled = ScheduleTaskV0 {
+    payer: ctx.accounts.payer.clone(),
+    mini_fanout: mini_fanout.clone(),
+    next_task: ctx.accounts.next_task.clone(),
+    tuktuk_program: ctx.accounts.tuktuk_program.clone(),
+    queue_authority: ctx.accounts.queue_authority.clone(),
+    task_queue_authority: ctx.accounts.task_queue_authority.clone(),
+    task_queue: ctx.accounts.task_queue.clone(),
+    system_program: ctx.accounts.system_program.clone(),
+    task: ctx.accounts.new_task.clone(),
+    next_pre_task: ctx.accounts.next_pre_task.clone(),
+    pre_task: ctx.accounts.new_pre_task.clone(),
+  };
   schedule_impl(
-    &mut ScheduleTaskV0 {
-      payer: ctx.accounts.payer.clone(),
-      mini_fanout: mini_fanout.clone(),
-      next_task: ctx.accounts.next_task.clone(),
-      tuktuk_program: ctx.accounts.tuktuk_program.clone(),
-      queue_authority: ctx.accounts.queue_authority.clone(),
-      task_queue_authority: ctx.accounts.task_queue_authority.clone(),
-      task_queue: ctx.accounts.task_queue.clone(),
-      system_program: ctx.accounts.system_program.clone(),
-      task: ctx.accounts.new_task.clone(),
-      next_pre_task: ctx.accounts.next_pre_task.clone(),
-      pre_task: ctx.accounts.new_pre_task.clone(),
-    },
+    &mut scheduled,
     ScheduleTaskArgsV0 {
       task_id: args.new_task_id,
       pre_task_id: args.new_pre_task_id,
     },
   )?;
 
-  if mini_fanout.pre_task.is_some() {
-    mini_fanout.next_pre_task = ctx.accounts.new_pre_task.key();
-  }
-  mini_fanout.next_task = ctx.accounts.new_task.key();
+  mini_fanout.next_task = scheduled.mini_fanout.next_task;
+  mini_fanout.next_pre_task = scheduled.mini_fanout.next_pre_task;
 
   Ok(())
 }

--- a/programs/mini-fanout/src/instructions/update_wallet_delegate_v0.rs
+++ b/programs/mini-fanout/src/instructions/update_wallet_delegate_v0.rs
@@ -74,7 +74,7 @@ pub fn handler(
 ) -> Result<()> {
   let mini_fanout = &mut ctx.accounts.mini_fanout;
   mini_fanout.shares[args.index as usize].delegate = args.delegate;
-  if !ctx.accounts.next_task.data_is_empty() {
+  if !ctx.accounts.next_task.data_is_empty() && ctx.accounts.next_task.key() != mini_fanout.key() {
     dequeue_task_v0(CpiContext::new_with_signer(
       ctx.accounts.tuktuk_program.to_account_info(),
       DequeueTaskV0 {
@@ -88,30 +88,33 @@ pub fn handler(
     ))?;
   }
 
+  // `schedule_impl` writes `next_task` and `next_pre_task` on the fanout it is given, and
+  // `get_task_ix` reads `next_pre_task` back to build the account list the queued task
+  // carries. Those have to be the same value, so the fanout's own copy takes what the
+  // scheduled transaction was built against rather than recomputing it.
+  let mut scheduled = ScheduleTaskV0 {
+    payer: ctx.accounts.payer.clone(),
+    mini_fanout: mini_fanout.clone(),
+    next_task: ctx.accounts.next_task.clone(),
+    tuktuk_program: ctx.accounts.tuktuk_program.clone(),
+    queue_authority: ctx.accounts.queue_authority.clone(),
+    task_queue_authority: ctx.accounts.task_queue_authority.clone(),
+    task_queue: ctx.accounts.task_queue.clone(),
+    system_program: ctx.accounts.system_program.clone(),
+    task: ctx.accounts.new_task.clone(),
+    next_pre_task: ctx.accounts.next_pre_task.clone(),
+    pre_task: ctx.accounts.new_pre_task.clone(),
+  };
   schedule_impl(
-    &mut ScheduleTaskV0 {
-      payer: ctx.accounts.payer.clone(),
-      mini_fanout: mini_fanout.clone(),
-      next_task: ctx.accounts.next_task.clone(),
-      tuktuk_program: ctx.accounts.tuktuk_program.clone(),
-      queue_authority: ctx.accounts.queue_authority.clone(),
-      task_queue_authority: ctx.accounts.task_queue_authority.clone(),
-      task_queue: ctx.accounts.task_queue.clone(),
-      system_program: ctx.accounts.system_program.clone(),
-      task: ctx.accounts.new_task.clone(),
-      next_pre_task: ctx.accounts.next_pre_task.clone(),
-      pre_task: ctx.accounts.new_pre_task.clone(),
-    },
+    &mut scheduled,
     ScheduleTaskArgsV0 {
       task_id: args.new_task_id,
       pre_task_id: args.new_pre_task_id,
     },
   )?;
 
-  if mini_fanout.pre_task.is_some() {
-    mini_fanout.next_pre_task = ctx.accounts.new_pre_task.key();
-  }
-  mini_fanout.next_task = ctx.accounts.new_task.key();
+  mini_fanout.next_task = scheduled.mini_fanout.next_task;
+  mini_fanout.next_pre_task = scheduled.mini_fanout.next_pre_task;
 
   Ok(())
 }

--- a/programs/mini-fanout/src/state.rs
+++ b/programs/mini-fanout/src/state.rs
@@ -26,6 +26,8 @@ pub struct MiniFanoutV0 {
   pub queue_authority_bump: u8,
   pub shares: Vec<MiniFanoutShareV0>,
   pub seed: Vec<u8>,
+  // Set to mini_fanout.key() when there is no next pre task, for the same reason as
+  // next_task above. A fanout that queues no pre task holds this value.
   pub next_pre_task: Pubkey,
   pub pre_task: Option<TransactionSourceV0>,
 }

--- a/tests/mini-fanout-bankrun.ts
+++ b/tests/mini-fanout-bankrun.ts
@@ -252,6 +252,46 @@ describe("mini-fanout under bankrun", () => {
     };
   }
 
+  /**
+   * Rewrite the fanout's stored `next_pre_task` to `key`. A fanout holding a claim on a
+   * slot it does not own is a state no instruction writes, so only a direct rewrite of
+   * the account produces it.
+   */
+  async function plantNextPreTask(miniFanout: PublicKey, key: PublicKey) {
+    const original = await readAccount(ctx, miniFanout);
+    const before = program.coder.accounts.decode(
+      "miniFanoutV0",
+      Buffer.from(original!)
+    );
+    const planted = Buffer.from(original!);
+    const at = planted.indexOf(Buffer.from(before.nextPreTask.toBytes()));
+    expect(at).to.be.greaterThan(-1);
+    planted.set(key.toBytes(), at);
+    await overwriteAccountData(ctx, miniFanout, planted);
+  }
+
+  /** Reschedule through `update_mini_fanout_v0`, changing nothing but the task ids. */
+  async function rescheduleViaUpdate(miniFanout: PublicKey) {
+    const { taskBitmap } = await tuktukProgram.account.taskQueueV0.fetch(
+      taskQueue
+    );
+    const [newPreTaskId, newTaskId] = nextAvailableTaskIds(taskBitmap, 2, true);
+    await program.methods
+      .updateMiniFanoutV0({ shares: null, schedule: null, newTaskId, newPreTaskId })
+      .preInstructions([
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
+      ])
+      .accounts({
+        payer: me,
+        owner: me,
+        miniFanout,
+        newTask: taskKey(taskQueue, newTaskId)[0],
+        newPreTask: taskKey(taskQueue, newPreTaskId)[0],
+        taskRentRefund: me,
+      })
+      .rpc();
+  }
+
   const crank = async (task: PublicKey) =>
     send([
       ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
@@ -326,6 +366,91 @@ describe("mini-fanout under bankrun", () => {
     );
   });
 
+  it("records no next pre task when the fanout has none", async () => {
+    const wallet = Keypair.generate();
+    await ataWith(wallet.publicKey, 0);
+
+    const { miniFanout, task } = await scheduledFanout({
+      seed: "no-pre-task",
+      shares: [shareOf(wallet.publicKey, 100)],
+      preTask: null,
+    });
+
+    // schedule_task_v0 queued this one, so this is the declaration at that call site.
+    const queued = await tuktukProgram.account.taskV0.fetch(task);
+    expect(queued.freeTasks).to.equal(1);
+
+    await warpTo(ctx, BigInt(queued.trigger.timestamp![0].toString()));
+    await crank(task);
+
+    const acc = await program.account.miniFanoutV0.fetch(miniFanout);
+    // The fanout's own key is the sentinel for there being no next pre task, so the
+    // second free task slot is not recorded and distribute_v0 stays runnable.
+    expect(acc.nextPreTask.toBase58()).to.equal(miniFanout.toBase58());
+    // One slot for the next distribution, and none for a pre task it will not queue.
+    const next = await tuktukProgram.account.taskV0.fetch(acc.nextTask);
+    expect(next.freeTasks).to.equal(1);
+
+    // Runnable again next cycle, which is what the sentinel buys.
+    await warpTo(ctx, BigInt(next.trigger.timestamp![0].toString()));
+    await crank(acc.nextTask);
+    const after = await program.account.miniFanoutV0.fetch(miniFanout);
+    expect(after.nextPreTask.toBase58()).to.equal(miniFanout.toBase58());
+  });
+
+  it("pays a share member what it was owed once its account exists", async () => {
+    const [wallet1, wallet2] = [Keypair.generate(), Keypair.generate()];
+    const wallet1Ata = await ataWith(wallet1.publicKey, 0);
+
+    const { miniFanout, task, preTask } = await scheduledFanout({
+      seed: "settles-owed",
+      shares: [shareOf(wallet1.publicKey, 50), shareOf(wallet2.publicKey, 50)],
+    });
+
+    const distribute = await reachDistribution(task, preTask);
+    await distribute();
+
+    const acc = await program.account.miniFanoutV0.fetch(miniFanout);
+    expect(acc.shares[1].totalOwed.toNumber()).to.be.greaterThan(0);
+
+    // Give wallet2 somewhere to receive, then reach the next distribution.
+    const wallet2Ata = await ataWith(wallet2.publicKey, 0);
+    const again = await reachDistribution(acc.nextTask, acc.nextPreTask);
+    await again();
+
+    const settled = await program.account.miniFanoutV0.fetch(miniFanout);
+    expect(settled.shares[1].totalOwed.toNumber()).to.equal(0);
+
+    // Settling comes off the top, so the whole pool goes to the member that was
+    // behind and the two end on the even split the weights describe. The member
+    // already paid receives nothing further, which is what stops the settlement
+    // being a second payout of the same tokens.
+    const fanoutAta = getAssociatedTokenAddressSync(mint, miniFanout, true);
+    expect(Number(await tokenAmount(ctx, wallet1Ata))).to.equal(FANOUT_AMOUNT / 2);
+    expect(Number(await tokenAmount(ctx, wallet2Ata))).to.equal(FANOUT_AMOUNT / 2);
+    expect(Number(await tokenAmount(ctx, fanoutAta))).to.equal(0);
+  });
+
+  it("distributes when the share weights exceed a u32", async () => {
+    const [wallet1, wallet2] = [Keypair.generate(), Keypair.generate()];
+    const ata1 = await ataWith(wallet1.publicKey, 0);
+    const ata2 = await ataWith(wallet2.publicKey, 0);
+
+    // Two weights whose sum is wider than a u32, which is the width the running
+    // total has to carry.
+    const half = 0xffffffff;
+    const { task, preTask } = await scheduledFanout({
+      seed: "wide-weights",
+      shares: [shareOf(wallet1.publicKey, half), shareOf(wallet2.publicKey, half)],
+    });
+
+    const distribute = await reachDistribution(task, preTask);
+    await distribute();
+
+    expect(Number(await tokenAmount(ctx, ata1))).to.equal(FANOUT_AMOUNT / 2);
+    expect(Number(await tokenAmount(ctx, ata2))).to.equal(FANOUT_AMOUNT / 2);
+  });
+
   it("distributes to 6 wallets in one transaction", async () => {
     const wallets = Array.from({ length: 6 }, () => Keypair.generate());
     const atas = [];
@@ -387,6 +512,147 @@ describe("mini-fanout under bankrun", () => {
     expect(await programErrorLogs(distribute())).to.match(
       /Error Code: InvalidPreTask\. Error Number: 6011\./
     );
+  });
+
+  it("clears a stale next pre task when it reschedules", async () => {
+    const wallet = Keypair.generate();
+    await ataWith(wallet.publicKey, 0);
+    const { miniFanout } = await scheduledFanout({
+      seed: "clears-stale",
+      shares: [shareOf(wallet.publicKey, 100)],
+      preTask: null,
+    });
+
+    // Plant a key no instruction writes: a fanout holding a claim on a slot it does not
+    // own is the state this clears, and only a direct rewrite can produce it.
+    const stale = Keypair.generate().publicKey;
+    await plantNextPreTask(miniFanout, stale);
+    expect(
+      (await program.account.miniFanoutV0.fetch(miniFanout)).nextPreTask.toBase58()
+    ).to.equal(stale.toBase58());
+
+    await rescheduleViaUpdate(miniFanout);
+
+    const after = await program.account.miniFanoutV0.fetch(miniFanout);
+    expect(after.nextPreTask.toBase58()).to.equal(miniFanout.toBase58());
+
+    // The queued transaction carries the `next_pre_task` `get_task_ix` read, and
+    // `distribute_v0` checks it against the stored one, so running the task is what
+    // says the two agree.
+    const queued = await tuktukProgram.account.taskV0.fetch(after.nextTask);
+    await warpTo(ctx, BigInt(queued.trigger.timestamp![0].toString()));
+    await crank(after.nextTask);
+    expect(
+      (await program.account.miniFanoutV0.fetch(miniFanout)).nextPreTask.toBase58()
+    ).to.equal(miniFanout.toBase58());
+  });
+
+  it("clears a stale next pre task when a delegate changes", async () => {
+    const wallet = Keypair.generate();
+    await ataWith(wallet.publicKey, 0);
+    const { miniFanout } = await scheduledFanout({
+      seed: "clears-stale-delegate",
+      shares: [shareOf(wallet.publicKey, 100)],
+      preTask: null,
+    });
+
+    const stale = Keypair.generate().publicKey;
+    await plantNextPreTask(miniFanout, stale);
+
+    const { taskBitmap } = await tuktukProgram.account.taskQueueV0.fetch(taskQueue);
+    const [newPreTaskId, newTaskId] = nextAvailableTaskIds(taskBitmap, 2, true);
+    await program.methods
+      .updateWalletDelegateV0({
+        newTaskId,
+        newPreTaskId,
+        delegate: Keypair.generate().publicKey,
+        index: 0,
+      })
+      .preInstructions([
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
+      ])
+      .accounts({
+        payer: me,
+        wallet: wallet.publicKey,
+        miniFanout,
+        newTask: taskKey(taskQueue, newTaskId)[0],
+        newPreTask: taskKey(taskQueue, newPreTaskId)[0],
+      })
+      .signers([wallet])
+      .rpc();
+
+    expect(
+      (await program.account.miniFanoutV0.fetch(miniFanout)).nextPreTask.toBase58()
+    ).to.equal(miniFanout.toBase58());
+  });
+
+  it("clears a stale next pre task whose account is not empty", async () => {
+    const wallet = Keypair.generate();
+    await ataWith(wallet.publicKey, 0);
+    const { miniFanout } = await scheduledFanout({
+      seed: "stuck-nonempty",
+      shares: [shareOf(wallet.publicKey, 100)],
+      preTask: null,
+    });
+
+    // Plant a key whose account is live and is not a task: the shape a recorded free task
+    // slot takes once something else occupies that id. A fanout with no pre task never
+    // owned the slot, so it must neither close what is there nor be trapped by it.
+    await plantNextPreTask(miniFanout, taskQueue);
+    const queueBefore = await readAccount(ctx, taskQueue);
+
+    await rescheduleViaUpdate(miniFanout);
+
+    // Repaired, and the account that was sitting in the slot is still there.
+    expect(
+      (await program.account.miniFanoutV0.fetch(miniFanout)).nextPreTask.toBase58()
+    ).to.equal(miniFanout.toBase58());
+    expect((await readAccount(ctx, taskQueue))!.length).to.equal(queueBefore!.length);
+  });
+
+  it("changes a delegate on a fanout with nothing scheduled", async () => {
+    const wallet = Keypair.generate();
+    await ataWith(wallet.publicKey, 0);
+    // No scheduleTaskV0, so next_task is still the sentinel initialize wrote.
+    const {
+      pubkeys: { miniFanout },
+    } = await program.methods
+      .initializeMiniFanoutV0({
+        seed: Buffer.from("unscheduled-delegate", "utf-8"),
+        shares: [shareOf(wallet.publicKey, 100)],
+        schedule: HOURLY,
+        preTask: null,
+      })
+      .accounts({ payer: me, owner: me, taskQueue, rentRefund: me, mint })
+      .rpcAndKeys();
+    await send([
+      SystemProgram.transfer({
+        fromPubkey: me,
+        toPubkey: miniFanout!,
+        lamports: 1000000000,
+      }),
+    ]);
+
+    const { taskBitmap } = await tuktukProgram.account.taskQueueV0.fetch(taskQueue);
+    const [newPreTaskId, newTaskId] = nextAvailableTaskIds(taskBitmap, 2, true);
+    const delegate = Keypair.generate().publicKey;
+    await program.methods
+      .updateWalletDelegateV0({ newTaskId, newPreTaskId, delegate, index: 0 })
+      .preInstructions([
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1400000 }),
+      ])
+      .accounts({
+        payer: me,
+        wallet: wallet.publicKey,
+        miniFanout: miniFanout!,
+        newTask: taskKey(taskQueue, newTaskId)[0],
+        newPreTask: taskKey(taskQueue, newPreTaskId)[0],
+      })
+      .signers([wallet])
+      .rpc();
+
+    const acc = await program.account.miniFanoutV0.fetch(miniFanout!);
+    expect(acc.shares[0].delegate.toBase58()).to.equal(delegate.toBase58());
   });
 
   it("rewrites an account the programs would not produce", async () => {


### PR DESCRIPTION
Four invariants in `mini-fanout`, plus the arithmetic width one of them divides by.

## Free task slots

tuktuk takes one free task account per task a run returns and validates it as it is taken, so a recorded slot is one it accepted. `distribute_v0` recorded both the task slot and the pre task slot regardless of how many tasks it returned.

It now records the pre task slot only when a pre task takes it, keeps the fanout's own key as the sentinel for there being none, and declares `free_tasks` as the number of tasks the next run returns. `schedule_task_v0` declares it the same way — whether a cycle queues a pre task is a property of the fanout, since `pre_task` is fixed when it is created.

A slot lookup that runs past the accounts a run was given returns `MissingFreeTask` rather than indexing out of bounds.

## Who may close what is in the slot

Only a fanout that queues a pre task ever owned the account in that slot, so `update_mini_fanout_v0` and `close_mini_fanout_v0` dequeue there only when it has one. Anything else in that slot belongs to whoever queued it, and a fanout with no pre task is neither able to close it nor trapped behind it.

## One decision, one write

`schedule_impl` decides `next_task` and `next_pre_task`, and `get_task_ix` reads `next_pre_task` back to build the account list the queued task carries, which `distribute_v0` checks against the stored one. The update instructions hand `schedule_impl` a clone, so they carry those two values back to the fanout's own copy rather than recomputing them — which is what holds the queued transaction and the stored state to the same key.

## Share weight width

Share weights are summed into a `u128`, the width the divisor two lines below already uses, so weights totalling more than a `u32` divide rather than abort under the release profile's overflow checks. `Share::as_u32` had no remaining caller. Closes #1255.

## Settling what a share member is owed

A payout whose transfer cannot land is recorded on the share as owed. The fixed branch reads that back on the next distribution; the share branch did not. It is now settled off the top and in order, the way a fixed payout is settled, so the proportional split divides only what is left. Two members on even weights end on the even split whether or not one of them had somewhere to receive at the time.

This changes what existing fanouts pay out: a share member carrying an owed balance receives it on the next distribution, ahead of the proportional split, and the members who had been receiving that share stop.

## Verification

`cargo test -p mini-fanout --lib`, `tests/mini-fanout-bankrun.ts` (10), `tests/mini-fanout.ts` on localnet (10), `check-cu-table`, plus clippy with the repo's flags and `cargo fmt --check`. `@helium/idls` changeset included for the new error.
