### PR TITLE
chore: bump helium-sub-daos, fanout, mini-fanout for mainnet deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fanout"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "helium-sub-daos"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "mini-fanout"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/fanout/Cargo.toml
+++ b/programs/fanout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fanout"
-version = "0.1.2"
+version = "0.1.3"
 # Trigger deployment - timestamp: 03-31-2025 #3
 description = "Created with Anchor"
 edition = "2021"

--- a/programs/helium-sub-daos/Cargo.toml
+++ b/programs/helium-sub-daos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helium-sub-daos"
-version = "0.2.47"
+version = "0.2.48"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/programs/mini-fanout/Cargo.toml
+++ b/programs/mini-fanout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mini-fanout"
-version = "0.1.5"
+version = "0.1.6"
 # Trigger deployment - timestamp: 03-31-2025 #4
 description = "Created with Anchor"
 edition = "2021"


### PR DESCRIPTION
Version bumps ahead of mainnet tags:

- helium-sub-daos 0.2.47 -> 0.2.48 (#1285)
- fanout 0.1.2 -> 0.1.3 (#1288, plus the anchor 0.31 build fix)
- mini-fanout 0.1.5 -> 0.1.6 (#1290)

No changeset: @helium/idls 0.11.25 already carries the IDL changes from #1288 and #1290. Only the IDL version strings move here.

Tags to push after develop -> master, one per push: `program-helium-sub-daos-0.2.48`, `program-fanout-0.1.3`, `program-mini-fanout-0.1.6`.

https://claude.ai/code/session_01Lsc2KJ3LtSQY4dvAc9g9bu