### PR TITLE
fix(blockchain-api): review follow-ups for batch expiry, migration race, e2e helpers

### DIFF
--- a/.changeset/batch-finalized-expiry.md
+++ b/.changeset/batch-finalized-expiry.md
@@ -1,0 +1,10 @@
+---
+"@helium/blockchain-api-service": patch
+---
+
+A transaction the cluster reports confirmed is no longer written expired, and
+its batch failed, when it is polled at finalized after its blockhash leaves
+range. The extend-delegation procedure judges lockup, expiration and season on
+the registrar clock, matching delegate. The pending_transactions index migration
+serialises concurrent replicas with an advisory lock and drops an invalid
+leftover index concurrently.

--- a/.github/workflows/blockchain-api-e2e.yml
+++ b/.github/workflows/blockchain-api-e2e.yml
@@ -9,10 +9,14 @@ on:
     paths:
       - "packages/blockchain-api/**"
       - "packages/blockchain-api-client/**"
+      # The matrix check below reads this file, so an edit here runs it.
+      - ".github/workflows/blockchain-api-e2e.yml"
   pull_request:
     paths:
       - "packages/blockchain-api/**"
       - "packages/blockchain-api-client/**"
+      # The matrix check below reads this file, so an edit here runs it.
+      - ".github/workflows/blockchain-api-e2e.yml"
 
 jobs:
   # Build anchor once and share the generated types/IDLs as an artifact. The

--- a/packages/blockchain-api/src/lib/migrations/20260902000000-add-pending-transactions-signature-index.js
+++ b/packages/blockchain-api/src/lib/migrations/20260902000000-add-pending-transactions-signature-index.js
@@ -20,6 +20,13 @@
  * locks belong to one connection, so the whole migration runs on a single
  * client taken from the pool rather than through sequelize's pooled query.
  *
+ * The lock is polled with pg_try_advisory_lock rather than taken with the
+ * blocking pg_advisory_lock. A session parked inside pg_advisory_lock holds an
+ * open snapshot, and CREATE INDEX CONCURRENTLY waits for exactly those
+ * snapshots before it can finish, so the holder and the waiter deadlock and
+ * postgres kills one of them. Each try is its own short statement, so the
+ * waiter holds no snapshot between attempts.
+ *
  * @type {import('sequelize-cli').Migration}
  */
 const INDEXES = [
@@ -35,7 +42,16 @@ module.exports = {
     const manager = queryInterface.sequelize.connectionManager;
     const client = await manager.getConnection({ type: "write" });
     try {
-      await client.query("SELECT pg_advisory_lock($1)", [ADVISORY_LOCK_KEY]);
+      for (;;) {
+        const { rows } = await client.query(
+          "SELECT pg_try_advisory_lock($1) AS got",
+          [ADVISORY_LOCK_KEY],
+        );
+        if (rows[0].got) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
       try {
         for (const { name, column } of INDEXES) {
           // to_regclass resolves through the search path, the same way the

--- a/packages/blockchain-api/src/lib/migrations/20260902000000-add-pending-transactions-signature-index.js
+++ b/packages/blockchain-api/src/lib/migrations/20260902000000-add-pending-transactions-signature-index.js
@@ -13,6 +13,13 @@
  * rebuilt. sequelize-cli does not wrap migrations in a transaction, which
  * CREATE INDEX CONCURRENTLY could not run inside anyway.
  *
+ * Every replica runs db:migrate on start, so two can reach this at once. An
+ * index mid-build also shows as invalid, and the second replica would drop the
+ * first one's live build and fail its start. A session advisory lock serialises
+ * them: the second waits, then finds the valid index and keeps it. Session
+ * locks belong to one connection, so the whole migration runs on a single
+ * client taken from the pool rather than through sequelize's pooled query.
+ *
  * @type {import('sequelize-cli').Migration}
  */
 const INDEXES = [
@@ -20,32 +27,53 @@ const INDEXES = [
   { name: "idx_pending_transactions_batch_id", column: "batch_id" },
 ];
 
+/** Arbitrary but fixed; only this migration takes it. */
+const ADVISORY_LOCK_KEY = 20260902;
+
 module.exports = {
   async up(queryInterface) {
-    for (const { name, column } of INDEXES) {
-      // to_regclass resolves through the search path, the same way the
-      // unqualified CREATE INDEX below does, so a same-named index in another
-      // schema is not mistaken for this one. It yields NULL when none exists.
-      const [rows] = await queryInterface.sequelize.query(
-        `SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(:name)`,
-        { replacements: { name } },
-      );
-      if (rows.length > 0 && rows[0].indisvalid) {
-        continue;
+    const manager = queryInterface.sequelize.connectionManager;
+    const client = await manager.getConnection({ type: "write" });
+    try {
+      await client.query("SELECT pg_advisory_lock($1)", [ADVISORY_LOCK_KEY]);
+      try {
+        for (const { name, column } of INDEXES) {
+          // to_regclass resolves through the search path, the same way the
+          // unqualified CREATE INDEX below does, so a same-named index in
+          // another schema is not mistaken for this one. It yields NULL when
+          // none exists.
+          const { rows } = await client.query(
+            "SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass($1)",
+            [name],
+          );
+          if (rows.length > 0 && rows[0].indisvalid) {
+            continue;
+          }
+          if (rows.length > 0) {
+            // CONCURRENTLY so the drop waits for readers instead of taking
+            // ACCESS EXCLUSIVE on the table and queueing the submit path
+            // behind a long read.
+            await client.query(`DROP INDEX CONCURRENTLY IF EXISTS "${name}"`);
+          }
+          await client.query(
+            `CREATE INDEX CONCURRENTLY "${name}" ON "pending_transactions" ("${column}")`,
+          );
+        }
+      } finally {
+        await client.query("SELECT pg_advisory_unlock($1)", [
+          ADVISORY_LOCK_KEY,
+        ]);
       }
-      if (rows.length > 0) {
-        await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "${name}"`);
-      }
-      await queryInterface.addIndex("pending_transactions", [column], {
-        name,
-        concurrently: true,
-      });
+    } finally {
+      manager.releaseConnection(client);
     }
   },
 
   async down(queryInterface) {
     for (const { name } of INDEXES) {
-      await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "${name}"`);
+      await queryInterface.sequelize.query(
+        `DROP INDEX CONCURRENTLY IF EXISTS "${name}"`,
+      );
     }
   },
 };

--- a/packages/blockchain-api/src/lib/migrations/20260902000000-add-pending-transactions-signature-index.js
+++ b/packages/blockchain-api/src/lib/migrations/20260902000000-add-pending-transactions-signature-index.js
@@ -42,13 +42,18 @@ module.exports = {
     const manager = queryInterface.sequelize.connectionManager;
     const client = await manager.getConnection({ type: "write" });
     try {
-      for (;;) {
+      for (let attempt = 0; ; attempt++) {
         const { rows } = await client.query(
           "SELECT pg_try_advisory_lock($1) AS got",
           [ADVISORY_LOCK_KEY],
         );
         if (rows[0].got) {
           break;
+        }
+        if (attempt === 0) {
+          console.log(
+            "Waiting for another db:migrate run to finish building the pending_transactions indexes",
+          );
         }
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }

--- a/packages/blockchain-api/src/lib/utils/batch-status.ts
+++ b/packages/blockchain-api/src/lib/utils/batch-status.ts
@@ -210,16 +210,14 @@ function decideTransactionStatus(
     if (landed.includes(signatureStatus.confirmationStatus ?? "")) {
       return "confirmed";
     }
-    // Confirmed but not yet finalized: it is in a block the cluster will not
-    // drop, so its blockhash ageing out says nothing about it. Only a
-    // processed status can still be forked off and needs the expiry check.
-    if (LANDED_LEVELS.confirmed.includes(signatureStatus.confirmationStatus ?? "")) {
-      return "pending";
-    }
+    // Below the commitment asked for, but the cluster has it in a block, so
+    // its blockhash ageing out says nothing about it. Should that block be
+    // forked off, the cluster stops reporting the signature and the next read
+    // expires it.
+    return "pending";
   }
 
-  // Never seen, or only processed: it can still land until its blockhash
-  // goes out of range.
+  // Never seen: it can still land until its blockhash goes out of range.
   return isTransactionExpired({
     transaction: tx,
     currentBlockHeight,

--- a/packages/blockchain-api/src/lib/utils/batch-status.ts
+++ b/packages/blockchain-api/src/lib/utils/batch-status.ts
@@ -210,10 +210,16 @@ function decideTransactionStatus(
     if (landed.includes(signatureStatus.confirmationStatus ?? "")) {
       return "confirmed";
     }
+    // Confirmed but not yet finalized: it is in a block the cluster will not
+    // drop, so its blockhash ageing out says nothing about it. Only a
+    // processed status can still be forked off and needs the expiry check.
+    if (LANDED_LEVELS.confirmed.includes(signatureStatus.confirmationStatus ?? "")) {
+      return "pending";
+    }
   }
 
-  // Never seen, or seen but not yet confirmed at the commitment asked for: it
-  // can still land until its blockhash goes out of range.
+  // Never seen, or only processed: it can still land until its blockhash
+  // goes out of range.
   return isTransactionExpired({
     transaction: tx,
     currentBlockHeight,

--- a/packages/blockchain-api/src/lib/utils/get-multiple-accounts.ts
+++ b/packages/blockchain-api/src/lib/utils/get-multiple-accounts.ts
@@ -1,0 +1,19 @@
+import { chunks } from "@helium/spl-utils";
+import type { Connection, PublicKey } from "@solana/web3.js";
+
+// getMultipleAccounts caps out at 100 keys per call, so anything longer is
+// split. The splits are independent reads, so they go out together: a claim
+// spanning five batches of 128 epochs is 10 round trips, and awaiting them one
+// at a time costs ten times a single round trip in request latency.
+export async function getMultipleAccounts(
+  connection: Connection,
+  keys: PublicKey[],
+): Promise<(Awaited<ReturnType<Connection["getAccountInfo"]>> | null)[]> {
+  const batches = await Promise.all(
+    chunks(keys, 100).map((batchKeys) =>
+      connection.getMultipleAccountsInfo(batchKeys),
+    ),
+  );
+
+  return batches.flat();
+}

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/extend.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/delegation/extend.ts
@@ -80,7 +80,10 @@ export const extend = publicProcedure.governance.extendDelegation.handler(
 
     const clock = await connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
     const unixTime = clock!.data.readBigInt64LE(8 * 4);
-    const now = new BN(Number(unixTime));
+    // The program judges the lockup, expiration and season against
+    // `registrar.clock_unix_timestamp()`, the cluster clock plus the
+    // registrar's time_offset. Zero on mainnet; tests dial it forward.
+    const now = new BN(Number(unixTime)).add(registrar.timeOffset);
 
     const lockupKind = getLockupKind(positionAcc.lockup);
     if (

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/build-claim-instructions.ts
@@ -10,6 +10,7 @@ import {
   PROGRAM_ID as CIRCUIT_BREAKER_PROGRAM_ID,
 } from "@helium/circuit-breaker-sdk";
 import { chunks, HNT_MINT, truthy } from "@helium/spl-utils";
+import { getMultipleAccounts } from "@/lib/utils/get-multiple-accounts";
 import {
   isClaimed,
   PROGRAM_ID as VSR_PROGRAM_ID,
@@ -81,23 +82,6 @@ export interface BuildClaimInstructionsParams {
   walletPubkey: PublicKey;
   connection: Connection;
   hsdProgram: HsdProgram;
-}
-
-// getMultipleAccounts caps out at 100 keys per call, so anything longer is
-// split. The splits are independent reads, so they go out together: a claim
-// spanning five batches of 128 epochs is 10 round trips, and awaiting them one
-// at a time costs ten times a single round trip in request latency.
-export async function getMultipleAccounts(
-  connection: Connection,
-  keys: PublicKey[],
-): Promise<(Awaited<ReturnType<Connection["getAccountInfo"]>> | null)[]> {
-  const batches = await Promise.all(
-    chunks(keys, 100).map((batchKeys) =>
-      connection.getMultipleAccountsInfo(batchKeys),
-    ),
-  );
-
-  return batches.flat();
 }
 
 export async function buildClaimInstructions(

--- a/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/rent.ts
+++ b/packages/blockchain-api/src/server/api/routers/governance/procedures/helpers/rent.ts
@@ -2,7 +2,7 @@ import { HNT_MINT } from "@helium/spl-utils";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { Connection, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import { RENT_COSTS } from "@/lib/utils/balance-validation";
-import { getMultipleAccounts } from "./build-claim-instructions";
+import { getMultipleAccounts } from "@/lib/utils/get-multiple-accounts";
 
 /**
  * Space `init_delegation_claim_bot_v0` allocates for a DelegationClaimBotV0:

--- a/packages/blockchain-api/tests/e2e/delegate-automation.test.ts
+++ b/packages/blockchain-api/tests/e2e/delegate-automation.test.ts
@@ -9,7 +9,7 @@ import {
 import { MOBILE_MINT } from "@helium/spl-utils";
 import { positionKey } from "@helium/voter-stake-registry-sdk";
 import { isDefinedError } from "@orpc/client";
-import { PublicKey } from "@solana/web3.js";
+import { PublicKey, SYSVAR_CLOCK_PUBKEY } from "@solana/web3.js";
 import { expect } from "chai";
 import { after, before, describe, it } from "mocha";
 import { DEFAULT_HPL_CRONS_TASK_QUEUE } from "./helpers/constants";
@@ -142,6 +142,54 @@ describe("delegatePositions automation", () => {
       }
       expect(error.code).to.equal("BAD_REQUEST");
       expect(error.message).to.include("fully decayed");
+    } finally {
+      await setRegistrarTimeOffset(ctx, registrar, 0);
+    }
+  });
+
+  it("judges delegation expiry on the registrar clock, not the cluster clock", async () => {
+    // #given a delegated constant position whose registrar clock is dialed
+    // past the delegation's expiration, as extend_expiration_ts_v0 would see
+    // it. A constant lockup never decays, so only the expiry check can trip.
+    const { positionMint } = await createAndFundPosition(ctx, {
+      amount: "100000000",
+      lockupKind: "constant",
+      lockupPeriodsInDays: 365,
+      subDaoMint: MOBILE_MINT,
+      automationEnabled: false,
+    });
+    const { vsrProgram, hsdProgram } = await getPrograms(ctx);
+    const [positionPubkey] = positionKey(new PublicKey(positionMint));
+    const { registrar } = await vsrProgram.account.positionV0.fetch(
+      positionPubkey,
+    );
+    const [delegatedPosPubkey] = delegatedPositionKey(positionPubkey);
+    const { expirationTs } =
+      await hsdProgram.account.delegatedPositionV0.fetch(delegatedPosPubkey);
+    const clockInfo = await ctx.connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+    const clusterNow = Number(clockInfo!.data.readBigInt64LE(32));
+    await setRegistrarTimeOffset(
+      ctx,
+      registrar,
+      expirationTs.toNumber() - clusterNow + 3600,
+    );
+
+    try {
+      // #when the delegation is extended
+      const { error } = await ctx.safeClient.governance.extendDelegation({
+        walletAddress,
+        positionMint,
+      });
+
+      // #then the request is refused rather than built for the program to
+      // reject: on the cluster clock alone the delegation is still live
+      if (!isDefinedError(error)) {
+        expect.fail(
+          `Expected defined ORPCError - but got: ${JSON.stringify(error)}`,
+        );
+      }
+      expect(error.code).to.equal("BAD_REQUEST");
+      expect(error.message).to.include("Delegation has expired");
     } finally {
       await setRegistrarTimeOffset(ctx, registrar, 0);
     }

--- a/packages/blockchain-api/tests/e2e/helpers/governance.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/governance.ts
@@ -13,7 +13,7 @@ import { getCurrentSeasonEnd } from "../../../src/server/api/routers/governance/
 import { TestCtx } from "./context";
 import { signAndSubmitTransactionData } from "./tx";
 import { ensureFunds, ensureTokenBalance } from "./wallet";
-import { getSurfpoolRpcUrl } from "./surfpool";
+import { setSurfnetAccount } from "./surfpool";
 
 /**
  * Initialize Anchor programs for on-chain state verification
@@ -91,23 +91,7 @@ export async function ensureSubDaoEpochsCurrent(ctx: TestCtx): Promise<void> {
       VEHNT_LAST_CALCULATED_TS_OFFSET
     );
 
-    await fetch(getSurfpoolRpcUrl(), {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "surfnet_setAccount",
-        params: [
-          subDaoK.toBase58(),
-          {
-            data: newData.toString("hex"),
-            owner: accountInfo.owner.toBase58(),
-            lamports: accountInfo.lamports,
-          },
-        ],
-      }),
-    });
+    await setSurfnetAccount(subDaoK, { ...accountInfo, data: newData });
   }
 }
 
@@ -142,23 +126,7 @@ export async function setDelegatedPositionExpiration(
     );
   }
 
-  await fetch(getSurfpoolRpcUrl(), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "surfnet_setAccount",
-      params: [
-        delegatedPositionPubkey.toBase58(),
-        {
-          data: newData.toString("hex"),
-          owner: accountInfo.owner.toBase58(),
-          lamports: accountInfo.lamports,
-        },
-      ],
-    }),
-  });
+  await setSurfnetAccount(delegatedPositionPubkey, { ...accountInfo, data: newData });
 }
 
 const POSITION_LOCKUP_END_TS_OFFSET = 80;
@@ -176,23 +144,7 @@ export async function setPositionLockupEndTs(
   const newData = Buffer.from(accountInfo.data);
   newData.writeBigInt64LE(BigInt(newEndTs), POSITION_LOCKUP_END_TS_OFFSET);
 
-  await fetch(getSurfpoolRpcUrl(), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "surfnet_setAccount",
-      params: [
-        positionPubkey.toBase58(),
-        {
-          data: newData.toString("hex"),
-          owner: accountInfo.owner.toBase58(),
-          lamports: accountInfo.lamports,
-        },
-      ],
-    }),
-  });
+  await setSurfnetAccount(positionPubkey, { ...accountInfo, data: newData });
 }
 
 // Registrar layout: 8-byte discriminator, then four pubkeys, then time_offset.
@@ -216,23 +168,7 @@ export async function setRegistrarTimeOffset(
   const newData = Buffer.from(accountInfo.data);
   newData.writeBigInt64LE(BigInt(offsetSeconds), REGISTRAR_TIME_OFFSET_OFFSET);
 
-  await fetch(getSurfpoolRpcUrl(), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "surfnet_setAccount",
-      params: [
-        registrarPubkey.toBase58(),
-        {
-          data: newData.toString("hex"),
-          owner: accountInfo.owner.toBase58(),
-          lamports: accountInfo.lamports,
-        },
-      ],
-    }),
-  });
+  await setSurfnetAccount(registrarPubkey, { ...accountInfo, data: newData });
 }
 
 interface CreatePositionOptions {

--- a/packages/blockchain-api/tests/e2e/helpers/proposal.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/proposal.ts
@@ -19,7 +19,7 @@ import { init as initHsd, daoKey } from "@helium/helium-sub-daos-sdk";
 import { HNT_MINT } from "@helium/spl-utils";
 import { TestCtx } from "./context";
 import { sendAndConfirmInstructions } from "./tx";
-import { getSurfpoolRpcUrl } from "./surfpool";
+import { setSurfnetAccount } from "./surfpool";
 import BN from "bn.js";
 
 interface CreateProposalOptions {
@@ -336,31 +336,6 @@ export async function createTestOrganizationProposal(
 const ORG_AUTHORITY_OFFSET = 12;
 const ORG_DEFAULT_PROPOSAL_CONFIG_OFFSET = 44;
 
-async function surfnetSetAccount(
-  pubkey: PublicKey,
-  data: Buffer,
-  owner: PublicKey,
-  lamports: number
-): Promise<void> {
-  await fetch(getSurfpoolRpcUrl(), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "surfnet_setAccount",
-      params: [
-        pubkey.toBase58(),
-        {
-          data: data.toString("hex"),
-          owner: owner.toBase58(),
-          lamports,
-        },
-      ],
-    }),
-  });
-}
-
 /**
  * Creates a voting proposal under the real "Helium" organization so it is
  * discoverable by the assignProxies procedure (which scans
@@ -452,12 +427,7 @@ export async function createHeliumOrgVotingProposal(
   const newData = Buffer.from(accountInfo.data);
   ctx.payer.publicKey.toBuffer().copy(newData, ORG_AUTHORITY_OFFSET);
   proposalConfig.toBuffer().copy(newData, ORG_DEFAULT_PROPOSAL_CONFIG_OFFSET);
-  await surfnetSetAccount(
-    hntOrg,
-    newData,
-    accountInfo.owner,
-    accountInfo.lamports
-  );
+  await setSurfnetAccount(hntOrg, { ...accountInfo, data: newData });
 
   const initProposalIx = await orgProgram.methods
     .initializeProposalV0({

--- a/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "child_process";
+import type { PublicKey } from "@solana/web3.js";
 import fs from "fs";
 
 type JsonRpcResponse<T> = {
@@ -209,4 +210,32 @@ export async function stopSurfpool(timeoutMs = 10_000): Promise<void> {
 
   ensurePromise = null;
   startInProgress = false;
+}
+
+/** Raw surfpool account write. Throws on RPC error, like `setTokenAccount`. */
+export async function setSurfnetAccount(
+  address: PublicKey,
+  accountInfo: { data: Buffer; owner: PublicKey; lamports: number }
+): Promise<void> {
+  const res = await fetch(getSurfpoolRpcUrl(), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "surfnet_setAccount",
+      params: [
+        address.toBase58(),
+        {
+          data: accountInfo.data.toString("hex"),
+          owner: accountInfo.owner.toBase58(),
+          lamports: accountInfo.lamports,
+        },
+      ],
+    }),
+  });
+  const json = await res.json();
+  if (json.error) {
+    throw new Error(`setAccount failed: ${JSON.stringify(json.error)}`);
+  }
 }

--- a/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
@@ -234,6 +234,9 @@ export async function setSurfnetAccount(
       ],
     }),
   });
+  if (!res.ok) {
+    throw new Error(`setAccount failed: HTTP ${res.status}`);
+  }
   const json = await res.json();
   if (json.error) {
     throw new Error(`setAccount failed: ${JSON.stringify(json.error)}`);

--- a/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
@@ -220,27 +220,14 @@ export async function setSurfnetAccount(
   address: PublicKey,
   accountInfo: { data: Buffer; owner: PublicKey; lamports: number }
 ): Promise<void> {
-  const res = await fetch(getSurfpoolRpcUrl(), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "surfnet_setAccount",
-      params: [
-        address.toBase58(),
-        {
-          data: accountInfo.data.toString("hex"),
-          owner: accountInfo.owner.toBase58(),
-          lamports: accountInfo.lamports,
-        },
-      ],
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`setAccount failed: HTTP ${res.status}`);
-  }
-  const json = await res.json();
+  const json = await jsonRpc("surfnet_setAccount", [
+    address.toBase58(),
+    {
+      data: accountInfo.data.toString("hex"),
+      owner: accountInfo.owner.toBase58(),
+      lamports: accountInfo.lamports,
+    },
+  ]);
   if (json.error) {
     throw new Error(`setAccount failed: ${JSON.stringify(json.error)}`);
   }

--- a/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/surfpool.ts
@@ -47,6 +47,9 @@ async function jsonRpc<T = unknown>(
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
     signal: AbortSignal.timeout(HEALTH_REQUEST_TIMEOUT_MS),
   });
+  if (!res.ok) {
+    throw new Error(`${method} failed: HTTP ${res.status}`);
+  }
   return res.json() as Promise<JsonRpcResponse<T>>;
 }
 

--- a/packages/blockchain-api/tests/e2e/helpers/tuktuk.ts
+++ b/packages/blockchain-api/tests/e2e/helpers/tuktuk.ts
@@ -15,35 +15,7 @@ import {
   PublicKey,
   sendAndConfirmRawTransaction,
 } from "@solana/web3.js";
-import { getSurfpoolRpcUrl } from "./surfpool";
-
-/** Raw surfpool account write. Throws on RPC error, like `setTokenAccount`. */
-async function setAccountData(
-  address: PublicKey,
-  accountInfo: { data: Buffer; owner: PublicKey; lamports: number }
-): Promise<void> {
-  const res = await fetch(getSurfpoolRpcUrl(), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "surfnet_setAccount",
-      params: [
-        address.toBase58(),
-        {
-          data: accountInfo.data.toString("hex"),
-          owner: accountInfo.owner.toBase58(),
-          lamports: accountInfo.lamports,
-        },
-      ],
-    }),
-  });
-  const json = await res.json();
-  if (json.error) {
-    throw new Error(`setAccount failed: ${JSON.stringify(json.error)}`);
-  }
-}
+import { setSurfnetAccount } from "./surfpool";
 
 function freeBitsInByte(byte: number): number[] {
   const bits: number[] = [];
@@ -97,7 +69,7 @@ export async function confineTaskQueueFreeIds(
   );
   const confinedData = Buffer.from(accountInfo.data);
   confined.copy(confinedData, bitmapOffset);
-  await setAccountData(taskQueue, { ...accountInfo, data: confinedData });
+  await setSurfnetAccount(taskQueue, { ...accountInfo, data: confinedData });
 
   return {
     freeIds,
@@ -106,7 +78,7 @@ export async function confineTaskQueueFreeIds(
       for (const id of freeIds) {
         restoredData[bitmapOffset + Math.floor(id / 8)] |= 1 << (id % 8);
       }
-      await setAccountData(taskQueue, { ...accountInfo, data: restoredData });
+      await setSurfnetAccount(taskQueue, { ...accountInfo, data: restoredData });
     },
   };
 }

--- a/packages/blockchain-api/tests/unit/batch-status.test.ts
+++ b/packages/blockchain-api/tests/unit/batch-status.test.ts
@@ -231,6 +231,20 @@ describe("decideBatchStatus", () => {
     expect(decision.transactionStatuses[0].status).to.equal("pending");
   });
 
+  it("does not expire a confirmed transaction awaiting finalization once its blockhash leaves range", () => {
+    const decision = decideBatchStatus({
+      batchId: BATCH_ID,
+      transactions: [{ ...pendingRow("sigA"), blockhash: "hashA" }],
+      signatureStatuses: new Map([["sigA", confirmed]]),
+      currentBlockHeight: 400,
+      blockhashValidity: new Map([["hashA", false]]),
+      commitment: "finalized",
+    });
+
+    expect(decision.transactionStatuses[0].status).to.equal("pending");
+    expect(decision.batchStatus).to.equal("pending");
+  });
+
   it("keeps the status the bundle check produced when no transaction resolved", () => {
     const decision = decideBatchStatus({
       batchId: BATCH_ID,

--- a/packages/blockchain-api/tests/unit/batch-status.test.ts
+++ b/packages/blockchain-api/tests/unit/batch-status.test.ts
@@ -97,12 +97,13 @@ describe("decideBatchStatus", () => {
     expect(decision.batchStatus).to.equal("failed");
   });
 
-  it("expiry-checks a transaction that is only processed, not yet confirmed", () => {
+  it("holds a processed transaction pending even once its blockhash leaves range", () => {
     const decision = decideBatchStatus({
       batchId: BATCH_ID,
-      transactions: [pendingRow("sigA")],
+      transactions: [{ ...pendingRow("sigA"), blockhash: "hashA" }],
       signatureStatuses: new Map([["sigA", processed]]),
-      currentBlockHeight: 250,
+      currentBlockHeight: 400,
+      blockhashValidity: new Map([["hashA", false]]),
     });
 
     expect(decision.transactionStatuses[0].status).to.equal("pending");


### PR DESCRIPTION
Follow-ups from review of the blockchain-api batch status / index migration work.

## Fixes

- **Finalized poll wrote a landed transaction expired.** A signature the cluster reports confirmed (not yet finalized) is in a block that will not be dropped. It now stays `pending` until it reaches the requested commitment instead of being expiry-checked and rolling its batch up to `failed`, which made a retry a double claim. Any status the cluster returns without an error (`processed` included) stays `pending`; only a signature the cluster has never seen goes through the blockhash check. Unit test added.
- **Migration race between replicas.** Every replica runs `db:migrate` on start. A concurrent build shows `indisvalid=false` mid-build, so a second replica dropped the first one's in-flight build and failed its start. The migration now holds a session advisory lock on one pooled client for the whole `up()`, and drops an invalid leftover with `DROP INDEX CONCURRENTLY` instead of taking ACCESS EXCLUSIVE on `pending_transactions`. The lock is polled with `pg_try_advisory_lock`: a session blocked inside `pg_advisory_lock` holds a snapshot that `CREATE INDEX CONCURRENTLY` waits on, so the blocking form deadlocked one replica. Verified on a scratch database (postgres 14, 3M rows): fresh build, idempotent rerun, forced-invalid rebuild, two concurrent `up()` calls at 0/1000/3000ms stagger both succeed with valid indexes, no lock leaked, `down` cleans up.
- **Matrix-coverage check could not fire on the change it guards.** The e2e workflow now also runs on edits to itself.
- **extend.ts judged on the raw cluster clock.** Now adds the registrar `time_offset`, matching `delegate.ts`. E2e added that dials the registrar past the delegation's expiration and asserts the refusal.
- **Unchecked `surfnet_setAccount` writes.** One exported `setSurfnetAccount` that throws on a non-2xx or an RPC error replaces the seven inline fetches across the tuktuk, governance and proposal e2e helpers, so a failed time-offset reset no longer leaves the registrar dialed forward silently.
- **`getMultipleAccounts` chunking helper** moved from `build-claim-instructions.ts` to `src/lib/utils/get-multiple-accounts.ts`.

## Not done

- **Post-split bundle cap test.** The measurer and the real build compile identical instructions, lookup tables and compute-budget prefix, so no public input makes the real build split where the measurer said it fit. That makes `buildOrSplit`'s recursive split and the post-split cap equally unreachable from public input; both are defensive, and neither has a test. Testing them needs a mock seam on `buildVersionedTransaction` (swc CJS exports are non-configurable, so the test cannot patch it). Left out rather than add an injection parameter for a test alone.

## Verification

- `pnpm test:unit`: 279 passing
- `pnpm typecheck`, `pnpm lint:check`: clean
- `tests/e2e/delegate-automation.test.ts`: 3 passing

https://claude.ai/code/session_01Lsc2KJ3LtSQY4dvAc9g9bu

